### PR TITLE
feat: use hashQuad for stable IDs in search index results

### DIFF
--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -4,6 +4,7 @@ import { Client } from "./client.ts";
 import { RdfjsQuadStore, RdfjsSearchIndex } from "./providers/rdfjs/mod.ts";
 import { ComunicaSparqlEngine } from "#/client/providers/comunica/mod.ts";
 import { QueryEngine } from "@comunica/query-sparql-rdfjs-lite";
+import { hashQuad } from "#/client/quad-store/hash-quad.ts";
 
 const queryEngine = new QueryEngine();
 
@@ -71,4 +72,23 @@ Deno.test("Client.search delegates to searchIndex.search", async () => {
   const response = await client.search({ query: "integrate" });
   assertEquals(response.results?.length, 1);
   assertEquals(response.results?.[0].text, "Integrate all systems.");
+});
+
+Deno.test("Client.search returns stable hashQuad-based search result ids", async () => {
+  const store = new Store();
+  const indexedQuad = DataFactory.quad(
+    DataFactory.namedNode("http://example.com/sub"),
+    DataFactory.namedNode("http://example.com/pred"),
+    DataFactory.literal("Integrate all systems."),
+  );
+  store.addQuad(indexedQuad);
+
+  const client = createTestClient(store);
+
+  const firstResponse = await client.search({ query: "integrate" });
+  const secondResponse = await client.search({ query: "integrate" });
+  const expectedId = await hashQuad(indexedQuad);
+
+  assertEquals(firstResponse.results?.[0].id, expectedId);
+  assertEquals(secondResponse.results?.[0].id, expectedId);
 });

--- a/src/client/providers/denokv/denokv-search-index.ts
+++ b/src/client/providers/denokv/denokv-search-index.ts
@@ -6,6 +6,7 @@ import type {
   SearchResponse,
   SearchResult,
 } from "#/client/search-index/search-index-interface.ts";
+import { hashQuad } from "#/client/quad-store/hash-quad.ts";
 import { filterQuads } from "#/client/quad-store/quad-filter.ts";
 import { isTextualLiteral } from "#/client/quad-store/is-textual-literal.ts";
 import { deserializeTerm, type SerializedQuad } from "./denokv-quad-store.ts";
@@ -65,6 +66,7 @@ export class DenokvSearchIndex implements SearchIndexInterface {
         const value = q.object.value;
         if (value.toLowerCase().includes(query)) {
           results.push({
+            id: await hashQuad(q),
             subject: q.subject.value,
             predicate: q.predicate.value,
             graph: q.graph.value,

--- a/src/client/providers/libsql/libsql-search-index.ts
+++ b/src/client/providers/libsql/libsql-search-index.ts
@@ -1,13 +1,17 @@
 import type { Client } from "@libsql/client";
+import { DataFactory } from "n3";
 import type {
   SearchIndexInterface,
   SearchRequest,
   SearchResponse,
   SearchResult,
 } from "#/client/search-index/search-index-interface.ts";
+import { hashQuad } from "#/client/quad-store/hash-quad.ts";
 import type { LibsqlQueryBuilder } from "./libsql-query-builder.ts";
 
 import type { EmbeddingService } from "#/client/search-index/embedding-service/mod.ts";
+
+const { literal, namedNode, quad: createQuad, defaultGraph } = DataFactory;
 
 /**
  * LibsqlSearchIndexOptions defines the structured configuration and dependency parameters needed to construct the LibSQL search engine.
@@ -74,13 +78,30 @@ export class LibsqlSearchIndex implements SearchIndexInterface {
 
     const resultSet = await this.options.client.execute({ sql, args });
 
-    const results: SearchResult[] = resultSet.rows.map((row) => ({
-      subject: String(row["subject"]),
-      predicate: String(row["predicate"]),
-      graph: String(row["graph"]),
-      text: String(row["value"]),
-      score: Number(row["combined_rank"]),
-    }));
+    const results: SearchResult[] = [];
+
+    for (const row of resultSet.rows) {
+      const searchResultBase = {
+        subject: String(row["subject"]),
+        predicate: String(row["predicate"]),
+        graph: String(row["graph"]),
+        text: String(row["value"]),
+      };
+      const searchQuad = createQuad(
+        namedNode(searchResultBase.subject),
+        namedNode(searchResultBase.predicate),
+        literal(searchResultBase.text),
+        searchResultBase.graph
+          ? namedNode(searchResultBase.graph)
+          : defaultGraph(),
+      );
+
+      results.push({
+        id: await hashQuad(searchQuad),
+        ...searchResultBase,
+        score: Number(row["combined_rank"]),
+      });
+    }
 
     return { results };
   }

--- a/src/client/providers/rdfjs/rdfjs-search-index.ts
+++ b/src/client/providers/rdfjs/rdfjs-search-index.ts
@@ -1,12 +1,16 @@
 import type * as rdfjs from "@rdfjs/types";
+import { DataFactory } from "n3";
 import type {
   SearchIndexInterface,
   SearchRequest,
   SearchResponse,
   SearchResult,
 } from "#/client/search-index/search-index-interface.ts";
+import { hashQuad } from "#/client/quad-store/hash-quad.ts";
 import { filterQuads } from "#/client/quad-store/quad-filter.ts";
 import { isTextualLiteral } from "#/client/quad-store/is-textual-literal.ts";
+
+const { literal, namedNode, quad: createQuad, defaultGraph } = DataFactory;
 
 /**
  * RdfjsSearchIndex is the implementation of SearchIndexInterface that uses an RDF/JS store.
@@ -20,6 +24,7 @@ export class RdfjsSearchIndex implements SearchIndexInterface {
     const query = request.query.toLowerCase();
     const stream = this.store.match(null, null, null, null);
     const results: Array<SearchResult> = [];
+    const pendingSearchResultPromises: Array<Promise<void>> = [];
 
     // 🛡️ Pre-compile the centralized O(1) execution gate from the request payload
     const matcher = filterQuads(request);
@@ -35,19 +40,35 @@ export class RdfjsSearchIndex implements SearchIndexInterface {
         if (isTextualLiteral(quad.object)) {
           const value = quad.object.value;
           if (value.toLowerCase().includes(query)) {
-            results.push({
-              subject: quad.subject.value,
-              predicate: quad.predicate.value,
-              graph: quad.graph.value,
-              text: value,
-              score: 1.0,
-            });
+            pendingSearchResultPromises.push((async () => {
+              const searchResultBase = {
+                subject: quad.subject.value,
+                predicate: quad.predicate.value,
+                graph: quad.graph.value,
+                text: value,
+              };
+              const searchQuad = createQuad(
+                namedNode(searchResultBase.subject),
+                namedNode(searchResultBase.predicate),
+                literal(searchResultBase.text),
+                searchResultBase.graph
+                  ? namedNode(searchResultBase.graph)
+                  : defaultGraph(),
+              );
+              results.push({
+                id: await hashQuad(searchQuad),
+                ...searchResultBase,
+                score: 1.0,
+              });
+            })());
           }
         }
       });
       stream.on("end", resolve);
       stream.on("error", reject);
     });
+
+    await Promise.all(pendingSearchResultPromises);
 
     return { results };
   }

--- a/src/client/search-index/search-index-interface.ts
+++ b/src/client/search-index/search-index-interface.ts
@@ -20,6 +20,9 @@ export interface SearchResponse {
  * SearchResult is a hybrid keyword/vector hit against an RDF literal.
  */
 export interface SearchResult {
+  /** id is the stable deterministic identifier for ranking and evaluation. */
+  id: string;
+
   /** subject is the subject resource of the hit */
   subject: string;
 


### PR DESCRIPTION
Separated concern from PR #12: use of \hashQuad\ for stable IDs.