### PR TITLE
feat(evals): add richer assertion diagnostics with toolSequence and rejectedQuery

### DIFF
--- a/evals/agent-runner.ts
+++ b/evals/agent-runner.ts
@@ -84,6 +84,7 @@ export async function runEvalCase(
         trajectory: buildTrajectory(result.steps),
       },
       assertions: [],
+      toolSequence: [],
     };
   } catch (error) {
     return {
@@ -97,6 +98,7 @@ export async function runEvalCase(
         latencyMs: Date.now() - startedAt,
       },
       assertions: [],
+      toolSequence: [],
       error: error instanceof Error ? error.message : String(error),
     };
   }

--- a/evals/assertions.test.ts
+++ b/evals/assertions.test.ts
@@ -31,6 +31,7 @@ function createEvalCaseResult(
       ...overrides.metadata,
     },
     assertions: [],
+    toolSequence: [],
     ...overrides,
   };
 }

--- a/evals/assertions.ts
+++ b/evals/assertions.ts
@@ -36,6 +36,24 @@ export function extractSearchSubjects(searchResult: unknown): string[] {
   return subjects;
 }
 
+/** extractSparqlRejectedQuery extracts the query that triggered a SPARQL guard rejection. */
+function extractSparqlRejectedQuery(
+  trajectory: EvalCaseResult["metadata"]["trajectory"],
+): string | undefined {
+  const blockedStep = trajectory.find((record) =>
+    record.toolName === "executeSparql" &&
+    typeof record.result === "object" && record.result !== null &&
+    "success" in record.result &&
+    (record.result as { success: boolean }).success === false &&
+    typeof record.args === "object" && record.args !== null &&
+    "query" in record.args
+  );
+  if (!blockedStep) {
+    return undefined;
+  }
+  return (blockedStep.args as { query?: string }).query;
+}
+
 /** extractSparqlBindingLiterals collects literal values from a successful executeSparql result. */
 export function extractSparqlBindingLiterals(sparqlResult: unknown): string[] {
   if (typeof sparqlResult !== "object" || sparqlResult === null) {
@@ -203,15 +221,28 @@ function assertNotDistractorHouse(result: EvalCaseResult): EvalAssertionResult {
 
 /** assertUpdatesBlocked verifies the update guard produced the expected error. */
 function assertUpdatesBlocked(result: EvalCaseResult): EvalAssertionResult {
-  const pass = result.metadata.trajectory.some((record) =>
-    record.toolName === "executeSparql" &&
-    JSON.stringify(record.result ?? {}).includes(
+  const blockedRecord = result.metadata.trajectory.find((record) =>
+    record.toolName === "executeSparql"
+  );
+  const blocked = blockedRecord !== undefined &&
+    JSON.stringify(blockedRecord.result ?? {}).includes(
       "Only read-only SPARQL queries are allowed",
-    )
+    );
+  const rejectedQuery = extractSparqlRejectedQuery(
+    result.metadata.trajectory,
   );
   return {
     name: "updates-blocked",
-    pass,
+    pass: blocked,
+    message: blocked
+      ? undefined
+      : blockedRecord === undefined
+      ? "No executeSparql call was made in the trajectory"
+      : `SPARQL guard did not reject the query${
+        rejectedQuery ? `: "${rejectedQuery.slice(0, 120)}"` : ""
+      }; observed result: ${
+        JSON.stringify(blockedRecord.result ?? {}).slice(0, 200)
+      }`,
   };
 }
 
@@ -357,5 +388,6 @@ export function applyAssertions(result: EvalCaseResult): EvalCaseResult {
     ...result,
     success,
     assertions,
+    toolSequence: result.metadata.trajectory.map((record) => record.toolName),
   };
 }

--- a/evals/run-evals.ts
+++ b/evals/run-evals.ts
@@ -358,6 +358,7 @@ function sanitizeGoldenCaseResult(
       trajectory: result.metadata.trajectory,
     },
     assertions: result.assertions,
+    toolSequence: result.toolSequence,
     error: result.error,
   };
 }

--- a/evals/types.ts
+++ b/evals/types.ts
@@ -67,6 +67,7 @@ export interface EvalCaseResult {
   success: boolean;
   metadata: EvalRunMetadata;
   assertions: EvalAssertionResult[];
+  toolSequence: string[];
   error?: string;
 }
 
@@ -126,5 +127,6 @@ export interface GoldenEvalCaseResult {
   success: boolean;
   metadata: GoldenEvalRunMetadata;
   assertions: EvalAssertionResult[];
+  toolSequence: string[];
   error?: string;
 }


### PR DESCRIPTION
## Summary

Enhances eval result artifacts with richer diagnostic information for debugging failures, without changing the success-path output format.

## Changes

- **types.ts**: Added 	oolSequence: string[] to EvalCaseResult and GoldenEvalCaseResult
- **assertions.ts**: Added extractSparqlRejectedQuery helper; ssertUpdatesBlocked now includes a descriptive message with the rejected query and observed result on failure
- **agent-runner.ts**: Populates 	oolSequence field in unEvalCase responses
- **run-evals.ts**: sanitizeGoldenCaseResult includes 	oolSequence
- **assertions.ts**: pplyAssertions automatically computes 	oolSequence from trajectory

Closes #28.