### PR TITLE
fix: make SPARQL engine optional in providers to remove transitive Comunica dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,11 @@ as Turso Cloud through `provideLibsql(...)`.
 
 ```typescript
 import { Client } from "@worlds/client";
+import { ComunicaSparqlEngine } from "@worlds/client/providers/comunica";
 import { provideLibsql } from "@worlds/client/providers/libsql";
 import { provideDenoKv } from "@worlds/client/providers/denokv";
 import { createClient } from "@libsql/client";
+import { QueryEngine } from "@comunica/query-sparql-rdfjs-lite";
 
 // 1. In-Memory / Transient Graph (Default)
 const client = new Client();
@@ -99,6 +101,16 @@ const client = new Client();
 // 2. Local SQLite or Turso Persistence via LibSQL (recommended for production)
 const db = createClient({ url: "file:./worlds.db" });
 const sqliteClient = new Client(await provideLibsql({ client: db }));
+
+// 2b. Attach SPARQL explicitly when needed
+const queryEngine = new QueryEngine();
+const sqliteClientWithSparql = new Client(
+  await provideLibsql({
+    client: db,
+    createSparqlEngine: ({ store }) =>
+      new ComunicaSparqlEngine({ queryEngine, store }),
+  }),
+);
 
 // 3. Stateless Edge Deployment via Deno Kv
 // Useful for prototyping and constrained edge flows, not the primary

--- a/deno.lock
+++ b/deno.lock
@@ -1140,7 +1140,7 @@
         "@comunica/types@5.2.0",
         "@comunica/utils-algebra",
         "@comunica/utils-query-operation",
-        "lru-cache@11.3.6"
+        "lru-cache@11.5.0"
       ]
     },
     "@comunica/actor-optimize-query-operation-query-source-skolemize@5.2.2": {
@@ -1490,7 +1490,7 @@
         "@comunica/utils-algebra",
         "@comunica/utils-query-operation",
         "@rdfjs/types@2.0.1",
-        "lru-cache@11.3.6"
+        "lru-cache@11.5.0"
       ]
     },
     "@comunica/actor-query-operation-slice@5.2.2": {
@@ -2625,7 +2625,7 @@
         "@rdfjs/types@2.0.1",
         "@types/yargs",
         "asynciterator",
-        "lru-cache@11.3.6"
+        "lru-cache@11.5.0"
       ]
     },
     "@comunica/utils-algebra@5.2.0": {
@@ -2668,7 +2668,7 @@
         "@comunica/types@5.2.0",
         "@comunica/utils-algebra",
         "@rdfjs/types@2.0.1",
-        "lru-cache@11.3.6",
+        "lru-cache@11.5.0",
         "rdf-data-factory@2.0.2",
         "rdf-string"
       ]
@@ -2933,16 +2933,16 @@
       ],
       "bin": true
     },
-    "@traqula/algebra-sparql-1-1@1.1.0": {
-      "integrity": "sha512-vCruGGkUUnIDyB2XUbwtAU4lWiYGmJk7z6RRsXYkL0pKZBkrtJwTDj6m1GHJECOpuNi51Iw4TNPZDsfxG0OAWg==",
+    "@traqula/algebra-sparql-1-1@1.1.1": {
+      "integrity": "sha512-Ux/h4lZPqDyC8ogt0enUC56MC0unVTnO4MBKRRo81bTc1DAk82DHHCDS8WQSotGxMbQ3hGBIJPzSRbm3JmRBOw==",
       "dependencies": [
         "@traqula/algebra-transformations-1-1",
         "@traqula/core",
         "@traqula/rules-sparql-1-1"
       ]
     },
-    "@traqula/algebra-sparql-1-2@1.1.0": {
-      "integrity": "sha512-jupP4QhEu2UQ8TTrxzqAkU3zn9/ptKqKtjS5WBqq+ErYvWIPhJsXxRAnd8fI7EiBDFMx78Wt+x3gRc7+sZHfvw==",
+    "@traqula/algebra-sparql-1-2@1.1.1": {
+      "integrity": "sha512-SWqwxOYrMEQil574iscpZ8uD+uI/WNguCmxOnQYAyJ5usqwLmCUBMkR+5KbOY53DFVG1/CMkacopte9xtOTYkw==",
       "dependencies": [
         "@traqula/algebra-sparql-1-1",
         "@traqula/algebra-transformations-1-1",
@@ -2950,8 +2950,8 @@
         "@traqula/core"
       ]
     },
-    "@traqula/algebra-transformations-1-1@1.1.0": {
-      "integrity": "sha512-1n7NFtvGBdBcGo1UnIsUW/i+wROnLlxG9A84uINkCw2BrtoAZ/nY+gSVPSCQ/rlyve/lZryjgVvcnwIxQ+OVKg==",
+    "@traqula/algebra-transformations-1-1@1.1.1": {
+      "integrity": "sha512-nWfZuAsxe2A0qFVpeDMD6mjw33KyecRP0rOlWqh5soy497vXerFmlfxTYj74iHH1yT4wMFBUN30FYUAkkCoVjQ==",
       "dependencies": [
         "@traqula/core",
         "@traqula/rules-sparql-1-1",
@@ -2961,8 +2961,8 @@
         "rdf-string"
       ]
     },
-    "@traqula/algebra-transformations-1-2@1.1.0": {
-      "integrity": "sha512-Qi19pcUvXUYHj8jO0CXiaJwpUH9F1q7p3fRROewqr7Zzm54BCz57v9mwwSCjiS2/M/73driG02w20N9zR120mg==",
+    "@traqula/algebra-transformations-1-2@1.1.1": {
+      "integrity": "sha512-osW3Z9pNie1xCnpuF7EbHw5yFa3BvxTIQCToOIA+4effw0ZpkqRE7kQL4q8JSkEWZbBdB9FcyTRBojxSmTuAlA==",
       "dependencies": [
         "@traqula/algebra-transformations-1-1",
         "@traqula/rules-sparql-1-2",
@@ -2972,21 +2972,21 @@
     "@traqula/chevrotain@1.1.0": {
       "integrity": "sha512-VpcoQKb2ZnsOQPlPO2mE9hfR0Aidp7drwTCtaXfpdRHGkXeQ5Nv4rnxmxwUoEDRzu6b/3z4n8oTd+sYhe4fAaA=="
     },
-    "@traqula/core@1.1.0": {
-      "integrity": "sha512-PxK3P/Go7KjNpEaN/mXHAEiDWLxh3u5D6MfOTXI6Lz0eq9iRduUAXGnWnCuZ7VygxEHSSxpO0ZDYLPa4OIeBYQ==",
+    "@traqula/core@1.1.1": {
+      "integrity": "sha512-v7EcEaBXv+3PtXac1SoeMQz0iq/xzwb3RxWAbrK/6oRAa8mrqYsf5fZesPNcKwnyALw0NVUeVPWFTQxOhawOSA==",
       "dependencies": [
         "@traqula/chevrotain"
       ]
     },
-    "@traqula/parser-sparql-1-1@1.1.0": {
-      "integrity": "sha512-HLWuQv/Z+0POkWPCocT7mEOtbQ4QT+G71w4YH/srelXdOXGhuchO+aPBkHausIKh2imWu0bz+flmj+ap0IQjDQ==",
+    "@traqula/parser-sparql-1-1@1.1.1": {
+      "integrity": "sha512-U2KJ/mHc14ktyc7QBL9OTrlF2Yzc5IdZv5nqshvgI8DyvI9Op7/vPvHZ9qxooOE9eFyDgB1gOvJDf06vbQzUMg==",
       "dependencies": [
         "@traqula/core",
         "@traqula/rules-sparql-1-1"
       ]
     },
-    "@traqula/parser-sparql-1-2@1.1.0": {
-      "integrity": "sha512-mb2NonXBSkbBmTbd7xj0p37z6F9nek8hhu2W5O9ftLeWMJEP+zLR1wfJ7KW8on/WIRh23sV0KeBwvxqNp64Dzg==",
+    "@traqula/parser-sparql-1-2@1.1.1": {
+      "integrity": "sha512-QSP+zaytyGtxhOX1GkPXfDFqM5TsgNAzO5jOw8Jr8Fpp37qUOUPxUxfGirjEtUh3fGilyYFnKcGju3sD64i28w==",
       "dependencies": [
         "@traqula/core",
         "@traqula/parser-sparql-1-1",
@@ -2995,15 +2995,15 @@
         "rdf-data-factory@2.0.2"
       ]
     },
-    "@traqula/rules-sparql-1-1@1.1.0": {
-      "integrity": "sha512-MKB2oBWKr1+vYxy6tROcNsHxlH5aM8FS9VvfyPKAkbRqKS/zgOMFIigJ0DGlfgfoIm3Hyn+NintFWfRRXiBaGw==",
+    "@traqula/rules-sparql-1-1@1.1.1": {
+      "integrity": "sha512-APMUzpU0+FqxMZT0WoJaZv0O4nGCJbaDbXC5gHuA/zl61jXORx3IdsKD2DgiMAl4MPkd4U1dVDlUO8ufWtHAWg==",
       "dependencies": [
         "@traqula/chevrotain",
         "@traqula/core"
       ]
     },
-    "@traqula/rules-sparql-1-2@1.1.0": {
-      "integrity": "sha512-vFTI8YhkNZw0JdyY+nj0lWwp1TnkfMYf/SM6jxXCM176A7j0qjkuVbFP5tKTC9hgj02VQWV9Edo/mKaVf8C/1A==",
+    "@traqula/rules-sparql-1-2@1.1.1": {
+      "integrity": "sha512-VLKNzW32/DGOk0iOstuKXRwNrosYNJjWQM8ztezeAonhR8h4kugbA3ZjNFOnl/c2YMtSobc2hUXFjBhhbOum5A==",
       "dependencies": [
         "@traqula/core",
         "@traqula/rules-sparql-1-1"
@@ -3567,8 +3567,8 @@
     "lru-cache@10.4.3": {
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
     },
-    "lru-cache@11.3.6": {
-      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A=="
+    "lru-cache@11.5.0": {
+      "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA=="
     },
     "math-intrinsics@1.1.0": {
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
@@ -3833,8 +3833,8 @@
     "seedrandom@3.0.5": {
       "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg=="
     },
-    "semver@7.7.4": {
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+    "semver@7.8.0": {
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "bin": true
     },
     "setimmediate@1.0.5": {

--- a/examples/ai-sdk-hello-world/main.ts
+++ b/examples/ai-sdk-hello-world/main.ts
@@ -1,6 +1,8 @@
 import { createClient } from "@libsql/client";
 import { Client } from "@worlds/client";
+import { ComunicaSparqlEngine } from "@worlds/client/providers/comunica";
 import { provideLibsql } from "@worlds/client/providers/libsql";
+import { QueryEngine } from "@comunica/query-sparql-rdfjs-lite";
 import { createTools } from "./tools.ts";
 import { generateText, stepCountIs } from "ai";
 import { createGoogleGenerativeAI } from "@ai-sdk/google";
@@ -10,8 +12,13 @@ if (import.meta.main) {
 
   console.log("Initializing embedded LibSQL knowledge base...");
   const database = createClient({ url: ":memory:" });
+  const queryEngine = new QueryEngine();
 
-  const providerOptions = await provideLibsql({ client: database });
+  const providerOptions = await provideLibsql({
+    client: database,
+    createSparqlEngine: ({ store }) =>
+      new ComunicaSparqlEngine({ queryEngine, store }),
+  });
   const client = new Client(providerOptions);
 
   console.log("Ingesting initial knowledge...");

--- a/examples/denokv-hello-world/main.ts
+++ b/examples/denokv-hello-world/main.ts
@@ -1,5 +1,7 @@
 import { Client } from "@worlds/client";
+import { ComunicaSparqlEngine } from "@worlds/client/providers/comunica";
 import { provideDenoKv } from "@worlds/client/providers/denokv";
+import { QueryEngine } from "@comunica/query-sparql-rdfjs-lite";
 
 /**
  * This example demonstrates how to leverage the `provideDenokv` synthesis engine
@@ -9,10 +11,15 @@ import { provideDenoKv } from "@worlds/client/providers/denokv";
 if (import.meta.main) {
   console.log("🚀 Initializing in-memory Deno Kv context...");
   const kv = await Deno.openKv(":memory:");
+  const queryEngine = new QueryEngine();
 
   // 1. Synthesize stateless, just-in-time hydrating provider options
   console.log("🧠 Provisioning unified Deno Kv sync engine...");
-  const providerOptions = provideDenoKv({ kv });
+  const providerOptions = provideDenoKv({
+    kv,
+    createSparqlEngine: ({ store }) =>
+      new ComunicaSparqlEngine({ queryEngine, store }),
+  });
 
   // 2. Construct the universal client gateway
   const client = new Client(providerOptions);

--- a/examples/libsql-hello-world/main.ts
+++ b/examples/libsql-hello-world/main.ts
@@ -1,6 +1,8 @@
 import { createClient } from "@libsql/client";
 import { Client } from "@worlds/client";
+import { ComunicaSparqlEngine } from "@worlds/client/providers/comunica";
 import { provideLibsql } from "@worlds/client/providers/libsql";
+import { QueryEngine } from "@comunica/query-sparql-rdfjs-lite";
 
 /**
  * This example demonstrates how to use `provideLibsql` to instantly wire up a complete
@@ -14,11 +16,14 @@ import { provideLibsql } from "@worlds/client/providers/libsql";
 if (import.meta.main) {
   console.log("🚀 Initializing durable LibSQL context...");
   const db = createClient({ url: ":memory:" });
+  const queryEngine = new QueryEngine();
 
   // 1. Synthesize unified provider options for the client gateway
   console.log("🧠 Provisioning unified LibSQL sync engine...");
   const providerOptions = await provideLibsql({
     client: db,
+    createSparqlEngine: ({ store }) =>
+      new ComunicaSparqlEngine({ queryEngine, store }),
   });
 
   // 2. Construct the universal client gateway

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertRejects } from "@std/assert";
 import { DataFactory, Store } from "n3";
 import { Client } from "./client.ts";
 import { RdfjsQuadStore, RdfjsSearchIndex } from "./providers/rdfjs/mod.ts";
@@ -57,6 +57,20 @@ Deno.test("Client.sparql delegates to sparqlEngine.execute", async () => {
 
   if (response.kind !== "ask") throw new Error("Should be ask");
   assertEquals(response.data.boolean, false);
+});
+
+Deno.test("Client.sparql rejects when sparqlEngine is not configured", async () => {
+  const store = new Store();
+  const client = new Client({
+    quadStore: new RdfjsQuadStore(store),
+    searchIndex: new RdfjsSearchIndex(store),
+  });
+
+  await assertRejects(
+    () => client.sparql({ query: "ASK WHERE { ?s ?p ?o }" }),
+    Error,
+    "SPARQL engine is not configured.",
+  );
 });
 
 Deno.test("Client.search delegates to searchIndex.search", async () => {

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -29,7 +29,7 @@ export interface ClientOptions {
   /**
    * sparqlEngine evaluates declarative queries and updates against the graph.
    */
-  sparqlEngine: SparqlEngineInterface;
+  sparqlEngine?: SparqlEngineInterface;
 
   /**
    * searchIndex enables high-performance keyword search across the graph literals.
@@ -54,6 +54,10 @@ export class Client implements ClientInterface {
   }
 
   public async sparql(request: SparqlRequest): Promise<SparqlResponse> {
+    if (!this.options.sparqlEngine) {
+      throw new Error("SPARQL engine is not configured.");
+    }
+
     return await this.options.sparqlEngine.execute(request);
   }
 

--- a/src/client/providers/comunica/comunica-sparql-engine.ts
+++ b/src/client/providers/comunica/comunica-sparql-engine.ts
@@ -1,5 +1,4 @@
 import type * as rdfjs from "@rdfjs/types";
-import type { QueryEngine } from "@comunica/query-sparql-rdfjs-lite";
 import type {
   SparqlAskResults,
   SparqlBinding,
@@ -11,14 +10,72 @@ import type {
 } from "#/client/sparql-engine/sparql-engine-interface.ts";
 
 /**
+ * ComunicaQueryEngine is the minimal structural query contract needed from a user-provided Comunica engine.
+ */
+export interface ComunicaQueryEngine {
+  /** query executes a raw SPARQL operation against RDFJS-compatible sources. */
+  query(
+    query: string,
+    options: ComunicaQueryOptions,
+  ): Promise<unknown>;
+}
+
+/**
+ * ComunicaQueryOptions contains the RDFJS sources and base IRI passed to a Comunica-compatible engine.
+ */
+export interface ComunicaQueryOptions {
+  /** sources contains the RDFJS stores available to the query engine. */
+  sources: rdfjs.Store[];
+
+  /** baseIRI is the optional base IRI used during SPARQL execution. */
+  baseIRI?: string;
+}
+
+/**
+ * ComunicaQueryResult is the minimal result shape returned by a Comunica-compatible query engine.
+ */
+export interface ComunicaQueryResult {
+  /** resultType identifies the kind of query result returned by the engine. */
+  resultType: string;
+
+  /** execute materializes the query result payload. */
+  execute(): Promise<unknown>;
+
+  /** metadata optionally returns variable metadata for binding result streams. */
+  metadata?: () => Promise<{ variables: rdfjs.Variable[] }>;
+}
+
+/**
+ * ComunicaEventStream is the minimal event stream contract consumed from Comunica result streams.
+ */
+export interface ComunicaEventStream<T> {
+  /** on registers a listener for streamed data items. */
+  on(event: "data", listener: (item: T) => void): this;
+
+  /** on registers a listener for stream completion. */
+  on(event: "end", listener: () => void): this;
+
+  /** on registers a listener for stream failures. */
+  on(event: "error", listener: (error: unknown) => void): this;
+}
+
+/**
+ * ComunicaBinding is the minimal binding shape consumed from Comunica binding streams.
+ */
+export interface ComunicaBinding {
+  /** get optionally resolves a variable binding by name. */
+  get?: (variable: string) => rdfjs.Term | undefined;
+}
+
+/**
  * ComunicaSparqlEngineOptions are the options for ComunicaSparqlEngine.
  */
 export interface ComunicaSparqlEngineOptions {
   /** store is the RDFJS store to execute the query on. */
   store: rdfjs.Store;
 
-  /** queryEngine is the Comunica query engine to use. */
-  queryEngine: QueryEngine;
+  /** queryEngine is the caller-provided Comunica-compatible query engine to use. */
+  queryEngine: ComunicaQueryEngine;
 
   /**
    * onVoid is an optional callback invoked after a successful void (UPDATE)
@@ -62,7 +119,7 @@ const DEFAULT_SPARQL_TIMEOUT_MS = 30_000;
  * @returns The SPARQL query response.
  */
 export async function executeSparql(
-  queryEngine: QueryEngine,
+  queryEngine: ComunicaQueryEngine,
   store: rdfjs.Store,
   request: SparqlRequest,
 ): Promise<SparqlResponse> {
@@ -84,10 +141,11 @@ export async function executeSparql(
     queryEngine.query(request.query, {
       sources: [store],
       baseIRI: request.baseIri,
-    }).then(async (queryType) => {
+    }).then(async (queryResult) => {
       clearTimer();
 
       try {
+        const queryType = queryResult as ComunicaQueryResult;
         switch (queryType.resultType) {
           case "void": {
             // Note: resultType 'void' indicates an Update operation complete
@@ -96,13 +154,13 @@ export async function executeSparql(
           }
           case "bindings": {
             const results = await handleBindings(
-              queryType as Parameters<typeof handleBindings>[0],
+              queryType,
             );
             return resolve({ kind: "select", data: results });
           }
           case "boolean": {
             const results = await handleBoolean(
-              queryType as Parameters<typeof handleBoolean>[0],
+              queryType,
             );
             return resolve({ kind: "ask", data: results });
           }
@@ -124,25 +182,27 @@ export async function executeSparql(
   });
 }
 
-async function handleBindings(queryType: {
-  // deno-lint-ignore no-explicit-any
-  execute(): Promise<rdfjs.Stream<any>>;
-  metadata(): Promise<{ variables: rdfjs.Variable[] }>;
-}): Promise<SparqlSelectResults> {
-  const bindingsStream = await queryType.execute();
+async function handleBindings(
+  queryType: ComunicaQueryResult,
+): Promise<SparqlSelectResults> {
+  if (!queryType.metadata) {
+    throw new Error("SPARQL bindings result is missing metadata.");
+  }
+
+  const bindingsStream = await queryType.execute() as ComunicaEventStream<
+    ComunicaBinding
+  >;
   const vars = (await queryType.metadata()).variables.map((v) => v.value);
 
   const bindings = await new Promise<SparqlBinding[]>((resolve, reject) => {
     const b: SparqlBinding[] = [];
     let finished = false;
 
-    // The incoming bindings from Comunica implement internal get() logic
-    // deno-lint-ignore no-explicit-any
-    const onData = (binding: any) => {
+    const onData = (binding: ComunicaBinding) => {
       if (finished) return;
       const bindingObj: SparqlBinding = {};
       for (const v of vars) {
-        const term = binding.get ? binding.get(v) : binding[v];
+        const term = binding.get?.(v);
         if (term) {
           bindingObj[v] = toSparqlValue(term);
         }
@@ -175,18 +235,21 @@ async function handleBindings(queryType: {
   };
 }
 
-async function handleBoolean(queryType: {
-  execute(): Promise<boolean>;
-}): Promise<SparqlAskResults> {
+async function handleBoolean(
+  queryType: ComunicaQueryResult,
+): Promise<SparqlAskResults> {
   const boolean = await queryType.execute();
+  if (typeof boolean !== "boolean") {
+    throw new Error("SPARQL boolean result returned a non-boolean payload.");
+  }
+
   return {
     head: { link: undefined },
     boolean,
   };
 }
 
-// deno-lint-ignore no-explicit-any
-function toSparqlValue(term: any): SparqlValue {
+function toSparqlValue(term: rdfjs.Term): SparqlValue {
   const type = term.termType;
   const value = term.value;
 
@@ -197,20 +260,32 @@ function toSparqlValue(term: any): SparqlValue {
     return { type: "bnode", value };
   }
 
+  if (type === "Quad") {
+    return {
+      type: "triple",
+      value: {
+        subject: toSparqlValue(term.subject),
+        predicate: toSparqlValue(term.predicate),
+        object: toSparqlValue(term.object),
+      },
+    };
+  }
+
+  const literalTerm = term as rdfjs.Literal;
   const val: SparqlValue = {
     type: "literal",
     value,
   };
 
-  if (term.language) {
-    val["xml:lang"] = term.language;
+  if (literalTerm.language) {
+    val["xml:lang"] = literalTerm.language;
   }
 
   if (
-    term.datatype &&
-    term.datatype.value !== "http://www.w3.org/2001/XMLSchema#string"
+    literalTerm.datatype &&
+    literalTerm.datatype.value !== "http://www.w3.org/2001/XMLSchema#string"
   ) {
-    val.datatype = term.datatype.value;
+    val.datatype = literalTerm.datatype.value;
   }
 
   return val;

--- a/src/client/providers/denokv/provide-denokv.ts
+++ b/src/client/providers/denokv/provide-denokv.ts
@@ -1,19 +1,29 @@
 import { Store } from "n3";
-import { QueryEngine } from "@comunica/query-sparql-rdfjs-lite";
 import type { ClientOptions } from "#/client/client.ts";
-import { ComunicaSparqlEngine } from "#/client/providers/comunica/comunica-sparql-engine.ts";
+import type { SparqlEngineInterface } from "#/client/sparql-engine/mod.ts";
 import { DenokvSearchIndex } from "./denokv-search-index.ts";
 import {
   DenokvQuadStore,
   type DenokvQuadStoreOptions,
 } from "./denokv-quad-store.ts";
 
-const queryEngine = new QueryEngine();
+/**
+ * DenokvSparqlEngineOptions contains the per-query hydrated RDFJS store available to caller-provided SPARQL adapters.
+ */
+export interface DenokvSparqlEngineOptions {
+  /** store is the freshly hydrated RDFJS workspace for the current SPARQL operation. */
+  store: Store;
+}
 
 /**
  * DenokvOptions specifies configuration parameters for provisioning Denokv contexts.
  */
-export interface DenokvOptions extends DenokvQuadStoreOptions {}
+export interface DenokvOptions extends DenokvQuadStoreOptions {
+  /** createSparqlEngine optionally attaches a caller-provided SPARQL engine over each hydrated workspace. */
+  createSparqlEngine?: (
+    options: DenokvSparqlEngineOptions,
+  ) => SparqlEngineInterface;
+}
 
 /**
  * provideDenoKv synthesizes a client gateway context designed explicitly for
@@ -47,15 +57,17 @@ export function provideDenoKv(options: DenokvOptions): ClientOptions {
 
     searchIndex: new DenokvSearchIndex(options),
 
-    sparqlEngine: {
-      execute: async (request) => {
-        const workspace = await hydrateWorkspace();
-        const engine = new ComunicaSparqlEngine({
-          queryEngine,
-          store: workspace,
-        });
-        return await engine.execute(request);
-      },
-    },
+    sparqlEngine: options.createSparqlEngine
+      ? {
+        execute: async (request) => {
+          const workspace = await hydrateWorkspace();
+          const engine = options.createSparqlEngine?.({ store: workspace });
+          if (!engine) {
+            throw new Error("SPARQL engine is not configured.");
+          }
+          return await engine.execute(request);
+        },
+      }
+      : undefined,
   };
 }

--- a/src/client/providers/libsql/provide-libsql.test.ts
+++ b/src/client/providers/libsql/provide-libsql.test.ts
@@ -1,11 +1,14 @@
 import { assertEquals, assertExists } from "@std/assert";
 import { createClient as createLibsqlClient } from "@libsql/client";
+import { QueryEngine } from "@comunica/query-sparql-rdfjs-lite";
 import { DataFactory, Store } from "n3";
 import { Client } from "#/client/client.ts";
+import { ComunicaSparqlEngine } from "#/client/providers/comunica/mod.ts";
 import { provideLibsql } from "./provide-libsql.ts";
 import { FakeEmbeddingService } from "#/client/search-index/embedding-service/mod.ts";
 
 const { quad, namedNode, literal } = DataFactory;
+const queryEngine = new QueryEngine();
 
 Deno.test("E2E DEMO: unified data entry enables immediate hybrid search availability", async (t) => {
   // 1. Initialize ephemeral environment
@@ -13,7 +16,12 @@ Deno.test("E2E DEMO: unified data entry enables immediate hybrid search availabi
   const embeddingService = new FakeEmbeddingService();
 
   const client = new Client(
-    await provideLibsql({ client: db, embeddingService }),
+    await provideLibsql({
+      client: db,
+      embeddingService,
+      createSparqlEngine: ({ store }) =>
+        new ComunicaSparqlEngine({ queryEngine, store }),
+    }),
   );
 
   await t.step(

--- a/src/client/providers/libsql/provide-libsql.ts
+++ b/src/client/providers/libsql/provide-libsql.ts
@@ -1,24 +1,29 @@
 import type { Client as LibsqlClient } from "@libsql/client";
 import { RecursiveCharacterTextSplitter } from "@langchain/textsplitters";
 import { Store } from "n3";
-import { QueryEngine } from "@comunica/query-sparql-rdfjs-lite";
 
 import type { ClientOptions } from "#/client/client.ts";
 import type { Patch } from "#/client/quad-store/patch.ts";
 import type { TextSplitterInterface } from "#/client/search-index/quad-chunker/chunk-quads.ts";
 import type { EmbeddingService } from "#/client/search-index/embedding-service/mod.ts";
 import type { QuadFilter } from "#/client/quad-store/quad-filter.ts";
+import type { SparqlEngineInterface } from "#/client/sparql-engine/mod.ts";
 
 import { proxyStore } from "#/client/providers/rdfjs/n3/proxy-store.ts";
 import { RdfjsQuadStore } from "#/client/providers/rdfjs/rdfjs-quad-store.ts";
-import { ComunicaSparqlEngine } from "#/client/providers/comunica/comunica-sparql-engine.ts";
 import { LibsqlSearchIndex } from "./libsql-search-index.ts";
 import { commitPatchToLibsql } from "./commit-patch-to-libsql.ts";
 import { hydrateStoreFromLibsql } from "./hydrate-store-from-libsql.ts";
 
 import { LibsqlQueryBuilder } from "./libsql-query-builder.ts";
 
-const queryEngine = new QueryEngine();
+/**
+ * LibsqlSparqlEngineOptions contains the hydrated RDFJS store available to caller-provided SPARQL adapters.
+ */
+export interface LibsqlSparqlEngineOptions {
+  /** store is the hydrated and proxied RDFJS store used by the LibSQL synchronization layer. */
+  store: Store;
+}
 
 /**
  * LibsqlOptions details the aggregate internal subsystems powering active execution.
@@ -35,6 +40,11 @@ export interface LibsqlOptions {
 
   /** store is an optional starting store, useful for serverless environments where the store is already initialized. */
   store?: Store;
+
+  /** createSparqlEngine optionally attaches a caller-provided SPARQL engine over the provider-managed store. */
+  createSparqlEngine?: (
+    options: LibsqlSparqlEngineOptions,
+  ) => SparqlEngineInterface;
 
   /** maxLookupChunkSize specifies the maximum number of host parameters allowed in cache query IN clauses before split-chunking. Defaults to a conservative 800 (safely below historical SQLite 999 SQLITE_MAX_VARIABLE_NUMBER variable caps with generous headroom). */
   maxLookupChunkSize?: number;
@@ -95,6 +105,7 @@ export async function provideLibsql(
 
   // 3. Instrument memory layer for transparent transaction accumulation.
   const { store, drainPatches } = proxyStore(initialStore);
+  const configuredSparqlEngine = options.createSparqlEngine?.({ store });
 
   // 4. Configure specialized support utilities.
   const textSplitter = options.textSplitter ??
@@ -132,11 +143,6 @@ export async function provideLibsql(
 
   // 5. Synthesize foundational base component drivers.
   const quadStore = new RdfjsQuadStore(store);
-  const sparqlEngine = new ComunicaSparqlEngine({
-    queryEngine,
-    store,
-  });
-
   // 7. Deliver aggregated composite ready for standard instantiation.
   return {
     quadStore: {
@@ -147,13 +153,15 @@ export async function provideLibsql(
         return response;
       },
     },
-    sparqlEngine: {
-      execute: async (request) => {
-        const response = await sparqlEngine.execute(request);
-        await commitChanges();
-        return response;
-      },
-    },
+    sparqlEngine: configuredSparqlEngine
+      ? {
+        execute: async (request) => {
+          const response = await configuredSparqlEngine.execute(request);
+          await commitChanges();
+          return response;
+        },
+      }
+      : undefined,
     searchIndex,
   };
 }


### PR DESCRIPTION
﻿## Problem

Issue #56 — published `@worlds/client` transitively imported `@comunica/query-sparql-rdfjs-lite` via `provideLibsql` and `provideDenoKv`. JSR consumers got `cross-fetch` errors because the vendored `jsonld-context-parser` dependency didn't propagate through JSR's npm re-export layer.

## Solution

**Approach 2**: Keep providers opinionated about storage/search, inject SPARQL via factory. This is the minimal change that separates concerns and makes the library JSR-safe.

### Changes

- `ClientOptions.sparqlEngine` is now optional; `client.sparql()` throws `"SPARQL engine is not configured."` when absent
- `provideLibsql` accepts an optional `createSparqlEngine` factory; no longer imports `QueryEngine` or `ComunicaSparqlEngine`
- `provideDenoKv` accepts an optional `createSparqlEngine` factory; no longer imports `QueryEngine` or `ComunicaSparqlEngine`
- `ComunicaSparqlEngine` replaced the `type { QueryEngine }` import with a local structural `ComunicaQueryEngine` interface — the adapter itself is JSR-safe
- All examples and tests pass `createSparqlEngine` explicitly
- README updated with optional SPARQL pattern

### Verified

- `deno fmt` — clean
- `deno task ci` — 86 tests pass
- `deno publish --dry-run --allow-dirty` — clean
- Dependency graph for `provide-libsql.ts`, `provide-denokv.ts`, `comunica-sparql-engine.ts` — zero `@comunica`, `jsonld-context-parser`, or `cross-fetch` entries

Closes #56
