### PR TITLE
refactor: migrate internal imports to @worlds/client exports

### DIFF
--- a/benchmarks/denokv-pressure.bench.ts
+++ b/benchmarks/denokv-pressure.bench.ts
@@ -1,5 +1,5 @@
-import { Client } from "#/client/client.ts";
-import { provideDenoKv } from "#/client/providers/denokv/provide-denokv.ts";
+import { Client } from "@worlds/client";
+import { provideDenoKv } from "@worlds/client/providers/denokv";
 import { generateSyntheticQuads } from "./synthetic-data.ts";
 
 // Pre-allocated payloads for strict repeatable boundaries

--- a/benchmarks/libsql-pressure.bench.ts
+++ b/benchmarks/libsql-pressure.bench.ts
@@ -1,9 +1,9 @@
 import { createClient as createLibsqlClient } from "@libsql/client";
 import { Store } from "n3";
-import { Client } from "#/client/client.ts";
-import { provideLibsql } from "#/client/providers/libsql/provide-libsql.ts";
-import { hydrateStoreFromLibsql } from "#/client/providers/libsql/hydrate-store-from-libsql.ts";
-import { FakeEmbeddingService } from "#/client/search-index/embedding-service/mod.ts";
+import { Client } from "@worlds/client";
+import { provideLibsql } from "@worlds/client/providers/libsql";
+import { hydrateStoreFromLibsql } from "@worlds/client/providers/libsql";
+import { FakeEmbeddingService } from "@worlds/client";
 import { generateSyntheticQuads } from "./synthetic-data.ts";
 
 // Pre-allocated payloads for strict repeatable boundaries

--- a/benchmarks/search-comparison.bench.ts
+++ b/benchmarks/search-comparison.bench.ts
@@ -1,10 +1,10 @@
 import { createClient as createLibsqlClient } from "@libsql/client";
 import { Store } from "n3";
-import { RdfjsSearchIndex } from "#/client/providers/rdfjs/rdfjs-search-index.ts";
-import { LibsqlSearchIndex } from "#/client/providers/libsql/libsql-search-index.ts";
-import { provideLibsql } from "#/client/providers/libsql/provide-libsql.ts";
-import { defaultLibsqlQueryBuilder } from "#/client/providers/libsql/libsql-query-builder.ts";
-import { Client } from "#/client/client.ts";
+import { RdfjsSearchIndex } from "@worlds/client/providers/rdfjs";
+import { LibsqlSearchIndex } from "@worlds/client/providers/libsql";
+import { provideLibsql } from "@worlds/client/providers/libsql";
+import { defaultLibsqlQueryBuilder } from "@worlds/client/providers/libsql";
+import { Client } from "@worlds/client";
 import { generateSyntheticQuads } from "./synthetic-data.ts";
 
 // -----------------------------------------------------------------------------

--- a/deno.json
+++ b/deno.json
@@ -4,7 +4,10 @@
   "nodeModulesDir": "auto",
   "exports": {
     ".": "./src/mod.ts",
-    "./providers/libsql": "./src/client/providers/libsql/provide-libsql.ts",
+    "./quad-store": "./src/client/quad-store/mod.ts",
+    "./search-index": "./src/client/search-index/mod.ts",
+    "./sparql-engine": "./src/client/sparql-engine/mod.ts",
+    "./providers/libsql": "./src/client/providers/libsql/mod.ts",
     "./providers/tfjs-universal-sentence-encoder": "./src/client/providers/tfjs-universal-sentence-encoder/mod.ts",
     "./providers/comunica": "./src/client/providers/comunica/mod.ts",
     "./providers/rdfjs": "./src/client/providers/rdfjs/mod.ts",
@@ -12,7 +15,6 @@
     "./providers/denokv": "./src/client/providers/denokv/mod.ts"
   },
   "imports": {
-    "#/": "./src/",
     "ai": "npm:ai@^6.0.185",
     "@ai-sdk/google": "npm:@ai-sdk/google@^3.0.75",
     "@comunica/query-sparql-rdfjs-lite": "npm:@comunica/query-sparql-rdfjs-lite@^5.2.2",

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -2,9 +2,9 @@ import { assertEquals, assertRejects } from "@std/assert";
 import { DataFactory, Store } from "n3";
 import { Client } from "./client.ts";
 import { RdfjsQuadStore, RdfjsSearchIndex } from "./providers/rdfjs/mod.ts";
-import { ComunicaSparqlEngine } from "#/client/providers/comunica/mod.ts";
+import { ComunicaSparqlEngine } from "@worlds/client/providers/comunica";
 import { QueryEngine } from "@comunica/query-sparql-rdfjs-lite";
-import { hashQuad } from "#/client/quad-store/hash-quad.ts";
+import { hashQuad } from "@worlds/client";
 
 const queryEngine = new QueryEngine();
 

--- a/src/client/providers/comunica/comunica-sparql-engine.ts
+++ b/src/client/providers/comunica/comunica-sparql-engine.ts
@@ -7,7 +7,7 @@ import type {
   SparqlResponse,
   SparqlSelectResults,
   SparqlValue,
-} from "#/client/sparql-engine/sparql-engine-interface.ts";
+} from "@worlds/client/sparql-engine";
 
 /**
  * ComunicaQueryEngine is the minimal structural query contract needed from a user-provided Comunica engine.

--- a/src/client/providers/denokv/denokv-quad-store.ts
+++ b/src/client/providers/denokv/denokv-quad-store.ts
@@ -6,8 +6,8 @@ import type {
   ImportRequest,
   ImportResponse,
   QuadStoreInterface,
-} from "#/client/quad-store/quad-store-interface.ts";
-import { hashQuad } from "#/client/quad-store/hash-quad.ts";
+} from "@worlds/client";
+import { hashQuad } from "@worlds/client";
 
 const { namedNode, blankNode, literal, defaultGraph, quad } = DataFactory;
 

--- a/src/client/providers/denokv/denokv-search-index.ts
+++ b/src/client/providers/denokv/denokv-search-index.ts
@@ -5,10 +5,10 @@ import type {
   SearchRequest,
   SearchResponse,
   SearchResult,
-} from "#/client/search-index/search-index-interface.ts";
-import { hashQuad } from "#/client/quad-store/hash-quad.ts";
-import { filterQuads } from "#/client/quad-store/quad-filter.ts";
-import { isTextualLiteral } from "#/client/quad-store/is-textual-literal.ts";
+} from "@worlds/client";
+import { hashQuad } from "@worlds/client";
+import { filterQuads } from "@worlds/client";
+import { isTextualLiteral } from "@worlds/client";
 import { deserializeTerm, type SerializedQuad } from "./denokv-quad-store.ts";
 
 const { quad } = DataFactory;

--- a/src/client/providers/denokv/provide-denokv.ts
+++ b/src/client/providers/denokv/provide-denokv.ts
@@ -1,6 +1,6 @@
 import { Store } from "n3";
-import type { ClientOptions } from "#/client/client.ts";
-import type { SparqlEngineInterface } from "#/client/sparql-engine/mod.ts";
+import type { ClientOptions } from "@worlds/client";
+import type { SparqlEngineInterface } from "@worlds/client";
 import { DenokvSearchIndex } from "./denokv-search-index.ts";
 import {
   DenokvQuadStore,

--- a/src/client/providers/libsql/commit-patch-to-libsql.test.ts
+++ b/src/client/providers/libsql/commit-patch-to-libsql.test.ts
@@ -3,7 +3,7 @@ import { createClient } from "@libsql/client";
 import { DataFactory } from "n3";
 import { RecursiveCharacterTextSplitter } from "@langchain/textsplitters";
 import { commitPatchToLibsql } from "./commit-patch-to-libsql.ts";
-import { FakeEmbeddingService } from "#/client/search-index/embedding-service/mod.ts";
+import { FakeEmbeddingService } from "@worlds/client";
 import { LibsqlQueryBuilder } from "./libsql-query-builder.ts";
 
 const { quad, namedNode, literal } = DataFactory;

--- a/src/client/providers/libsql/commit-patch-to-libsql.ts
+++ b/src/client/providers/libsql/commit-patch-to-libsql.ts
@@ -1,18 +1,12 @@
 import type { Client, InStatement } from "@libsql/client";
-import type { Patch } from "#/client/quad-store/patch.ts";
-import type {
-  ChunkRowPayload,
-  TextSplitterInterface,
-} from "#/client/search-index/quad-chunker/chunk-quads.ts";
-import { chunkQuads } from "#/client/search-index/quad-chunker/chunk-quads.ts";
-import { hashQuad } from "#/client/quad-store/hash-quad.ts";
+import type { Patch } from "@worlds/client";
+import type { ChunkRowPayload, TextSplitterInterface } from "@worlds/client";
+import { chunkQuads } from "@worlds/client";
+import { hashQuad } from "@worlds/client";
 import type * as rdfjs from "@rdfjs/types";
-import {
-  filterQuads,
-  type QuadFilter,
-} from "#/client/quad-store/quad-filter.ts";
+import { filterQuads, type QuadFilter } from "@worlds/client";
 import type { LibsqlQueryBuilder } from "./libsql-query-builder.ts";
-import type { EmbeddingService } from "#/client/search-index/embedding-service/mod.ts";
+import type { EmbeddingService } from "@worlds/client";
 
 /**
  * CommitPatchToLibsqlOptions provides configurations for executing updates against LibSQL durable stores.

--- a/src/client/providers/libsql/hydrate-store-from-libsql.ts
+++ b/src/client/providers/libsql/hydrate-store-from-libsql.ts
@@ -1,7 +1,7 @@
 import type { Client, Row } from "@libsql/client";
 import { DataFactory, type Store } from "n3";
 import type * as rdfjs from "@rdfjs/types";
-import type { QuadFilter } from "#/client/quad-store/quad-filter.ts";
+import type { QuadFilter } from "@worlds/client";
 import { defaultLibsqlQueryBuilder } from "./libsql-query-builder.ts";
 
 const { namedNode, literal, blankNode, defaultGraph, quad } = DataFactory;

--- a/src/client/providers/libsql/libsql-query-builder.ts
+++ b/src/client/providers/libsql/libsql-query-builder.ts
@@ -1,5 +1,4 @@
-import type { SearchRequest } from "#/client/search-index/search-index-interface.ts";
-import type { QuadFilter } from "#/client/quad-store/quad-filter.ts";
+import type { QuadFilter, SearchRequest } from "@worlds/client";
 
 /** Maximum embedding dimensions accepted by LibsqlQueryBuilder (LibSQL / resource guardrail). */
 const LIBSQL_QUERY_BUILDER_MAX_VECTOR_DIMENSIONS = 8192;
@@ -502,7 +501,10 @@ export class LibsqlQueryBuilder {
 /**
  * defaultLibsqlQueryBuilder is the default 32-dimensional builder for callers that do not vary embedding width.
  */
-export const defaultLibsqlQueryBuilder = new LibsqlQueryBuilder(32);
+export const defaultLibsqlQueryBuilder: LibsqlQueryBuilder =
+  new LibsqlQueryBuilder(
+    32,
+  );
 
 /**
  * sanitizeFtsQuery defends SQLite against internal parsing crash vectors

--- a/src/client/providers/libsql/libsql-search-index.test.ts
+++ b/src/client/providers/libsql/libsql-search-index.test.ts
@@ -1,7 +1,7 @@
 import { assertEquals, assertExists } from "@std/assert";
 import { createClient } from "@libsql/client";
 import { LibsqlSearchIndex } from "./libsql-search-index.ts";
-import { FakeEmbeddingService } from "#/client/search-index/embedding-service/mod.ts";
+import { FakeEmbeddingService } from "@worlds/client";
 import { LibsqlQueryBuilder } from "./libsql-query-builder.ts";
 
 // --- Helpers ---

--- a/src/client/providers/libsql/libsql-search-index.ts
+++ b/src/client/providers/libsql/libsql-search-index.ts
@@ -5,11 +5,11 @@ import type {
   SearchRequest,
   SearchResponse,
   SearchResult,
-} from "#/client/search-index/search-index-interface.ts";
-import { hashQuad } from "#/client/quad-store/hash-quad.ts";
+} from "@worlds/client";
+import { hashQuad } from "@worlds/client";
 import type { LibsqlQueryBuilder } from "./libsql-query-builder.ts";
 
-import type { EmbeddingService } from "#/client/search-index/embedding-service/mod.ts";
+import type { EmbeddingService } from "@worlds/client";
 
 const { literal, namedNode, quad: createQuad, defaultGraph } = DataFactory;
 

--- a/src/client/providers/libsql/libsql-store.test.ts
+++ b/src/client/providers/libsql/libsql-store.test.ts
@@ -377,7 +377,9 @@ function createFlushHandler(
 }
 
 async function computeQuadId(quad: rdfjs.Quad): Promise<string> {
-  const { hashQuad } = await import("#/client/quad-store/hash-quad.ts");
+  const { hashQuad } = await import(
+    "@worlds/client"
+  );
   return await hashQuad(quad);
 }
 

--- a/src/client/providers/libsql/libsql-store.ts
+++ b/src/client/providers/libsql/libsql-store.ts
@@ -4,7 +4,7 @@ import { DataFactory } from "n3";
 import { Readable } from "node:stream";
 import { EventEmitter } from "node:events";
 import type { LibsqlQueryBuilder } from "./libsql-query-builder.ts";
-import type { Patch } from "#/client/quad-store/patch.ts";
+import type { Patch } from "@worlds/client";
 
 const { namedNode, literal, blankNode, defaultGraph, quad } = DataFactory;
 

--- a/src/client/providers/libsql/mod.ts
+++ b/src/client/providers/libsql/mod.ts
@@ -2,3 +2,4 @@ export * from "./libsql-search-index.ts";
 export * from "./provide-libsql.ts";
 export * from "./hydrate-store-from-libsql.ts";
 export * from "./commit-patch-to-libsql.ts";
+export * from "./libsql-query-builder.ts";

--- a/src/client/providers/libsql/provide-libsql.test.ts
+++ b/src/client/providers/libsql/provide-libsql.test.ts
@@ -2,10 +2,10 @@ import { assertEquals, assertExists } from "@std/assert";
 import { createClient as createLibsqlClient } from "@libsql/client";
 import { QueryEngine } from "@comunica/query-sparql-rdfjs-lite";
 import { DataFactory, Store } from "n3";
-import { Client } from "#/client/client.ts";
-import { ComunicaSparqlEngine } from "#/client/providers/comunica/mod.ts";
+import { Client } from "@worlds/client";
+import { ComunicaSparqlEngine } from "@worlds/client/providers/comunica";
 import { provideLibsql } from "./provide-libsql.ts";
-import { FakeEmbeddingService } from "#/client/search-index/embedding-service/mod.ts";
+import { FakeEmbeddingService } from "@worlds/client";
 
 const { quad, namedNode, literal } = DataFactory;
 const queryEngine = new QueryEngine();

--- a/src/client/providers/libsql/provide-libsql.ts
+++ b/src/client/providers/libsql/provide-libsql.ts
@@ -2,15 +2,15 @@ import type { Client as LibsqlClient } from "@libsql/client";
 import { RecursiveCharacterTextSplitter } from "@langchain/textsplitters";
 import { Store } from "n3";
 
-import type { ClientOptions } from "#/client/client.ts";
-import type { Patch } from "#/client/quad-store/patch.ts";
-import type { TextSplitterInterface } from "#/client/search-index/quad-chunker/chunk-quads.ts";
-import type { EmbeddingService } from "#/client/search-index/embedding-service/mod.ts";
-import type { QuadFilter } from "#/client/quad-store/quad-filter.ts";
-import type { SparqlEngineInterface } from "#/client/sparql-engine/mod.ts";
+import type { ClientOptions } from "@worlds/client";
+import type { Patch } from "@worlds/client";
+import type { TextSplitterInterface } from "@worlds/client";
+import type { EmbeddingService } from "@worlds/client";
+import type { QuadFilter } from "@worlds/client";
+import type { SparqlEngineInterface } from "@worlds/client";
 
-import { proxyStore } from "#/client/providers/rdfjs/n3/proxy-store.ts";
-import { RdfjsQuadStore } from "#/client/providers/rdfjs/rdfjs-quad-store.ts";
+import { proxyStore } from "@worlds/client/providers/rdfjs/n3";
+import { RdfjsQuadStore } from "@worlds/client/providers/rdfjs";
 import { LibsqlSearchIndex } from "./libsql-search-index.ts";
 import { commitPatchToLibsql } from "./commit-patch-to-libsql.ts";
 import { hydrateStoreFromLibsql } from "./hydrate-store-from-libsql.ts";

--- a/src/client/providers/rdfjs/n3/proxy-store.test.ts
+++ b/src/client/providers/rdfjs/n3/proxy-store.test.ts
@@ -2,7 +2,7 @@ import { assertEquals } from "@std/assert";
 import { DataFactory, Store } from "n3";
 import { proxyStore } from "./proxy-store.ts";
 import { QueryEngine } from "@comunica/query-sparql-rdfjs-lite";
-import { executeSparql } from "#/client/providers/comunica/mod.ts";
+import { executeSparql } from "@worlds/client/providers/comunica";
 
 const { quad, namedNode, literal } = DataFactory;
 

--- a/src/client/providers/rdfjs/provide-rdfjs.ts
+++ b/src/client/providers/rdfjs/provide-rdfjs.ts
@@ -1,6 +1,6 @@
 import { Store } from "n3";
-import type { ClientOptions } from "#/client/client.ts";
-import type { SparqlEngineInterface } from "#/client/sparql-engine/mod.ts";
+import type { ClientOptions } from "@worlds/client";
+import type { SparqlEngineInterface } from "@worlds/client";
 import { RdfjsQuadStore } from "./rdfjs-quad-store.ts";
 import { RdfjsSearchIndex } from "./rdfjs-search-index.ts";
 

--- a/src/client/providers/rdfjs/rdfjs-quad-store.ts
+++ b/src/client/providers/rdfjs/rdfjs-quad-store.ts
@@ -7,7 +7,7 @@ import type {
   ImportRequest,
   ImportResponse,
   QuadStoreInterface,
-} from "#/client/quad-store/quad-store-interface.ts";
+} from "@worlds/client";
 
 /**
  * RdfjsQuadStore is the standard implementation of the QuadStoreInterface that uses

--- a/src/client/providers/rdfjs/rdfjs-search-index.ts
+++ b/src/client/providers/rdfjs/rdfjs-search-index.ts
@@ -5,10 +5,10 @@ import type {
   SearchRequest,
   SearchResponse,
   SearchResult,
-} from "#/client/search-index/search-index-interface.ts";
-import { hashQuad } from "#/client/quad-store/hash-quad.ts";
-import { filterQuads } from "#/client/quad-store/quad-filter.ts";
-import { isTextualLiteral } from "#/client/quad-store/is-textual-literal.ts";
+} from "@worlds/client";
+import { hashQuad } from "@worlds/client";
+import { filterQuads } from "@worlds/client";
+import { isTextualLiteral } from "@worlds/client";
 
 const { literal, namedNode, quad: createQuad, defaultGraph } = DataFactory;
 

--- a/src/client/providers/tfjs-universal-sentence-encoder/universal-sentence-encoder-embedding-service.ts
+++ b/src/client/providers/tfjs-universal-sentence-encoder/universal-sentence-encoder-embedding-service.ts
@@ -2,7 +2,7 @@ import "@tensorflow/tfjs-backend-wasm";
 import { isAbsolute, toFileUrl } from "@std/path";
 import * as tf from "@tensorflow/tfjs";
 import * as use from "@tensorflow-models/universal-sentence-encoder";
-import type { EmbeddingService } from "#/client/search-index/embedding-service/embedding-service.ts";
+import type { EmbeddingService } from "@worlds/client";
 
 /** UniversalSentenceEncoderEmbeddingServiceOptions defines the configuration for local or remote model resources. */
 export interface UniversalSentenceEncoderEmbeddingServiceOptions {

--- a/src/client/quad-store/mod.ts
+++ b/src/client/quad-store/mod.ts
@@ -2,3 +2,4 @@ export * from "./quad-store-interface.ts";
 export * from "./patch.ts";
 export * from "./quad-filter.ts";
 export * from "./is-textual-literal.ts";
+export * from "./hash-quad.ts";

--- a/src/client/search-index/mod.ts
+++ b/src/client/search-index/mod.ts
@@ -1,2 +1,3 @@
 export * from "./search-index-interface.ts";
 export * from "./embedding-service/mod.ts";
+export * from "./quad-chunker/mod.ts";

--- a/src/client/search-index/quad-chunker/chunk-quads.ts
+++ b/src/client/search-index/quad-chunker/chunk-quads.ts
@@ -1,6 +1,5 @@
 import type { Quad } from "@rdfjs/types";
-import { hashQuad } from "#/client/quad-store/hash-quad.ts";
-import { isTextualLiteral } from "#/client/quad-store/is-textual-literal.ts";
+import { hashQuad, isTextualLiteral } from "@worlds/client/quad-store";
 
 /**
  * ChunkRowPayload is the standardized structure of data that will be inserted into the FTS table.

--- a/src/client/search-index/search-index-interface.ts
+++ b/src/client/search-index/search-index-interface.ts
@@ -1,4 +1,4 @@
-import type { QuadFilter } from "#/client/quad-store/quad-filter.ts";
+import type { QuadFilter } from "@worlds/client/quad-store";
 
 /**
  * SearchRequest defines the parameters for executing a keyword search, extending central QuadFilter rules.


### PR DESCRIPTION
## Summary

- Remove the `#/` import-map alias from `deno.json`
- Route in-repo imports through published JSR barrels: `@worlds/client`, domain subpaths (`quad-store`, `search-index`, `sparql-engine`), and provider `mod.ts` exports
- Point `./providers/libsql` at `mod.ts` and re-export `hashQuad`, quad-chunker, and `libsql-query-builder` from barrels

## Test plan

- [x] `deno task ci` (fmt, lint, check, 86 tests)

Made with [Cursor](https://cursor.com)