### PR TITLE
feat(evals): scenarios, harness tests, and README

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -1,0 +1,107 @@
+# Agent eval harness
+
+Deno-native smoke harness for the AI SDK tool flow (`searchWorld`,
+`executeSparql`) against a seeded in-memory LibSQL world. Live runs call a
+credentialed Google model; deterministic assertion helpers and SPARQL guards are
+covered by unit tests in this directory (`*.test.ts`).
+
+Design direction: this stays a **targeted smoke harness**, not a general eval
+framework. See
+[issue #27](https://github.com/wazootech/worlds-client-ts/issues/27) for the
+recorded decision (opaque genid fixture, fixture-specific assertions, golden
+trajectories as representative snapshots).
+
+## Environment
+
+| Variable                       |    Required     | Default                 | Purpose                                         |
+| :----------------------------- | :-------------: | :---------------------- | :---------------------------------------------- |
+| `GOOGLE_GENERATIVE_AI_API_KEY` | Yes (live runs) | —                       | Google Generative AI API key for `generateText` |
+| `EVAL_PROVIDER_ID`             |       No        | `google`                | Provider label and golden filename segment      |
+| `EVAL_MODEL_ID`                |       No        | `gemini-3.1-flash-lite` | Model id passed to the Google provider          |
+
+Unit tests under `evals/*.test.ts` do not use these variables and run without an
+API key.
+
+## Run
+
+```bash
+deno task evals
+```
+
+Equivalent to:
+
+```bash
+deno run -A --env ./evals/run-evals.ts
+```
+
+### Flags
+
+| Flag                 | Description                                                                                     |
+| :------------------- | :---------------------------------------------------------------------------------------------- |
+| `--list`             | Print matching case ids and descriptions, then exit                                             |
+| `--filter <pattern>` | Deno-test-like filter on case `id` or `description` (literal or `/regex/i`)                     |
+| `--permit-no-files`  | Exit 0 when the filter matches no cases (default: error)                                        |
+| `--update-goldens`   | Write blessed snapshots under `evals/goldens/` (requires `--filter`; case must pass assertions) |
+| `--check-goldens`    | Compare run output to committed goldens (requires `--filter`)                                   |
+
+Examples:
+
+```bash
+deno task evals --list
+deno task evals --filter happy-path
+deno task evals --filter "/sparql|distractor/i"
+deno task evals --filter happy-path --update-goldens
+deno task evals --filter happy-path --check-goldens
+```
+
+## Output and exit codes
+
+- **Summary:** per-case pass/fail, step count, tool names, assertion lines
+  (stdout).
+- **Artifact:** `evals/results/latest.json` — full suite JSON (gitignored).
+- **Exit code:** `0` when every selected case passes assertions; `1` on any
+  failure or golden check mismatch.
+
+Types for results and goldens: `evals/types.ts`.
+
+## Permissions
+
+The `evals` task uses **`-A` (`--allow-all`)** and **`--env`** so the runner can
+read `.env`, open LibSQL, and reach the Google API. Unit tests are picked up by
+`deno task
+test` / `deno task ci` with the same project-wide
+`--allow-all --unstable-kv` settings.
+
+## Goldens vs assertions
+
+- **Golden files** (`evals/goldens/<case-id>.<provider>.<model>.json`) are
+  representative snapshots of trajectories and outputs for review and optional
+  `--check-goldens` regression diffs.
+- **Assertions** (`evals/assertions.ts`, routed by case id in `applyAssertions`)
+  are the behavioral pass/fail gate. A run can pass all assertions while goldens
+  drift until you intentionally re-bless with `--update-goldens`.
+
+## Eval cases
+
+| Case id                                  | What it exercises                                                                                     |
+| :--------------------------------------- | :---------------------------------------------------------------------------------------------------- |
+| `happy-path-search-then-sparql`          | Search discovers work URI, SPARQL handoff, grounded house literal, correct final answer (max 5 steps) |
+| `sparql-updates-blocked`                 | `INSERT` (and similar) rejected by read-only SPARQL guard                                             |
+| `avoid-excessive-tool-loops`             | Required tools with tight step budget (max 3)                                                         |
+| `discovery-efficient-search-then-sparql` | Search then one SPARQL SELECT; handoff and step cap (max 3)                                           |
+| `distractor-work-disambiguation`         | Correct work/house despite second seeded work; must not answer with distractor house                  |
+
+Case definitions and prompts: `evals/test-cases.ts`. Seeded graph:
+`evals/world-fixture.ts`.
+
+## Layout
+
+| Path              | Role                                                     |
+| :---------------- | :------------------------------------------------------- |
+| `run-evals.ts`    | CLI entry, filtering, golden update/check, `latest.json` |
+| `agent-runner.ts` | One case execution via AI SDK                            |
+| `tools.ts`        | Eval-isolated tools and SPARQL read-only guard           |
+| `assertions.ts`   | Per-case deterministic assertions                        |
+| `test-cases.ts`   | Scenario catalog                                         |
+| `goldens/`        | Committed provider/model snapshots                       |
+| `results/`        | Local run output (gitignored)                            |

--- a/evals/agent-runner.test.ts
+++ b/evals/agent-runner.test.ts
@@ -1,0 +1,89 @@
+import { assertEquals } from "@std/assert";
+import { buildTrajectory } from "./agent-runner.ts";
+
+Deno.test("buildTrajectory pairs tool results by toolCallId", () => {
+  const trajectory = buildTrajectory([{
+    toolCalls: [
+      {
+        toolName: "searchWorld",
+        input: { query: "q7Xm9pRw" },
+        toolCallId: "call-search",
+      },
+      {
+        toolName: "executeSparql",
+        input: { query: "SELECT ?house WHERE {}" },
+        toolCallId: "call-sparql",
+      },
+    ],
+    toolResults: [
+      { toolCallId: "call-sparql", output: { success: true, data: null } },
+      { toolCallId: "call-search", output: { success: true, results: [] } },
+    ],
+  }]);
+
+  assertEquals(trajectory, [
+    {
+      stepIndex: 0,
+      toolName: "searchWorld",
+      args: { query: "q7Xm9pRw" },
+      result: { success: true, results: [] },
+    },
+    {
+      stepIndex: 0,
+      toolName: "executeSparql",
+      args: { query: "SELECT ?house WHERE {}" },
+      result: { success: true, data: null },
+    },
+  ]);
+});
+
+Deno.test("buildTrajectory leaves result undefined when toolCallId is missing", () => {
+  const trajectory = buildTrajectory([{
+    toolCalls: [{
+      toolName: "searchWorld",
+      input: { query: "missing-result" },
+      toolCallId: "orphan-call",
+    }],
+    toolResults: [],
+  }]);
+
+  assertEquals(trajectory, [{
+    stepIndex: 0,
+    toolName: "searchWorld",
+    args: { query: "missing-result" },
+    result: undefined,
+  }]);
+});
+
+Deno.test("buildTrajectory flattens multiple steps in order", () => {
+  const trajectory = buildTrajectory([
+    {
+      toolCalls: [{
+        toolName: "searchWorld",
+        input: { query: "step-0" },
+        toolCallId: "step-0-call",
+      }],
+      toolResults: [{
+        toolCallId: "step-0-call",
+        output: { step: 0 },
+      }],
+    },
+    {
+      toolCalls: [{
+        toolName: "executeSparql",
+        input: { query: "SELECT ?x WHERE {}" },
+        toolCallId: "step-1-call",
+      }],
+      toolResults: [{
+        toolCallId: "step-1-call",
+        output: { step: 1 },
+      }],
+    },
+  ]);
+
+  assertEquals(trajectory.map((record) => record.stepIndex), [0, 1]);
+  assertEquals(trajectory.map((record) => record.toolName), [
+    "searchWorld",
+    "executeSparql",
+  ]);
+});

--- a/evals/agent-runner.ts
+++ b/evals/agent-runner.ts
@@ -9,7 +9,7 @@ import type {
 import { createSeededWorldClient } from "./world-fixture.ts";
 
 /** buildTrajectory flattens the AI SDK step history into a tool sequence. */
-function buildTrajectory(
+export function buildTrajectory(
   steps: Array<{
     toolCalls: Array<{
       toolName: string;

--- a/evals/assertions.test.ts
+++ b/evals/assertions.test.ts
@@ -1,0 +1,255 @@
+import { assertEquals, assertFalse } from "@std/assert";
+import {
+  applyAssertions,
+  extractSearchSubjects,
+  extractSparqlBindingLiterals,
+} from "./assertions.ts";
+import type { EvalCaseResult, EvalToolRecord } from "./types.ts";
+import {
+  DISTRACTOR_EXPECTED_HOUSE_LITERAL,
+  EXPECTED_HOUSE_LITERAL,
+  WORK_SUBJECT_URI,
+} from "./world-fixture.ts";
+
+/** createEvalCaseResult builds a minimal case result for assertion routing tests. */
+function createEvalCaseResult(
+  overrides: Partial<EvalCaseResult> & Pick<EvalCaseResult, "id">,
+): EvalCaseResult {
+  return {
+    description: overrides.description ?? overrides.id,
+    prompt: overrides.prompt ?? "",
+    output: overrides.output ?? "",
+    success: overrides.success ?? true,
+    metadata: {
+      providerId: "google",
+      modelId: "gemini-3.1-flash-lite",
+      stepCount: overrides.metadata?.stepCount ?? 2,
+      latencyMs: overrides.metadata?.latencyMs ?? 0,
+      trajectory: overrides.metadata?.trajectory ?? [],
+      ...overrides.metadata,
+    },
+    assertions: [],
+    ...overrides,
+  };
+}
+
+/** createPassingHappyPathTrajectory returns a trajectory that satisfies happy-path assertions. */
+function createPassingHappyPathTrajectory(): EvalToolRecord[] {
+  return [
+    {
+      stepIndex: 0,
+      toolName: "searchWorld",
+      args: { query: "q7Xm9pRw" },
+      result: {
+        success: true,
+        results: [{ subject: WORK_SUBJECT_URI }],
+      },
+    },
+    {
+      stepIndex: 1,
+      toolName: "executeSparql",
+      args: {
+        query: `SELECT ?house WHERE { <${WORK_SUBJECT_URI}> ?p ?o }`,
+      },
+      result: {
+        success: true,
+        data: {
+          results: {
+            bindings: [{
+              house: { type: "literal", value: EXPECTED_HOUSE_LITERAL },
+            }],
+          },
+        },
+      },
+    },
+  ];
+}
+
+const CASE_ASSERTION_NAMES: Record<string, string[]> = {
+  "happy-path-search-then-sparql": [
+    "used-required-tools",
+    "search-before-sparql",
+    "sparql-handoff-valid",
+    "step-count-bounded",
+    "sparql-answer-grounded",
+    "final-answer-correct",
+  ],
+  "sparql-updates-blocked": ["updates-blocked", "step-count-bounded"],
+  "avoid-excessive-tool-loops": [
+    "used-required-tools",
+    "step-count-bounded",
+    "sparql-answer-grounded",
+    "final-answer-correct",
+  ],
+  "discovery-efficient-search-then-sparql": [
+    "used-required-tools",
+    "search-before-sparql",
+    "sparql-handoff-valid",
+    "step-count-bounded",
+    "sparql-answer-grounded",
+    "final-answer-correct",
+  ],
+  "distractor-work-disambiguation": [
+    "used-required-tools",
+    "search-before-sparql",
+    "sparql-handoff-valid",
+    "sparql-answer-grounded",
+    "final-answer-correct",
+    "not-distractor-house",
+  ],
+};
+
+for (
+  const [caseId, expectedAssertionNames] of Object.entries(
+    CASE_ASSERTION_NAMES,
+  )
+) {
+  Deno.test(`applyAssertions routes ${caseId} to the expected assertion set`, () => {
+    const trajectory = caseId === "sparql-updates-blocked"
+      ? [{
+        stepIndex: 0,
+        toolName: "executeSparql",
+        args: { query: "INSERT { ?s ?p ?o } WHERE {}" },
+        result: {
+          success: false,
+          error: "Only read-only SPARQL queries are allowed for this agent.",
+        },
+      }]
+      : createPassingHappyPathTrajectory();
+
+    const output = caseId === "sparql-updates-blocked"
+      ? ""
+      : `The house is ${EXPECTED_HOUSE_LITERAL}.`;
+
+    const result = applyAssertions(createEvalCaseResult({
+      id: caseId,
+      output,
+      metadata: {
+        providerId: "google",
+        modelId: "gemini-3.1-flash-lite",
+        stepCount: trajectory.length,
+        latencyMs: 0,
+        trajectory,
+      },
+    }));
+
+    assertEquals(
+      result.assertions.map((assertion) => assertion.name),
+      expectedAssertionNames,
+    );
+    assertEquals(result.success, true);
+  });
+}
+
+Deno.test("applyAssertions fails unknown case ids with recognized-case-id", () => {
+  const result = applyAssertions(createEvalCaseResult({
+    id: "unknown-eval-case",
+    metadata: {
+      providerId: "google",
+      modelId: "gemini-3.1-flash-lite",
+      stepCount: 0,
+      latencyMs: 0,
+      trajectory: [],
+    },
+  }));
+
+  assertEquals(result.assertions.length, 1);
+  assertEquals(result.assertions[0].name, "recognized-case-id");
+  assertFalse(result.assertions[0].pass);
+  assertFalse(result.success);
+});
+
+Deno.test("applyAssertions clears success when a routed assertion fails", () => {
+  const result = applyAssertions(createEvalCaseResult({
+    id: "happy-path-search-then-sparql",
+    output: "no house literal here",
+    metadata: {
+      providerId: "google",
+      modelId: "gemini-3.1-flash-lite",
+      stepCount: 2,
+      latencyMs: 0,
+      trajectory: createPassingHappyPathTrajectory(),
+    },
+  }));
+
+  assertFalse(result.success);
+  assertFalse(
+    result.assertions.find((assertion) =>
+      assertion.name === "final-answer-correct"
+    )?.pass,
+  );
+});
+
+Deno.test("extractSearchSubjects collects subject IRIs from searchWorld results", () => {
+  const subjects = extractSearchSubjects({
+    success: true,
+    results: [
+      { subject: WORK_SUBJECT_URI },
+      { subject: "https://example.org/other" },
+      { notASubject: true },
+    ],
+  });
+
+  assertEquals(subjects, [
+    WORK_SUBJECT_URI,
+    "https://example.org/other",
+  ]);
+});
+
+Deno.test("extractSearchSubjects returns empty array for malformed input", () => {
+  assertEquals(extractSearchSubjects(null), []);
+  assertEquals(extractSearchSubjects({}), []);
+  assertEquals(extractSearchSubjects({ results: "not-an-array" }), []);
+  assertEquals(extractSearchSubjects({ results: [{ subject: 42 }] }), []);
+});
+
+Deno.test("extractSparqlBindingLiterals collects literal binding values", () => {
+  const literals = extractSparqlBindingLiterals({
+    success: true,
+    data: {
+      results: {
+        bindings: [
+          {
+            house: { type: "literal", value: EXPECTED_HOUSE_LITERAL },
+            work: {
+              type: "uri",
+              value: WORK_SUBJECT_URI,
+            },
+          },
+          {
+            label: { value: "untagged-literal" },
+          },
+        ],
+      },
+    },
+  });
+
+  assertEquals(literals, [EXPECTED_HOUSE_LITERAL, "untagged-literal"]);
+});
+
+Deno.test("extractSparqlBindingLiterals returns empty array for failed or missing data", () => {
+  assertEquals(extractSparqlBindingLiterals({ success: false }), []);
+  assertEquals(extractSparqlBindingLiterals({ success: true, data: null }), []);
+  assertEquals(extractSparqlBindingLiterals("not-an-object"), []);
+});
+
+Deno.test("applyAssertions not-distractor-house rejects distractor literal in output", () => {
+  const result = applyAssertions(createEvalCaseResult({
+    id: "distractor-work-disambiguation",
+    output: `House: ${DISTRACTOR_EXPECTED_HOUSE_LITERAL}`,
+    metadata: {
+      providerId: "google",
+      modelId: "gemini-3.1-flash-lite",
+      stepCount: 2,
+      latencyMs: 0,
+      trajectory: createPassingHappyPathTrajectory(),
+    },
+  }));
+
+  assertFalse(
+    result.assertions.find((assertion) =>
+      assertion.name === "not-distractor-house"
+    )?.pass,
+  );
+  assertFalse(result.success);
+});

--- a/evals/assertions.ts
+++ b/evals/assertions.ts
@@ -1,5 +1,8 @@
 import type { EvalAssertionResult, EvalCaseResult } from "./types.ts";
-import { EXPECTED_HOUSE_LITERAL } from "./world-fixture.ts";
+import {
+  DISTRACTOR_EXPECTED_HOUSE_LITERAL,
+  EXPECTED_HOUSE_LITERAL,
+} from "./world-fixture.ts";
 
 /** normalizeOutputText canonicalizes free-form final text before tolerant comparison. */
 function normalizeOutputText(value: string): string {
@@ -30,6 +33,47 @@ function extractSearchSubjects(searchResult: unknown): string[] {
     }
   }
   return subjects;
+}
+
+/** extractSparqlBindingLiterals collects literal values from a successful executeSparql result. */
+export function extractSparqlBindingLiterals(sparqlResult: unknown): string[] {
+  if (typeof sparqlResult !== "object" || sparqlResult === null) {
+    return [];
+  }
+
+  const toolResult = sparqlResult as { success?: boolean; data?: unknown };
+  if (!toolResult.success || toolResult.data === null) {
+    return [];
+  }
+
+  if (typeof toolResult.data !== "object" || toolResult.data === null) {
+    return [];
+  }
+
+  const bindings = (toolResult.data as {
+    results?: { bindings?: Array<Record<string, unknown>> };
+  }).results?.bindings;
+
+  if (!Array.isArray(bindings)) {
+    return [];
+  }
+
+  const literals: string[] = [];
+  for (const binding of bindings) {
+    for (const variable of Object.values(binding)) {
+      if (
+        typeof variable !== "object" || variable === null ||
+        !("value" in variable) || typeof variable.value !== "string"
+      ) {
+        continue;
+      }
+      const bindingValue = variable as { type?: string; value: string };
+      if (!bindingValue.type || bindingValue.type === "literal") {
+        literals.push(bindingValue.value);
+      }
+    }
+  }
+  return literals;
 }
 
 /** assertUsedRequiredTools verifies that both phase-one tools were called. */
@@ -117,6 +161,45 @@ function assertFinalAnswerCorrect(result: EvalCaseResult): EvalAssertionResult {
   };
 }
 
+/** assertSparqlAnswerGrounded verifies the expected house literal appears in SPARQL bindings. */
+function assertSparqlAnswerGrounded(
+  result: EvalCaseResult,
+  expectedLiteral: string = EXPECTED_HOUSE_LITERAL,
+): EvalAssertionResult {
+  const bindingLiterals = result.metadata.trajectory
+    .filter((record) => record.toolName === "executeSparql")
+    .flatMap((record) => extractSparqlBindingLiterals(record.result));
+
+  const pass = bindingLiterals.includes(expectedLiteral);
+  return {
+    name: "sparql-answer-grounded",
+    pass,
+    message: pass
+      ? undefined
+      : `Expected executeSparql binding literal "${expectedLiteral}"; observed literals: ${
+        bindingLiterals.length > 0 ? bindingLiterals.join(", ") : "(none)"
+      }`,
+  };
+}
+
+/** assertNotDistractorHouse verifies the final answer does not report the distractor house. */
+function assertNotDistractorHouse(result: EvalCaseResult): EvalAssertionResult {
+  const normalizedOutput = normalizeOutputText(result.output);
+  const distractorSubstring = normalizeOutputText(
+    DISTRACTOR_EXPECTED_HOUSE_LITERAL,
+  );
+  const pass = !normalizedOutput.includes(distractorSubstring);
+  return {
+    name: "not-distractor-house",
+    pass,
+    message: pass
+      ? undefined
+      : `Final answer must not contain distractor house "${DISTRACTOR_EXPECTED_HOUSE_LITERAL}"; got: ${
+        result.output.slice(0, 200)
+      }`,
+  };
+}
+
 /** assertUpdatesBlocked verifies the update guard produced the expected error. */
 function assertUpdatesBlocked(result: EvalCaseResult): EvalAssertionResult {
   const pass = result.metadata.trajectory.some((record) =>
@@ -141,6 +224,7 @@ export function applyAssertions(result: EvalCaseResult): EvalCaseResult {
       assertions.push(assertSearchBeforeSparql(result));
       assertions.push(assertSparqlHandoffValid(result));
       assertions.push(assertStepCountBounded(result, 5));
+      assertions.push(assertSparqlAnswerGrounded(result));
       assertions.push(assertFinalAnswerCorrect(result));
       break;
     case "sparql-updates-blocked":
@@ -150,7 +234,24 @@ export function applyAssertions(result: EvalCaseResult): EvalCaseResult {
     case "avoid-excessive-tool-loops":
       assertions.push(assertUsedRequiredTools(result));
       assertions.push(assertStepCountBounded(result, 3));
+      assertions.push(assertSparqlAnswerGrounded(result));
       assertions.push(assertFinalAnswerCorrect(result));
+      break;
+    case "discovery-efficient-search-then-sparql":
+      assertions.push(assertUsedRequiredTools(result));
+      assertions.push(assertSearchBeforeSparql(result));
+      assertions.push(assertSparqlHandoffValid(result));
+      assertions.push(assertStepCountBounded(result, 3));
+      assertions.push(assertSparqlAnswerGrounded(result));
+      assertions.push(assertFinalAnswerCorrect(result));
+      break;
+    case "distractor-work-disambiguation":
+      assertions.push(assertUsedRequiredTools(result));
+      assertions.push(assertSearchBeforeSparql(result));
+      assertions.push(assertSparqlHandoffValid(result));
+      assertions.push(assertSparqlAnswerGrounded(result));
+      assertions.push(assertFinalAnswerCorrect(result));
+      assertions.push(assertNotDistractorHouse(result));
       break;
     default:
       assertions.push({

--- a/evals/assertions.ts
+++ b/evals/assertions.ts
@@ -10,7 +10,7 @@ function normalizeOutputText(value: string): string {
 }
 
 /** extractSearchSubjects collects subject IRIs from a searchWorld tool result. */
-function extractSearchSubjects(searchResult: unknown): string[] {
+export function extractSearchSubjects(searchResult: unknown): string[] {
   if (
     typeof searchResult !== "object" || searchResult === null ||
     !("results" in searchResult)

--- a/evals/goldens/discovery-efficient-search-then-sparql.google.gemini-3.1-flash-lite.json
+++ b/evals/goldens/discovery-efficient-search-then-sparql.google.gemini-3.1-flash-lite.json
@@ -1,7 +1,7 @@
 {
-  "id": "avoid-excessive-tool-loops",
-  "description": "Agent avoids excessive tool loops",
-  "prompt": "Find the protagonist and house for the work with label \"q7Xm9pRw\" using the fewest tool calls needed. First call searchWorld with exactly \"q7Xm9pRw\". Then use one executeSparql SELECT query: SELECT ?house WHERE { <https://worlds.wazoo.dev/.well-known/genid/c4f8e2a91b0d7e3f> <https://worlds.wazoo.dev/vocab/protagonist> ?protagonist . ?protagonist <https://worlds.wazoo.dev/vocab/house> ?house . } The house value is a literal. Answer with the house name.",
+  "id": "discovery-efficient-search-then-sparql",
+  "description": "Discovery-efficient search then one SPARQL SELECT",
+  "prompt": "Find the protagonist and house for the work with label \"q7Xm9pRw\" using the fewest tool calls needed. First call searchWorld with exactly \"q7Xm9pRw\". Then use exactly one executeSparql SELECT query of the form SELECT ?house WHERE { <work-uri-from-search> <https://worlds.wazoo.dev/vocab/protagonist> ?protagonist . ?protagonist <https://worlds.wazoo.dev/vocab/house> ?house . } where <work-uri-from-search> is the subject field from the searchWorld hit (do not invent URIs). Answer with the house literal only.",
   "output": "pZ3kN8vQ",
   "success": true,
   "metadata": {
@@ -62,6 +62,14 @@
   "assertions": [
     {
       "name": "used-required-tools",
+      "pass": true
+    },
+    {
+      "name": "search-before-sparql",
+      "pass": true
+    },
+    {
+      "name": "sparql-handoff-valid",
       "pass": true
     },
     {

--- a/evals/goldens/distractor-work-disambiguation.google.gemini-3.1-flash-lite.json
+++ b/evals/goldens/distractor-work-disambiguation.google.gemini-3.1-flash-lite.json
@@ -1,7 +1,7 @@
 {
-  "id": "avoid-excessive-tool-loops",
-  "description": "Agent avoids excessive tool loops",
-  "prompt": "Find the protagonist and house for the work with label \"q7Xm9pRw\" using the fewest tool calls needed. First call searchWorld with exactly \"q7Xm9pRw\". Then use one executeSparql SELECT query: SELECT ?house WHERE { <https://worlds.wazoo.dev/.well-known/genid/c4f8e2a91b0d7e3f> <https://worlds.wazoo.dev/vocab/protagonist> ?protagonist . ?protagonist <https://worlds.wazoo.dev/vocab/house> ?house . } The house value is a literal. Answer with the house name.",
+  "id": "distractor-work-disambiguation",
+  "description": "Target work house excludes distractor work",
+  "prompt": "Find the house of the protagonist linked only to the work with label \"q7Xm9pRw\" (ignore any other work). First call searchWorld with exactly \"q7Xm9pRw\". Then use one executeSparql SELECT that binds the work URI from search and traverses <https://worlds.wazoo.dev/vocab/protagonist> then <https://worlds.wazoo.dev/vocab/house> ?house. Answer with only that house literal.",
   "output": "pZ3kN8vQ",
   "success": true,
   "metadata": {
@@ -34,7 +34,7 @@
         "stepIndex": 1,
         "toolName": "executeSparql",
         "args": {
-          "query": "SELECT ?house WHERE { <https://worlds.wazoo.dev/.well-known/genid/c4f8e2a91b0d7e3f> <https://worlds.wazoo.dev/vocab/protagonist> ?protagonist . ?protagonist <https://worlds.wazoo.dev/vocab/house> ?house . }"
+          "query": "SELECT ?house WHERE {\n  <https://worlds.wazoo.dev/.well-known/genid/c4f8e2a91b0d7e3f> <https://worlds.wazoo.dev/vocab/protagonist> / <https://worlds.wazoo.dev/vocab/house> ?house .\n}"
         },
         "result": {
           "success": true,
@@ -65,7 +65,11 @@
       "pass": true
     },
     {
-      "name": "step-count-bounded",
+      "name": "search-before-sparql",
+      "pass": true
+    },
+    {
+      "name": "sparql-handoff-valid",
       "pass": true
     },
     {
@@ -74,6 +78,10 @@
     },
     {
       "name": "final-answer-correct",
+      "pass": true
+    },
+    {
+      "name": "not-distractor-house",
       "pass": true
     }
   ]

--- a/evals/goldens/happy-path-search-then-sparql.google.gemini-3.1-flash-lite.json
+++ b/evals/goldens/happy-path-search-then-sparql.google.gemini-3.1-flash-lite.json
@@ -2,7 +2,7 @@
   "id": "happy-path-search-then-sparql",
   "description": "Happy path uses search then SPARQL traversal",
   "prompt": "Find the house of the protagonist linked to the work with label \"q7Xm9pRw\". First, use searchWorld to discover the subject URI for \"q7Xm9pRw\". Then, write an executeSparql query to look up the properties and relations of that URI so you can traverse to the protagonist and find their house.",
-  "output": "The protagonist of the work labeled \"q7Xm9pRw\" is associated with the house labeled \"pZ3kN8vQ\".",
+  "output": "The protagonist of the work with the label \"q7Xm9pRw\" is associated with the house labeled \"pZ3kN8vQ\".",
   "success": true,
   "metadata": {
     "providerId": "google",
@@ -141,6 +141,10 @@
     },
     {
       "name": "step-count-bounded",
+      "pass": true
+    },
+    {
+      "name": "sparql-answer-grounded",
       "pass": true
     },
     {

--- a/evals/test-cases.ts
+++ b/evals/test-cases.ts
@@ -48,4 +48,30 @@ export const evalCases: EvalCaseDefinition[] = [
       },
     },
   },
+  {
+    id: "discovery-efficient-search-then-sparql",
+    description: "Discovery-efficient search then one SPARQL SELECT",
+    prompt:
+      `Find the protagonist and house for the work with label "${WORK_SEARCH_LABEL}" using the fewest tool calls needed. First call searchWorld with exactly "${WORK_SEARCH_LABEL}". Then use exactly one executeSparql SELECT query of the form SELECT ?house WHERE { <work-uri-from-search> <${WAZOO_VOCAB_NAMESPACE}protagonist> ?protagonist . ?protagonist <${WAZOO_VOCAB_NAMESPACE}house> ?house . } where <work-uri-from-search> is the subject field from the searchWorld hit (do not invent URIs). Answer with the house literal only.`,
+    maxSteps: 3,
+    golden: {
+      output: {
+        mode: "contains-substrings",
+        requiredSubstrings: [EXPECTED_HOUSE_LITERAL.toLowerCase()],
+      },
+    },
+  },
+  {
+    id: "distractor-work-disambiguation",
+    description: "Target work house excludes distractor work",
+    prompt:
+      `Find the house of the protagonist linked only to the work with label "${WORK_SEARCH_LABEL}" (ignore any other work). First call searchWorld with exactly "${WORK_SEARCH_LABEL}". Then use one executeSparql SELECT that binds the work URI from search and traverses <${WAZOO_VOCAB_NAMESPACE}protagonist> then <${WAZOO_VOCAB_NAMESPACE}house> ?house. Answer with only that house literal.`,
+    maxSteps: 4,
+    golden: {
+      output: {
+        mode: "contains-substrings",
+        requiredSubstrings: [EXPECTED_HOUSE_LITERAL.toLowerCase()],
+      },
+    },
+  },
 ];

--- a/evals/tools.test.ts
+++ b/evals/tools.test.ts
@@ -1,0 +1,37 @@
+import { assertEquals, assertFalse } from "@std/assert";
+import { isReadOnlySparqlQuery } from "./tools.ts";
+
+const READ_ONLY_QUERIES = [
+  "SELECT ?s WHERE { ?s ?p ?o }",
+  "  SELECT ?s WHERE { ?s ?p ?o }",
+  "# plan comment\nSELECT ?s WHERE { ?s ?p ?o }",
+  "ASK { ?s ?p ?o }",
+  "ask { ?s a ?o }",
+];
+
+const MUTATING_OR_INVALID_QUERIES = [
+  'INSERT DATA { <http://example.org/s> <http://example.org/p> "o" }',
+  "DELETE WHERE { ?s ?p ?o }",
+  "DROP ALL",
+  "CLEAR GRAPH <http://example.org/g>",
+  "LOAD <http://example.org/data>",
+  "CREATE GRAPH <http://example.org/g>",
+  "WITH <http://example.org/g> INSERT { ?s ?p ?o }",
+  "COPY GRAPH <http://example.org/a> TO <http://example.org/b>",
+  "MOVE GRAPH <http://example.org/a> TO <http://example.org/b>",
+  "ADD GRAPH <http://example.org/a> TO <http://example.org/b>",
+  "not a sparql query",
+  "",
+];
+
+for (const query of READ_ONLY_QUERIES) {
+  Deno.test(`isReadOnlySparqlQuery accepts read-only query: ${query.slice(0, 40)}`, () => {
+    assertEquals(isReadOnlySparqlQuery(query), true);
+  });
+}
+
+for (const query of MUTATING_OR_INVALID_QUERIES) {
+  Deno.test(`isReadOnlySparqlQuery rejects mutating or invalid query: ${query.slice(0, 40)}`, () => {
+    assertFalse(isReadOnlySparqlQuery(query));
+  });
+}

--- a/evals/tools.ts
+++ b/evals/tools.ts
@@ -3,7 +3,7 @@ import { tool } from "ai";
 import { z } from "zod";
 
 /** isReadOnlySparqlQuery reports whether a query begins with an allowed read-only form. */
-function isReadOnlySparqlQuery(query: string): boolean {
+export function isReadOnlySparqlQuery(query: string): boolean {
   const normalizedQuery = query.trim().replace(/^(?:#.*\n\s*)+/, "");
   return /^(SELECT|ASK)\b/i.test(normalizedQuery);
 }

--- a/evals/world-fixture.ts
+++ b/evals/world-fixture.ts
@@ -26,6 +26,25 @@ export const AUTHOR_LITERAL = "k2Nw8LhT";
 /** EXPECTED_HOUSE_LITERAL is the opaque ex:house literal the happy-path scenarios must discover. */
 export const EXPECTED_HOUSE_LITERAL = "pZ3kN8vQ";
 
+/** DISTRACTOR_WORK_SUBJECT_URI is the subject IRI for the second seeded work entity. */
+export const DISTRACTOR_WORK_SUBJECT_URI = `${GENID_BASE}1d6a9f3e7b2c4058`;
+
+/** DISTRACTOR_PROTAGONIST_SUBJECT_URI is the subject IRI for the distractor protagonist. */
+export const DISTRACTOR_PROTAGONIST_SUBJECT_URI =
+  `${GENID_BASE}6e0f1a2b3c4d5e6f`;
+
+/** DISTRACTOR_WORK_SEARCH_LABEL is the opaque rdfs:label for the distractor work entity. */
+export const DISTRACTOR_WORK_SEARCH_LABEL = "r5Hv2KjW";
+
+/** DISTRACTOR_PROTAGONIST_LABEL is the opaque rdfs:label for the distractor protagonist. */
+export const DISTRACTOR_PROTAGONIST_LABEL = "w8Nz4QmL";
+
+/** DISTRACTOR_AUTHOR_LITERAL is the opaque ex:author literal on the distractor work. */
+export const DISTRACTOR_AUTHOR_LITERAL = "n3Jc7VfR";
+
+/** DISTRACTOR_EXPECTED_HOUSE_LITERAL is the house literal linked to the distractor protagonist. */
+export const DISTRACTOR_EXPECTED_HOUSE_LITERAL = "j6Tx1BpY";
+
 /** BLOCKED_INSERT_SUBJECT_URI is an unrelated genid used only by sparql-updates-blocked. */
 export const BLOCKED_INSERT_SUBJECT_URI = `${GENID_BASE}f91c0e4b2a198765`;
 
@@ -40,6 +59,11 @@ const SEEDED_WORLD_DATA = `
                         vocab:protagonist <${PROTAGONIST_SUBJECT_URI}> .
   <${PROTAGONIST_SUBJECT_URI}> rdfs:label "${PROTAGONIST_LABEL}" ;
            vocab:house "${EXPECTED_HOUSE_LITERAL}" .
+  <${DISTRACTOR_WORK_SUBJECT_URI}> rdfs:label "${DISTRACTOR_WORK_SEARCH_LABEL}" ;
+                                   vocab:author "${DISTRACTOR_AUTHOR_LITERAL}" ;
+                                   vocab:protagonist <${DISTRACTOR_PROTAGONIST_SUBJECT_URI}> .
+  <${DISTRACTOR_PROTAGONIST_SUBJECT_URI}> rdfs:label "${DISTRACTOR_PROTAGONIST_LABEL}" ;
+           vocab:house "${DISTRACTOR_EXPECTED_HOUSE_LITERAL}" .
 `;
 
 /** createSeededWorldClient builds a fresh in-memory world with the seeded graph. */


### PR DESCRIPTION
## Summary

- Closes #37, #38, #39: adds `discovery-efficient-search-then-sparql` and `distractor-work-disambiguation` scenarios, distractor fixture entities, handoff/grounding assertions, and blessed goldens.
- Closes #26: deterministic unit tests for `applyAssertions`, `isReadOnlySparqlQuery`, `extractSearchSubjects`, `extractSparqlBindingLiterals`, and `buildTrajectory` (no live model calls).
- Closes #30: `evals/README.md` documenting env, CLI flags, output, exit codes, permissions, and smoke-harness decision (#27).

## Test plan

- [x] `deno task ci` (117 tests, including 32 new eval harness tests)
- [ ] `deno task evals` with `GOOGLE_GENERATIVE_AI_API_KEY` (live smoke; optional for merge if CI-only gate is enough)