### PR TITLE
fix: harden LibSQL replace mode

### DIFF
--- a/src/client/providers/libsql/commit-patch-to-libsql.ts
+++ b/src/client/providers/libsql/commit-patch-to-libsql.ts
@@ -60,11 +60,15 @@ export async function commitPatchToLibsql(
   const targetedInsertions = patch.insertions?.filter(matcher) ?? [];
 
   // 1. Stage Sweeping Deletion Operations
+  const deletionQuadIds = new Set<string>();
   if (targetedDeletions.length) {
-    const deletionQuadIds = await computeQuadIds(targetedDeletions);
-    if (deletionQuadIds.length > 0) {
+    const computedDeletionQuadIds = await computeQuadIds(targetedDeletions);
+    for (const quadId of computedDeletionQuadIds) {
+      deletionQuadIds.add(quadId);
+    }
+    if (computedDeletionQuadIds.length > 0) {
       statements.push(
-        ...buildDeletionStatements(deletionQuadIds, libsqlQueryBuilder),
+        ...buildDeletionStatements(computedDeletionQuadIds, libsqlQueryBuilder),
       );
     }
   }
@@ -84,7 +88,7 @@ export async function commitPatchToLibsql(
     const novelQuadIds: string[] = [];
     for (let i = 0; i < targetedInsertions.length; i++) {
       const id = proposedQuadIds[i];
-      if (!existingIds.has(id)) {
+      if (!existingIds.has(id) || deletionQuadIds.has(id)) {
         novelInsertions.push(targetedInsertions[i]);
         novelQuadIds.push(id);
       }

--- a/src/client/providers/libsql/provide-libsql.test.ts
+++ b/src/client/providers/libsql/provide-libsql.test.ts
@@ -1,6 +1,6 @@
 import { assertEquals, assertExists } from "@std/assert";
 import { createClient as createLibsqlClient } from "@libsql/client";
-import { DataFactory } from "n3";
+import { DataFactory, Store } from "n3";
 import { Client } from "#/client/client.ts";
 import { provideLibsql } from "./provide-libsql.ts";
 import { FakeEmbeddingService } from "#/client/search-index/embedding-service/mod.ts";
@@ -170,6 +170,137 @@ Deno.test("E2E DEMO: unified data entry enables immediate hybrid search availabi
           result.subject === "urn:person:dave"
         ),
         false,
+      );
+
+      const quadsTable = await db.execute(
+        "SELECT COUNT(*) AS count FROM quads",
+      );
+      const chunksTable = await db.execute(
+        "SELECT COUNT(*) AS count FROM chunks",
+      );
+      assertEquals(Number(quadsTable.rows[0]?.count), 1);
+      assertEquals(Number(chunksTable.rows[0]?.count), 1);
+    },
+  );
+
+  await t.step(
+    "Scenario 5: dataset replace removes stale rows and keeps survivor",
+    async () => {
+      const db = createLibsqlClient({ url: ":memory:" });
+      const embeddingService = new FakeEmbeddingService();
+      const client = new Client(
+        await provideLibsql({ client: db, embeddingService }),
+      );
+
+      const staleQuad = quad(
+        namedNode("urn:person:erin"),
+        namedNode("urn:bio"),
+        literal("Erin has unique_z111_dataset stale notes."),
+      );
+      const survivingQuad = quad(
+        namedNode("urn:person:frank"),
+        namedNode("urn:bio"),
+        literal("Frank keeps unique_z222_dataset surviving notes."),
+      );
+      const dataset = new Store();
+      dataset.add(survivingQuad);
+
+      await client.import({
+        source: { kind: "quads", quads: [staleQuad, survivingQuad] },
+      });
+      await client.import({
+        mode: "replace",
+        source: { kind: "dataset", dataset },
+      });
+
+      const staleSearch = await client.search({
+        query: "unique_z111_dataset",
+      });
+      const survivingSearch = await client.search({
+        query: "unique_z222_dataset",
+      });
+
+      assertExists(survivingSearch.results);
+      assertEquals(
+        Boolean(
+          staleSearch.results?.some((result) =>
+            result.subject === "urn:person:erin"
+          ),
+        ),
+        false,
+      );
+      assertEquals(
+        Boolean(
+          survivingSearch.results?.some((result) =>
+            result.subject === "urn:person:frank"
+          ),
+        ),
+        true,
+      );
+
+      const quadsTable = await db.execute(
+        "SELECT COUNT(*) AS count FROM quads",
+      );
+      const chunksTable = await db.execute(
+        "SELECT COUNT(*) AS count FROM chunks",
+      );
+      assertEquals(Number(quadsTable.rows[0]?.count), 1);
+      assertEquals(Number(chunksTable.rows[0]?.count), 1);
+    },
+  );
+
+  await t.step(
+    "Scenario 6: serialized replace removes stale rows and keeps survivor",
+    async () => {
+      const db = createLibsqlClient({ url: ":memory:" });
+      const embeddingService = new FakeEmbeddingService();
+      const client = new Client(
+        await provideLibsql({ client: db, embeddingService }),
+      );
+
+      const staleQuad = quad(
+        namedNode("urn:person:gina"),
+        namedNode("urn:bio"),
+        literal("Gina has unique_z333_serialized stale notes."),
+      );
+      const survivingQuad = quad(
+        namedNode("urn:person:henry"),
+        namedNode("urn:bio"),
+        literal("Henry keeps unique_z444_serialized surviving notes."),
+      );
+      const serialized = `<urn:person:henry> <urn:bio> "Henry keeps unique_z444_serialized surviving notes." .`;
+
+      await client.import({
+        source: { kind: "quads", quads: [staleQuad, survivingQuad] },
+      });
+      await client.import({
+        mode: "replace",
+        source: { kind: "serialized", data: serialized },
+      });
+
+      const staleSearch = await client.search({
+        query: "unique_z333_serialized",
+      });
+      const survivingSearch = await client.search({
+        query: "unique_z444_serialized",
+      });
+
+      assertExists(survivingSearch.results);
+      assertEquals(
+        Boolean(
+          staleSearch.results?.some((result) =>
+            result.subject === "urn:person:gina"
+          ),
+        ),
+        false,
+      );
+      assertEquals(
+        Boolean(
+          survivingSearch.results?.some((result) =>
+            result.subject === "urn:person:henry"
+          ),
+        ),
+        true,
       );
 
       const quadsTable = await db.execute(

--- a/src/client/providers/libsql/provide-libsql.test.ts
+++ b/src/client/providers/libsql/provide-libsql.test.ts
@@ -108,6 +108,80 @@ Deno.test("E2E DEMO: unified data entry enables immediate hybrid search availabi
       assertExists(match, "Bootstrap hydration skipped master record data.");
     },
   );
+
+  await t.step(
+    "Scenario 4: replace mode removes stale quads and search rows",
+    async () => {
+      const firstQuad = quad(
+        namedNode("urn:person:carol"),
+        namedNode("urn:bio"),
+        literal("Carol is a unique_z444_test_tag mountain explorer."),
+      );
+      const secondQuad = quad(
+        namedNode("urn:person:dave"),
+        namedNode("urn:bio"),
+        literal("Dave is a unique_z888_test_tag sea navigator."),
+      );
+
+      await client.import({
+        source: { kind: "quads", quads: [firstQuad, secondQuad] },
+      });
+
+      const beforeCarol = await client.search({
+        query: "unique_z444_test_tag",
+      });
+      const beforeDave = await client.search({
+        query: "unique_z888_test_tag",
+      });
+
+      assertEquals(
+        beforeCarol.results?.some((result) =>
+          result.subject === "urn:person:carol"
+        ),
+        true,
+      );
+      assertEquals(
+        beforeDave.results?.some((result) =>
+          result.subject === "urn:person:dave"
+        ),
+        true,
+      );
+
+      await client.import({
+        mode: "replace",
+        source: { kind: "quads", quads: [firstQuad] },
+      });
+
+      const afterCarol = await client.search({
+        query: "unique_z444_test_tag",
+      });
+      const afterDave = await client.search({
+        query: "unique_z888_test_tag",
+      });
+
+      assertEquals(
+        afterCarol.results?.some((result) =>
+          result.subject === "urn:person:carol"
+        ),
+        true,
+      );
+      assertEquals(
+        afterDave.results?.some((result) =>
+          result.subject === "urn:person:dave"
+        ),
+        false,
+      );
+
+      const quadsTable = await db.execute(
+        "SELECT COUNT(*) AS count FROM quads",
+      );
+      const chunksTable = await db.execute(
+        "SELECT COUNT(*) AS count FROM chunks",
+      );
+      assertEquals(Number(quadsTable.rows[0]?.count), 1);
+      assertEquals(Number(chunksTable.rows[0]?.count), 1);
+    },
+  );
 });
 
 Deno.test("QuadFilter Integration: enables hybrid partitioning persisting specific graphs while keeping others ephemeral", async () => {

--- a/src/client/providers/rdfjs/rdfjs-quad-store.test.ts
+++ b/src/client/providers/rdfjs/rdfjs-quad-store.test.ts
@@ -106,6 +106,25 @@ Deno.test("RdfjsQuadStore.import - replace mode combined with serialized data cl
   assertEquals(store.has(q1), false);
 });
 
+Deno.test("RdfjsQuadStore.import - replace mode preserves existing data when serialized import fails", async () => {
+  const store = new Store();
+  store.add(q1);
+
+  await assertRejects(async () => {
+    await new RdfjsQuadStore(store).import({
+      mode: "replace",
+      source: {
+        kind: "serialized",
+        data: "GARBAGE SNOT@@$",
+        contentType: "text/turtle",
+      },
+    });
+  });
+
+  assertEquals(store.size, 1);
+  assertEquals(store.has(q1), true);
+});
+
 Deno.test("RdfjsQuadStore.import - invalid serialization rejects properly", async () => {
   const store = new Store();
 

--- a/src/client/providers/rdfjs/rdfjs-quad-store.ts
+++ b/src/client/providers/rdfjs/rdfjs-quad-store.ts
@@ -18,6 +18,8 @@ export class RdfjsQuadStore implements QuadStoreInterface {
 
   public async import(request: ImportRequest): Promise<ImportResponse> {
     const mode = request.mode ?? "merge";
+    const quads = await materializeImportQuads(request.source);
+
     if (mode === "replace") {
       await new Promise<void>((resolve, reject) => {
         const removalStream = this.store.removeMatches(null, null, null, null);
@@ -26,26 +28,10 @@ export class RdfjsQuadStore implements QuadStoreInterface {
       });
     }
 
-    let stream: rdfjs.Stream<rdfjs.Quad>;
-    if (request.source.kind === "quads") {
-      stream = Readable.from(request.source.quads) as unknown as rdfjs.Stream<
-        rdfjs.Quad
-      >;
-    } else if (request.source.kind === "dataset") {
-      stream = Readable.from(request.source.dataset) as unknown as rdfjs.Stream<
-        rdfjs.Quad
-      >;
-    } else if (request.source.kind === "serialized") {
-      stream = parseQuads(request.source.data, request.source.contentType);
-    } else {
-      throw new Error("Unsupported import source kind");
+    for (const quad of quads) {
+      // deno-lint-ignore no-explicit-any
+      (this.store as any).addQuad(quad);
     }
-
-    return await new Promise<void>((resolve, reject) => {
-      const res = this.store.import(stream);
-      res.on("end", resolve);
-      res.on("error", reject);
-    });
   }
 
   public async export(request: ExportRequest): Promise<ExportResponse> {
@@ -125,4 +111,29 @@ export function parseQuads(
   const parser = new Parser({ format: n3Format });
   const quads = parser.parse(data);
   return Readable.from(quads) as unknown as rdfjs.Stream<rdfjs.Quad>;
+}
+
+async function materializeImportQuads(
+  source: ImportRequest["source"],
+): Promise<rdfjs.Quad[]> {
+  if (source.kind === "quads") {
+    return Array.from(source.quads);
+  }
+
+  if (source.kind === "dataset") {
+    return Array.from(source.dataset);
+  }
+
+  if (source.kind === "serialized") {
+    const parsedStream = parseQuads(source.data, source.contentType);
+    const quads: rdfjs.Quad[] = [];
+    await new Promise<void>((resolve, reject) => {
+      parsedStream.on("data", (quad: rdfjs.Quad) => quads.push(quad));
+      parsedStream.on("end", resolve);
+      parsedStream.on("error", reject);
+    });
+    return quads;
+  }
+
+  throw new Error("Unsupported import source kind");
 }

--- a/src/client/providers/rdfjs/rdfjs-quad-store.ts
+++ b/src/client/providers/rdfjs/rdfjs-quad-store.ts
@@ -19,7 +19,11 @@ export class RdfjsQuadStore implements QuadStoreInterface {
   public async import(request: ImportRequest): Promise<ImportResponse> {
     const mode = request.mode ?? "merge";
     if (mode === "replace") {
-      this.store.removeMatches(null, null, null, null);
+      await new Promise<void>((resolve, reject) => {
+        const removalStream = this.store.removeMatches(null, null, null, null);
+        removalStream.on("end", resolve);
+        removalStream.on("error", reject);
+      });
     }
 
     let stream: rdfjs.Stream<rdfjs.Quad>;


### PR DESCRIPTION
## Summary
- add an end-to-end regression test for replace-mode imports through the LibSQL provider
- ensure replace-mode waits for deletion capture before importing replacement quads
- allow quads removed and reinserted in the same replace transaction to be materialized correctly

## Verification
- deno test --allow-all src/client/providers/libsql/provide-libsql.test.ts
- deno test --allow-all src/client/providers/rdfjs/rdfjs-quad-store.test.ts
- deno test --allow-all src/client/providers/libsql/commit-patch-to-libsql.test.ts