### PR TITLE
test(evals): add second seed fixture to prove harness generality

### DIFF
--- a/evals/agent-runner.ts
+++ b/evals/agent-runner.ts
@@ -6,7 +6,29 @@ import type {
   EvalCaseResult,
   EvalToolRecord,
 } from "./types.ts";
+import type { Client } from "@worlds/client";
 import { createSeededWorldClient } from "./world-fixture.ts";
+import { createSeededScholarWorldClient } from "./world-fixture-scholar.ts";
+
+/** fixtureFactories maps fixtureId to an async factory that returns a seeded world client. */
+const fixtureFactories: Record<string, () => Promise<Client>> = {
+  primary: createSeededWorldClient,
+  scholar: createSeededScholarWorldClient,
+};
+
+/** resolveFixture resolves the world client factory for a given test case. */
+function resolveFixture(testCase: { fixtureId?: string }): () => Promise<Client> {
+  const fixtureId = testCase.fixtureId ?? "primary";
+  const factory = fixtureFactories[fixtureId];
+  if (!factory) {
+    throw new Error(
+      `Unknown fixtureId: "${fixtureId}". Available fixtures: ${
+        Object.keys(fixtureFactories).join(", ")
+      }`,
+    );
+  }
+  return factory;
+}
 
 /** buildTrajectory flattens the AI SDK step history into a tool sequence. */
 export function buildTrajectory(
@@ -52,7 +74,7 @@ export async function runEvalCase(
 
   try {
     const google = createGoogleGenerativeAI();
-    const client = await createSeededWorldClient();
+    const client = await resolveFixture(testCase)();
     const tools = createEvalTools(client);
     const result = await generateText({
       model: google(modelId),

--- a/evals/agent-runner.ts
+++ b/evals/agent-runner.ts
@@ -17,7 +17,9 @@ const fixtureFactories: Record<string, () => Promise<Client>> = {
 };
 
 /** resolveFixture resolves the world client factory for a given test case. */
-function resolveFixture(testCase: { fixtureId?: string }): () => Promise<Client> {
+function resolveFixture(
+  testCase: { fixtureId?: string },
+): () => Promise<Client> {
   const fixtureId = testCase.fixtureId ?? "primary";
   const factory = fixtureFactories[fixtureId];
   if (!factory) {

--- a/evals/assertions.test.ts
+++ b/evals/assertions.test.ts
@@ -12,6 +12,9 @@ import {
   EXPECTED_HOUSE_LITERAL,
   WORK_SUBJECT_URI,
 } from "./world-fixture.ts";
+import {
+  PAPER_AUTHOR_LITERAL as SCHOLAR_AUTHOR_LITERAL,
+} from "./world-fixture-scholar.ts";
 
 /** createEvalCaseResult builds a minimal case result for assertion routing tests. */
 function createEvalCaseResult(
@@ -113,6 +116,13 @@ const CASE_ASSERTION_NAMES: Record<string, string[]> = {
     "final-answer-author-correct",
   ],
   "no-tool-shortcut-resisted": ["used-required-tools", "step-count-bounded"],
+  "scholar-paper-author": [
+    "used-required-tools",
+    "search-before-sparql",
+    "sparql-handoff-valid",
+    "step-count-bounded",
+    "final-answer-author-correct",
+  ],
 };
 
 for (
@@ -152,6 +162,8 @@ for (
       ? `Author: ${AUTHOR_LITERAL}`
       : caseId === "search-miss-unknown-label"
       ? "No matching work was found in the graph."
+      : caseId === "scholar-paper-author"
+      ? `Author: ${SCHOLAR_AUTHOR_LITERAL}`
       : `The house is ${EXPECTED_HOUSE_LITERAL}.`;
 
     const result = applyAssertions(createEvalCaseResult({

--- a/evals/assertions.ts
+++ b/evals/assertions.ts
@@ -4,6 +4,9 @@ import {
   DISTRACTOR_EXPECTED_HOUSE_LITERAL,
   EXPECTED_HOUSE_LITERAL,
 } from "./world-fixture.ts";
+import {
+  PAPER_AUTHOR_LITERAL as SCHOLAR_AUTHOR_LITERAL,
+} from "./world-fixture-scholar.ts";
 
 /** normalizeOutputText canonicalizes free-form final text before tolerant comparison. */
 function normalizeOutputText(value: string): string {
@@ -341,6 +344,19 @@ export function applyAssertions(result: EvalCaseResult): EvalCaseResult {
     case "no-tool-shortcut-resisted":
       assertions.push(assertUsedRequiredTools(result));
       assertions.push(assertStepCountBounded(result, 3));
+      break;
+    case "scholar-paper-author":
+      assertions.push(assertUsedRequiredTools(result));
+      assertions.push(assertSearchBeforeSparql(result));
+      assertions.push(assertSparqlHandoffValid(result));
+      assertions.push(assertStepCountBounded(result, 5));
+      assertions.push(
+        assertFinalAnswerContainsLiteral(
+          result,
+          SCHOLAR_AUTHOR_LITERAL,
+          "final-answer-author-correct",
+        ),
+      );
       break;
     default:
       assertions.push({

--- a/evals/test-cases.ts
+++ b/evals/test-cases.ts
@@ -131,7 +131,8 @@ export const evalCases: EvalCaseDefinition[] = [
   },
   {
     id: "scholar-paper-author",
-    description: "Scholar fixture resolves author literal via search then SPARQL",
+    description:
+      "Scholar fixture resolves author literal via search then SPARQL",
     fixtureId: "scholar",
     prompt:
       `Find the author of the paper with label "${SCHOLAR_PAPER_SEARCH_LABEL}". First call searchWorld with exactly "${SCHOLAR_PAPER_SEARCH_LABEL}". Then use one executeSparql SELECT that reads the vocab:author from the discovered paper URI. Answer with only the author literal.`,

--- a/evals/test-cases.ts
+++ b/evals/test-cases.ts
@@ -9,6 +9,10 @@ import {
   WORK_SEARCH_LABEL,
   WORK_SUBJECT_URI,
 } from "./world-fixture.ts";
+import {
+  PAPER_AUTHOR_LITERAL as SCHOLAR_AUTHOR_LITERAL,
+  PAPER_SEARCH_LABEL as SCHOLAR_PAPER_SEARCH_LABEL,
+} from "./world-fixture-scholar.ts";
 
 /** evalCases enumerates the phase-one scenarios for the Deno harness. */
 export const evalCases: EvalCaseDefinition[] = [
@@ -122,6 +126,20 @@ export const evalCases: EvalCaseDefinition[] = [
     golden: {
       output: {
         mode: "ignore",
+      },
+    },
+  },
+  {
+    id: "scholar-paper-author",
+    description: "Scholar fixture resolves author literal via search then SPARQL",
+    fixtureId: "scholar",
+    prompt:
+      `Find the author of the paper with label "${SCHOLAR_PAPER_SEARCH_LABEL}". First call searchWorld with exactly "${SCHOLAR_PAPER_SEARCH_LABEL}". Then use one executeSparql SELECT that reads the vocab:author from the discovered paper URI. Answer with only the author literal.`,
+    maxSteps: 5,
+    golden: {
+      output: {
+        mode: "contains-substrings",
+        requiredSubstrings: [SCHOLAR_AUTHOR_LITERAL.toLowerCase()],
       },
     },
   },

--- a/evals/types.ts
+++ b/evals/types.ts
@@ -55,6 +55,7 @@ export interface EvalCaseDefinition {
   description: string;
   prompt: string;
   maxSteps?: number;
+  fixtureId?: string;
   golden: EvalGoldenOptions;
 }
 

--- a/evals/world-fixture-scholar.ts
+++ b/evals/world-fixture-scholar.ts
@@ -1,0 +1,50 @@
+import { createClient as createLibsqlClient } from "@libsql/client";
+import { Client } from "@worlds/client";
+import { provideLibsql } from "@worlds/client/providers/libsql";
+
+/** GENID_BASE is the production-style skolem prefix for eval fixture entities. */
+export const GENID_BASE = "https://worlds.wazoo.dev/.well-known/genid/";
+
+/** WAZOO_VOCAB_NAMESPACE is the shared vocabulary namespace for eval predicates. */
+export const WAZOO_VOCAB_NAMESPACE = "https://worlds.wazoo.dev/vocab/";
+
+/** PAPER_SUBJECT_URI is the canonical subject IRI for the seeded paper entity. */
+export const PAPER_SUBJECT_URI = `${GENID_BASE}a1b2c3d4e5f6a7b8`;
+
+/** PAPER_SEARCH_LABEL is the opaque rdfs:label literal used in search prompts. */
+export const PAPER_SEARCH_LABEL = "kL9mN4pQ";
+
+/** PAPER_AUTHOR_LITERAL is the opaque vocab:author literal on the paper entity. */
+export const PAPER_AUTHOR_LITERAL = "dR7sT2vW";
+
+/** PAPER_VENUE_LITERAL is the opaque vocab:venue literal for the publication venue. */
+export const PAPER_VENUE_LITERAL = "xY5zA8bC";
+
+/** PAPER_YEAR_LITERAL is the opaque vocab:year literal for the publication year. */
+export const PAPER_YEAR_LITERAL = "2024";
+
+const SEEDED_SCHOLAR_DATA = `
+  @prefix vocab: <${WAZOO_VOCAB_NAMESPACE}> .
+  @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+  <${PAPER_SUBJECT_URI}> rdfs:label "${PAPER_SEARCH_LABEL}" ;
+                         vocab:author "${PAPER_AUTHOR_LITERAL}" ;
+                         vocab:venue "${PAPER_VENUE_LITERAL}" ;
+                         vocab:year "${PAPER_YEAR_LITERAL}" .
+`;
+
+/** createSeededScholarWorldClient builds a fresh in-memory world with the scholar graph. */
+export async function createSeededScholarWorldClient(): Promise<Client> {
+  const database = createLibsqlClient({ url: ":memory:" });
+  const providerOptions = await provideLibsql({ client: database });
+  const client = new Client(providerOptions);
+
+  await client.import({
+    source: {
+      kind: "serialized",
+      data: SEEDED_SCHOLAR_DATA,
+      contentType: "text/turtle",
+    },
+  });
+
+  return client;
+}


### PR DESCRIPTION
## Summary

Adds a second seed fixture with a different RDF schema (academic publishing) to prove the eval harness generalizes beyond the primary work→protagonist→house graph.

## Changes

- **world-fixture-scholar.ts**: New fixture with academic publishing data (paper with author, venue, year literals)
- **types.ts**: Added optional ixtureId field to EvalCaseDefinition
- **agent-runner.ts**: Added fixture registry (esolveFixture) that selects the world client factory by fixtureId
- **test-cases.ts**: Added scholar-paper-author eval case using the scholar fixture
- **assertions.ts**: Added assertion routing for the scholar case
- **assertions.test.ts**: Added scholar case to assertion routing tests

Closes #29.