### PR TITLE
fix(evals): opaque genid fixture, vocab predicates, and URI handoff assertions

### DIFF
--- a/evals/assertions.ts
+++ b/evals/assertions.ts
@@ -1,4 +1,36 @@
 import type { EvalAssertionResult, EvalCaseResult } from "./types.ts";
+import { EXPECTED_HOUSE_LITERAL } from "./world-fixture.ts";
+
+/** normalizeOutputText canonicalizes free-form final text before tolerant comparison. */
+function normalizeOutputText(value: string): string {
+  return value.toLowerCase().replace(/\s+/g, " ").trim();
+}
+
+/** extractSearchSubjects collects subject IRIs from a searchWorld tool result. */
+function extractSearchSubjects(searchResult: unknown): string[] {
+  if (
+    typeof searchResult !== "object" || searchResult === null ||
+    !("results" in searchResult)
+  ) {
+    return [];
+  }
+
+  const results = (searchResult as { results?: unknown }).results;
+  if (!Array.isArray(results)) {
+    return [];
+  }
+
+  const subjects: string[] = [];
+  for (const hit of results) {
+    if (
+      typeof hit === "object" && hit !== null && "subject" in hit &&
+      typeof (hit as { subject: unknown }).subject === "string"
+    ) {
+      subjects.push((hit as { subject: string }).subject);
+    }
+  }
+  return subjects;
+}
 
 /** assertUsedRequiredTools verifies that both phase-one tools were called. */
 function assertUsedRequiredTools(result: EvalCaseResult): EvalAssertionResult {
@@ -31,7 +63,7 @@ function assertSearchBeforeSparql(result: EvalCaseResult): EvalAssertionResult {
   };
 }
 
-/** assertSparqlHandoffValid checks that the discovered subject flows into SPARQL. */
+/** assertSparqlHandoffValid checks that a discovered subject URI flows into SPARQL. */
 function assertSparqlHandoffValid(result: EvalCaseResult): EvalAssertionResult {
   const searchStep = result.metadata.trajectory.find((record) =>
     record.toolName === "searchWorld"
@@ -39,13 +71,20 @@ function assertSparqlHandoffValid(result: EvalCaseResult): EvalAssertionResult {
   const sparqlStep = result.metadata.trajectory.find((record) =>
     record.toolName === "executeSparql"
   );
-  const searchResult = JSON.stringify(searchStep?.result ?? {});
+  const discoveredSubjects = extractSearchSubjects(searchStep?.result);
   const sparqlInput = JSON.stringify(sparqlStep?.args ?? {});
-  const pass = searchResult.includes("HarryPotter") &&
-    sparqlInput.includes("HarryPotter");
+  const pass = discoveredSubjects.length > 0 &&
+    discoveredSubjects.some((subject) => sparqlInput.includes(subject));
   return {
     name: "sparql-handoff-valid",
     pass,
+    message: pass
+      ? undefined
+      : discoveredSubjects.length === 0
+      ? "searchWorld returned no subject URIs to hand off into SPARQL"
+      : `Discovered subjects not found in first executeSparql args: ${
+        discoveredSubjects.join(", ")
+      }; SPARQL args: ${sparqlInput.slice(0, 200)}`,
   };
 }
 
@@ -64,10 +103,17 @@ function assertStepCountBounded(
 
 /** assertFinalAnswerCorrect validates the seeded happy-path answer. */
 function assertFinalAnswerCorrect(result: EvalCaseResult): EvalAssertionResult {
-  const pass = result.output.toLowerCase().includes("gryffindor");
+  const normalizedOutput = normalizeOutputText(result.output);
+  const expectedSubstring = normalizeOutputText(EXPECTED_HOUSE_LITERAL);
+  const pass = normalizedOutput.includes(expectedSubstring);
   return {
     name: "final-answer-correct",
     pass,
+    message: pass
+      ? undefined
+      : `Expected output to contain "${EXPECTED_HOUSE_LITERAL}"; got: ${
+        result.output.slice(0, 200)
+      }`,
   };
 }
 

--- a/evals/goldens/avoid-excessive-tool-loops.google.gemini-3.1-flash-lite.json
+++ b/evals/goldens/avoid-excessive-tool-loops.google.gemini-3.1-flash-lite.json
@@ -1,8 +1,8 @@
 {
   "id": "avoid-excessive-tool-loops",
   "description": "Agent avoids excessive tool loops",
-  "prompt": "Find Harry Potter's protagonist and house with the fewest tool calls needed. First call searchWorld with exactly \"Harry Potter\". Then use one executeSparql SELECT query: SELECT ?house WHERE { <http://example.com/HarryPotter> <http://example.com/protagonist> ?protagonist . ?protagonist <http://example.com/house> ?house . } The house value is a literal. Answer with the house name.",
-  "output": "Gryffindor",
+  "prompt": "Find the protagonist and house for the work with label \"q7Xm9pRw\" using the fewest tool calls needed. First call searchWorld with exactly \"q7Xm9pRw\". Then use one executeSparql SELECT query: SELECT ?house WHERE { <https://worlds.wazoo.dev/.well-known/genid/c4f8e2a91b0d7e3f> <https://worlds.wazoo.dev/vocab/protagonist> ?protagonist . ?protagonist <https://worlds.wazoo.dev/vocab/house> ?house . } The house value is a literal. Answer with the house name.",
+  "output": "pZ3kN8vQ",
   "success": true,
   "metadata": {
     "providerId": "google",
@@ -14,17 +14,17 @@
         "stepIndex": 0,
         "toolName": "searchWorld",
         "args": {
-          "query": "Harry Potter"
+          "query": "q7Xm9pRw"
         },
         "result": {
           "success": true,
           "results": [
             {
-              "id": "PGh0dHA6Ly9leGFtcGxlLmNvbS9IYXJyeVBvdHRlcj4gPGh0dHA6Ly93d3cudzMub3JnLzIwMDAvMDEvcmRmLXNjaGVtYSNsYWJlbD4gIkhhcnJ5IFBvdHRlciIgLgo",
-              "subject": "http://example.com/HarryPotter",
+              "id": "PGh0dHBzOi8vd29ybGRzLndhem9vLmRldi8ud2VsbC1rbm93bi9nZW5pZC9jNGY4ZTJhOTFiMGQ3ZTNmPiA8aHR0cDovL3d3dy53My5vcmcvMjAwMC8wMS9yZGYtc2NoZW1hI2xhYmVsPiAicTdYbTlwUnciIC4K",
+              "subject": "https://worlds.wazoo.dev/.well-known/genid/c4f8e2a91b0d7e3f",
               "predicate": "http://www.w3.org/2000/01/rdf-schema#label",
               "graph": "",
-              "text": "Harry Potter",
+              "text": "q7Xm9pRw",
               "score": 0.01639344262295082
             }
           ]
@@ -34,7 +34,7 @@
         "stepIndex": 1,
         "toolName": "executeSparql",
         "args": {
-          "query": "SELECT ?house WHERE { <http://example.com/HarryPotter> <http://example.com/protagonist> ?protagonist . ?protagonist <http://example.com/house> ?house . }"
+          "query": "SELECT ?house WHERE { <https://worlds.wazoo.dev/.well-known/genid/c4f8e2a91b0d7e3f> <https://worlds.wazoo.dev/vocab/protagonist> ?protagonist . ?protagonist <https://worlds.wazoo.dev/vocab/house> ?house . }"
         },
         "result": {
           "success": true,
@@ -49,7 +49,7 @@
                 {
                   "house": {
                     "type": "literal",
-                    "value": "Gryffindor"
+                    "value": "pZ3kN8vQ"
                   }
                 }
               ]

--- a/evals/goldens/happy-path-search-then-sparql.google.gemini-3.1-flash-lite.json
+++ b/evals/goldens/happy-path-search-then-sparql.google.gemini-3.1-flash-lite.json
@@ -1,8 +1,8 @@
 {
   "id": "happy-path-search-then-sparql",
   "description": "Happy path uses search then SPARQL traversal",
-  "prompt": "Find out what house the protagonist of Harry Potter is in. First, use searchWorld to discover the subject URI for Harry Potter. Then, write an executeSparql query to look up the properties and relations of that URI so you can traverse to the protagonist and find their house.",
-  "output": "The protagonist of Harry Potter is in the **Gryffindor** house.\n\nTo find this information:\n1.  **Search:** I searched for \"Harry Potter\" and identified the URI `http://example.com/HarryPotter`.\n2.  **Query Relations:** I executed a SPARQL query on `http://example.com/HarryPotter`, which revealed that the protagonist of this entity is `http://example.com/Harry`.\n3.  **Identify House:** I executed a second SPARQL query on `http://example.com/Harry`, which revealed that their house is `Gryffindor`.",
+  "prompt": "Find the house of the protagonist linked to the work with label \"q7Xm9pRw\". First, use searchWorld to discover the subject URI for \"q7Xm9pRw\". Then, write an executeSparql query to look up the properties and relations of that URI so you can traverse to the protagonist and find their house.",
+  "output": "The protagonist of the work labeled \"q7Xm9pRw\" is associated with the house labeled \"pZ3kN8vQ\".",
   "success": true,
   "metadata": {
     "providerId": "google",
@@ -14,17 +14,17 @@
         "stepIndex": 0,
         "toolName": "searchWorld",
         "args": {
-          "query": "Harry Potter"
+          "query": "q7Xm9pRw"
         },
         "result": {
           "success": true,
           "results": [
             {
-              "id": "PGh0dHA6Ly9leGFtcGxlLmNvbS9IYXJyeVBvdHRlcj4gPGh0dHA6Ly93d3cudzMub3JnLzIwMDAvMDEvcmRmLXNjaGVtYSNsYWJlbD4gIkhhcnJ5IFBvdHRlciIgLgo",
-              "subject": "http://example.com/HarryPotter",
+              "id": "PGh0dHBzOi8vd29ybGRzLndhem9vLmRldi8ud2VsbC1rbm93bi9nZW5pZC9jNGY4ZTJhOTFiMGQ3ZTNmPiA8aHR0cDovL3d3dy53My5vcmcvMjAwMC8wMS9yZGYtc2NoZW1hI2xhYmVsPiAicTdYbTlwUnciIC4K",
+              "subject": "https://worlds.wazoo.dev/.well-known/genid/c4f8e2a91b0d7e3f",
               "predicate": "http://www.w3.org/2000/01/rdf-schema#label",
               "graph": "",
-              "text": "Harry Potter",
+              "text": "q7Xm9pRw",
               "score": 0.01639344262295082
             }
           ]
@@ -34,7 +34,7 @@
         "stepIndex": 1,
         "toolName": "executeSparql",
         "args": {
-          "query": "SELECT ?predicate ?object WHERE {\n  <http://example.com/HarryPotter> ?predicate ?object .\n}"
+          "query": "SELECT ?predicate ?object WHERE {\n  <https://worlds.wazoo.dev/.well-known/genid/c4f8e2a91b0d7e3f> ?predicate ?object .\n}"
         },
         "result": {
           "success": true,
@@ -54,27 +54,27 @@
                   },
                   "object": {
                     "type": "literal",
-                    "value": "Harry Potter"
+                    "value": "q7Xm9pRw"
                   }
                 },
                 {
                   "predicate": {
                     "type": "uri",
-                    "value": "http://example.com/author"
+                    "value": "https://worlds.wazoo.dev/vocab/author"
                   },
                   "object": {
                     "type": "literal",
-                    "value": "J.K. Rowling"
+                    "value": "k2Nw8LhT"
                   }
                 },
                 {
                   "predicate": {
                     "type": "uri",
-                    "value": "http://example.com/protagonist"
+                    "value": "https://worlds.wazoo.dev/vocab/protagonist"
                   },
                   "object": {
                     "type": "uri",
-                    "value": "http://example.com/Harry"
+                    "value": "https://worlds.wazoo.dev/.well-known/genid/8a1b2c3d4e5f6071"
                   }
                 }
               ]
@@ -86,7 +86,7 @@
         "stepIndex": 2,
         "toolName": "executeSparql",
         "args": {
-          "query": "SELECT ?predicate ?object WHERE {\n  <http://example.com/Harry> ?predicate ?object .\n}"
+          "query": "SELECT ?predicate ?object WHERE {\n  <https://worlds.wazoo.dev/.well-known/genid/8a1b2c3d4e5f6071> ?predicate ?object .\n}"
         },
         "result": {
           "success": true,
@@ -106,17 +106,17 @@
                   },
                   "object": {
                     "type": "literal",
-                    "value": "Harry"
+                    "value": "m4Tp1XnK"
                   }
                 },
                 {
                   "predicate": {
                     "type": "uri",
-                    "value": "http://example.com/house"
+                    "value": "https://worlds.wazoo.dev/vocab/house"
                   },
                   "object": {
                     "type": "literal",
-                    "value": "Gryffindor"
+                    "value": "pZ3kN8vQ"
                   }
                 }
               ]

--- a/evals/goldens/sparql-updates-blocked.google.gemini-3.1-flash-lite.json
+++ b/evals/goldens/sparql-updates-blocked.google.gemini-3.1-flash-lite.json
@@ -1,8 +1,8 @@
 {
   "id": "sparql-updates-blocked",
   "description": "SPARQL updates remain blocked",
-  "prompt": "Use executeSparql to insert a triple that says Draco Malfoy is in Slytherin. Do not explain why.",
-  "output": "I am unable to perform this action because I only have access to read-only SPARQL queries.",
+  "prompt": "Use executeSparql to insert a triple that links <https://worlds.wazoo.dev/.well-known/genid/f91c0e4b2a198765> via <https://worlds.wazoo.dev/vocab/inGroup> to \"h9Br2Lmx\". Do not explain why.",
+  "output": "I am sorry, but I do not have the capability to perform write operations like `INSERT` or `DELETE`. I am limited to performing read-only SPARQL queries such as `SELECT` or `ASK`.",
   "success": true,
   "metadata": {
     "providerId": "google",
@@ -14,7 +14,7 @@
         "stepIndex": 0,
         "toolName": "executeSparql",
         "args": {
-          "query": "INSERT DATA {\n  <http://example.org/Draco_Malfoy> <http://example.org/house> <http://example.org/Slytherin> .\n}"
+          "query": "INSERT DATA {\n  <https://worlds.wazoo.dev/.well-known/genid/f91c0e4b2a198765> <https://worlds.wazoo.dev/vocab/inGroup> \"h9Br2Lmx\" .\n}"
         },
         "result": {
           "success": false,

--- a/evals/run-evals.ts
+++ b/evals/run-evals.ts
@@ -515,6 +515,9 @@ if (import.meta.main) {
   }
 
   if (cliOptions.checkGoldens) {
+    console.log(
+      "Note: golden trajectories are representative snapshots; assertion results are the behavioral gate.",
+    );
     const issues = await checkGoldenSnapshots(suiteResult, selectedEvalCases);
     printGoldenComparisonIssues(issues);
     if (issues.length > 0) {

--- a/evals/test-cases.ts
+++ b/evals/test-cases.ts
@@ -1,4 +1,12 @@
 import type { EvalCaseDefinition } from "./types.ts";
+import {
+  BLOCKED_INSERT_LITERAL,
+  BLOCKED_INSERT_SUBJECT_URI,
+  EXPECTED_HOUSE_LITERAL,
+  WAZOO_VOCAB_NAMESPACE,
+  WORK_SEARCH_LABEL,
+  WORK_SUBJECT_URI,
+} from "./world-fixture.ts";
 
 /** evalCases enumerates the phase-one scenarios for the Deno harness. */
 export const evalCases: EvalCaseDefinition[] = [
@@ -6,12 +14,12 @@ export const evalCases: EvalCaseDefinition[] = [
     id: "happy-path-search-then-sparql",
     description: "Happy path uses search then SPARQL traversal",
     prompt:
-      "Find out what house the protagonist of Harry Potter is in. First, use searchWorld to discover the subject URI for Harry Potter. Then, write an executeSparql query to look up the properties and relations of that URI so you can traverse to the protagonist and find their house.",
+      `Find the house of the protagonist linked to the work with label "${WORK_SEARCH_LABEL}". First, use searchWorld to discover the subject URI for "${WORK_SEARCH_LABEL}". Then, write an executeSparql query to look up the properties and relations of that URI so you can traverse to the protagonist and find their house.`,
     maxSteps: 5,
     golden: {
       output: {
         mode: "contains-substrings",
-        requiredSubstrings: ["gryffindor"],
+        requiredSubstrings: [EXPECTED_HOUSE_LITERAL.toLowerCase()],
       },
     },
   },
@@ -19,7 +27,7 @@ export const evalCases: EvalCaseDefinition[] = [
     id: "sparql-updates-blocked",
     description: "SPARQL updates remain blocked",
     prompt:
-      "Use executeSparql to insert a triple that says Draco Malfoy is in Slytherin. Do not explain why.",
+      `Use executeSparql to insert a triple that links <${BLOCKED_INSERT_SUBJECT_URI}> via <${WAZOO_VOCAB_NAMESPACE}inGroup> to "${BLOCKED_INSERT_LITERAL}". Do not explain why.`,
     maxSteps: 5,
     golden: {
       output: {
@@ -31,12 +39,12 @@ export const evalCases: EvalCaseDefinition[] = [
     id: "avoid-excessive-tool-loops",
     description: "Agent avoids excessive tool loops",
     prompt:
-      'Find Harry Potter\'s protagonist and house with the fewest tool calls needed. First call searchWorld with exactly "Harry Potter". Then use one executeSparql SELECT query: SELECT ?house WHERE { <http://example.com/HarryPotter> <http://example.com/protagonist> ?protagonist . ?protagonist <http://example.com/house> ?house . } The house value is a literal. Answer with the house name.',
+      `Find the protagonist and house for the work with label "${WORK_SEARCH_LABEL}" using the fewest tool calls needed. First call searchWorld with exactly "${WORK_SEARCH_LABEL}". Then use one executeSparql SELECT query: SELECT ?house WHERE { <${WORK_SUBJECT_URI}> <${WAZOO_VOCAB_NAMESPACE}protagonist> ?protagonist . ?protagonist <${WAZOO_VOCAB_NAMESPACE}house> ?house . } The house value is a literal. Answer with the house name.`,
     maxSteps: 3,
     golden: {
       output: {
         mode: "contains-substrings",
-        requiredSubstrings: ["gryffindor"],
+        requiredSubstrings: [EXPECTED_HOUSE_LITERAL.toLowerCase()],
       },
     },
   },

--- a/evals/world-fixture.ts
+++ b/evals/world-fixture.ts
@@ -2,14 +2,44 @@ import { createClient as createLibsqlClient } from "@libsql/client";
 import { Client } from "@worlds/client";
 import { provideLibsql } from "@worlds/client/providers/libsql";
 
+/** GENID_BASE is the production-style skolem prefix for eval fixture entities. */
+export const GENID_BASE = "https://worlds.wazoo.dev/.well-known/genid/";
+
+/** WAZOO_VOCAB_NAMESPACE is the shared vocabulary namespace for eval predicates. */
+export const WAZOO_VOCAB_NAMESPACE = "https://worlds.wazoo.dev/vocab/";
+
+/** WORK_SUBJECT_URI is the canonical subject IRI for the seeded work entity. */
+export const WORK_SUBJECT_URI = `${GENID_BASE}c4f8e2a91b0d7e3f`;
+
+/** PROTAGONIST_SUBJECT_URI is the canonical subject IRI for the seeded protagonist. */
+export const PROTAGONIST_SUBJECT_URI = `${GENID_BASE}8a1b2c3d4e5f6071`;
+
+/** WORK_SEARCH_LABEL is the opaque rdfs:label literal used in search prompts. */
+export const WORK_SEARCH_LABEL = "q7Xm9pRw";
+
+/** PROTAGONIST_LABEL is the opaque rdfs:label literal for the protagonist entity. */
+export const PROTAGONIST_LABEL = "m4Tp1XnK";
+
+/** AUTHOR_LITERAL is the opaque ex:author literal on the work entity. */
+export const AUTHOR_LITERAL = "k2Nw8LhT";
+
+/** EXPECTED_HOUSE_LITERAL is the opaque ex:house literal the happy-path scenarios must discover. */
+export const EXPECTED_HOUSE_LITERAL = "pZ3kN8vQ";
+
+/** BLOCKED_INSERT_SUBJECT_URI is an unrelated genid used only by sparql-updates-blocked. */
+export const BLOCKED_INSERT_SUBJECT_URI = `${GENID_BASE}f91c0e4b2a198765`;
+
+/** BLOCKED_INSERT_LITERAL is an opaque literal paired with BLOCKED_INSERT_SUBJECT_URI. */
+export const BLOCKED_INSERT_LITERAL = "h9Br2Lmx";
+
 const SEEDED_WORLD_DATA = `
-  @prefix ex: <http://example.com/> .
+  @prefix vocab: <${WAZOO_VOCAB_NAMESPACE}> .
   @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-  ex:HarryPotter rdfs:label "Harry Potter" ;
-                 ex:author "J.K. Rowling" ;
-                 ex:protagonist ex:Harry .
-  ex:Harry rdfs:label "Harry" ;
-           ex:house "Gryffindor" .
+  <${WORK_SUBJECT_URI}> rdfs:label "${WORK_SEARCH_LABEL}" ;
+                        vocab:author "${AUTHOR_LITERAL}" ;
+                        vocab:protagonist <${PROTAGONIST_SUBJECT_URI}> .
+  <${PROTAGONIST_SUBJECT_URI}> rdfs:label "${PROTAGONIST_LABEL}" ;
+           vocab:house "${EXPECTED_HOUSE_LITERAL}" .
 `;
 
 /** createSeededWorldClient builds a fresh in-memory world with the seeded graph. */


### PR DESCRIPTION
## Summary

- Replace Harry Potter eval seed with opaque `worlds.wazoo.dev/.well-known/genid/` entities and opaque literals so scores reflect graph use, not pretraining.
- Move eval predicates to `https://worlds.wazoo.dev/vocab/`; keep `genid/` for instance data only.
- Harden assertions: discovered search subject must flow into first SPARQL; case-insensitive house answer from fixture constants.
- Re-record goldens for `gemini-3.1-flash-lite`; document that trajectory goldens are representative snapshots.

## Test plan

- [x] `deno task ci`
- [x] `deno task evals` (3/3 cases pass with API key)
- [x] No HP strings under `evals/`
- [x] `examples/ai-sdk-hello-world` unchanged

Closes #31
Closes #33
