### PR TITLE
Benchmark preload and chunked LibSQL hydration

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,7 +1,7 @@
 # Benchmarks
 
 Performance benchmarks for `@worlds/client`. Follow-up work is tracked in GitHub
-issues — do not comment on closed perf threads
+issues â€” do not comment on closed perf threads
 ([#2](https://github.com/wazootech/worlds-client-ts/issues/2),
 [#3](https://github.com/wazootech/worlds-client-ts/issues/3),
 [#8](https://github.com/wazootech/worlds-client-ts/issues/8),
@@ -31,7 +31,33 @@ Compares **hydrate+N3** (`createLibsqlN3ClientOptions` from
 (`createLibsqlClientOptions` from `@worlds/client/adapters/libsql`). See
 [discussion #45](https://github.com/wazootech/worlds-client-ts/discussions/45).
 
-## Baseline table (0.0.5, 2026-05-21)
+## Measurement notes
+
+Benchmarks preload datasets and SPARQL engines at **module load**; only the hot
+path runs inside `benchContext.start()` / `end()`. Write-pressure benches still
+create a fresh database per iteration and use `warmup: 5`, `n: 50`.
+
+- **avg** is the primary regression signal; compare like-for-like OS and Deno
+  versions only.
+- Large **p99** gaps vs **avg** on older runs usually meant per-iteration import
+  - GC between timed slices, not multi-second SPARQL alone. After preload,
+    crossover p99 should stay within a fewÃ— of avg.
+- Optional GC trace (local only, not CI):
+
+  ```bash
+  deno bench --allow-all --v8-flags=--trace-gc benchmarks/sparql-hexastore-crossover.bench.ts
+  ```
+
+**Production (millions of quads):** prefer
+[`createLibsqlClient`](src/client/adapters/libsql/create-libsql-client.ts) for
+indexed SPARQL without a full N3 mirror; reuse a warmed
+[`store`](src/client/adapters/libsql/n3/create-libsql-n3-client.ts) on the N3
+path per container, not per request.
+
+Baselines before preload refactors (2026-05-21 table below) are **not** directly
+comparable to post-refactor captures.
+
+## Baseline table (0.0.5, 2026-05-21, pre-preload)
 
 Captured on **Deno 2.7.14 (Windows x86_64)**. CI should pin OS/runtime or use
 relaxed tolerances.
@@ -46,24 +72,78 @@ relaxed tolerances.
 
 ### `denokv-pressure.bench.ts`
 
-| Benchmark                           | Avg                       |
-| :---------------------------------- | :------------------------ |
-| Import 10 / 100 / 1000              | 419 µs / 1.9 ms / 18.9 ms |
-| Hydration 100 / 1k / 5k             | 1.1 ms / 9.0 ms / 49.0 ms |
-| Search hit / miss (full 2k KV scan) | 21.7 ms / 20.8 ms         |
+| Benchmark                           | Avg                        |
+| :---------------------------------- | :------------------------- |
+| Import 10 / 100 / 1000              | 419 Âµs / 1.9 ms / 18.9 ms |
+| Hydration 100 / 1k / 5k             | 1.1 ms / 9.0 ms / 49.0 ms  |
+| Search hit / miss (full 2k KV scan) | 21.7 ms / 20.8 ms          |
 
 ### `search-comparison.bench.ts` (LibSQL FTS vs RDF/JS naive)
 
 | Scale | RDF/JS specific | LibSQL FTS specific |
 | :---- | :-------------- | :------------------ |
-| 100   | 273 µs          | 329 µs              |
-| 1k    | 3.1 ms          | 327 µs              |
-| 10k   | 18.3 ms         | 300 µs              |
+| 100   | 273 Âµs         | 329 Âµs             |
+| 1k    | 3.1 ms          | 327 Âµs             |
+| 10k   | 18.3 ms         | 300 Âµs             |
+
+## Baseline table (post-preload, 2026-05-21)
+
+Captured on **Deno 2.7.14 (Windows x86_64)** with module-level preload and
+chunked hydration (`DEFAULT_HYDRATION_BATCH_SIZE = 1000`).
+
+### `libsql-pressure.bench.ts`
+
+| Benchmark                                      | Avg                         |
+| :--------------------------------------------- | :-------------------------- |
+| Import 10 / 100 / 1000 quads                   | 3.2 ms / 46.0 ms / 485 ms   |
+| Hydration 100 / 1k / 5k                        | 994 Âµs / 10.0 ms / 46.3 ms |
+| FTS search (2k corpus) specific / multi / miss | 726 Âµs / 5.2 ms / 720 Âµs  |
+
+### `denokv-pressure.bench.ts`
+
+| Benchmark                           | Avg                        |
+| :---------------------------------- | :------------------------- |
+| Import 10 / 100 / 1000              | 278 Âµs / 1.5 ms / 16.7 ms |
+| Hydration 100 / 1k / 5k             | 717 Âµs / 7.2 ms / 37.5 ms |
+| Search hit / miss (full 2k KV scan) | 16.0 ms / 15.2 ms          |
+
+### `search-comparison.bench.ts` (LibSQL FTS vs RDF/JS naive)
+
+| Scale | RDF/JS specific | LibSQL FTS specific |
+| :---- | :-------------- | :------------------ |
+| 100   | 150 µs          | 238 µs              |
+| 1k    | 2.0 ms          | 198 µs              |
+| 10k   | 13.3 ms         | 198 µs              |
+
+### `sparql-hexastore-crossover.bench.ts` (execute only, preloaded)
+
+| Quads | Query shape | Backend     | Avg     |
+| :---- | :---------- | :---------- | :------ |
+| 1000  | selective   | hydrate+N3  | 511 Âµs |
+| 1000  | selective   | libsqlStore | 1.0 ms  |
+| 1000  | fullScan    | hydrate+N3  | 3.0 ms  |
+| 1000  | fullScan    | libsqlStore | 20.1 ms |
+| 5000  | selective   | hydrate+N3  | 362 Âµs |
+| 5000  | selective   | libsqlStore | 2.3 ms  |
+| 5000  | fullScan    | hydrate+N3  | 4.0 ms  |
+| 5000  | fullScan    | libsqlStore | 87.2 ms |
+| 10000 | selective   | hydrate+N3  | 274 Âµs |
+| 10000 | selective   | libsqlStore | 3.1 ms  |
+| 10000 | fullScan    | hydrate+N3  | 5.5 ms  |
+| 10000 | fullScan    | libsqlStore | 211 ms  |
+| 25000 | selective   | hydrate+N3  | 462 Âµs |
+| 25000 | selective   | libsqlStore | 9.5 ms  |
+| 25000 | fullScan    | hydrate+N3  | 12.3 ms |
+| 25000 | fullScan    | libsqlStore | 509 ms  |
+| 50000 | selective   | hydrate+N3  | 357 Âµs |
+| 50000 | selective   | libsqlStore | 15.2 ms |
+| 50000 | fullScan    | hydrate+N3  | 24.4 ms |
+| 50000 | fullScan    | libsqlStore | 1.1 s   |
 
 ## Regression policy
 
 - Investigate when a keyed benchmark regresses by **more than ~15%** average vs
-  the baseline above (same OS/Deno).
+  the post-preload baseline above (same OS/Deno).
 - Open a **new issue** linking
   [#65](https://github.com/wazootech/worlds-client-ts/issues/65) with pasted
   before/after `deno bench` output.
@@ -82,4 +162,4 @@ or release notes:
 | 1000  | fullScan    | libsqlStore |     |
 | 5000  | selective   | hydrate+N3  |     |
 | 5000  | selective   | libsqlStore |     |
-| …     | …           | …           |     |
+| â€¦   | â€¦         | â€¦         |     |

--- a/benchmarks/denokv-pressure.bench.ts
+++ b/benchmarks/denokv-pressure.bench.ts
@@ -7,6 +7,10 @@ const payloadSmall = generateSyntheticQuads(10);
 const payloadMedium = generateSyntheticQuads(100);
 const payloadLarge = generateSyntheticQuads(1000);
 
+/** writeBenchIterations stabilizes write-pressure timings across GC between cold KV setups. */
+const writeBenchWarmup = 5;
+const writeBenchIterations = 50;
+
 /**
  * setupIsolatedClient establishes an ephemeral in-memory Deno.Kv and returns a client.
  */
@@ -21,19 +25,34 @@ async function setupIsolatedClient(): Promise<{
 }
 
 /**
- * createPreloadedDatabase persists a specified number of quads prior to timing trials.
+ * createPreloadedClient persists a specified number of quads prior to timing trials.
  */
-async function createPreloadedDatabase(count: number): Promise<{
+async function createPreloadedClient(count: number): Promise<{
   client: Client;
   kv: Deno.Kv;
 }> {
   const { client, kv } = await setupIsolatedClient();
-  const testQuads = generateSyntheticQuads(count);
   await client.import({
-    source: { kind: "quads", quads: testQuads },
+    source: { kind: "quads", quads: generateSyntheticQuads(count) },
   });
   return { client, kv };
 }
+
+console.log("Pre-populating Deno Kv benchmark datasets...");
+
+const hydrationCorpus100 = await createPreloadedClient(100);
+const hydrationCorpus1000 = await createPreloadedClient(1000);
+const hydrationCorpus5000 = await createPreloadedClient(5000);
+const searchCorpus = await createPreloadedClient(2000);
+
+console.log("Deno Kv benchmark datasets ready.");
+
+globalThis.addEventListener("unload", () => {
+  hydrationCorpus100.kv.close();
+  hydrationCorpus1000.kv.close();
+  hydrationCorpus5000.kv.close();
+  searchCorpus.kv.close();
+});
 
 // -----------------------------------------------------------------------------
 // BENCHMARK GROUP 1: Write Pressure (Deno Kv Batched Commits)
@@ -43,6 +62,8 @@ async function createPreloadedDatabase(count: number): Promise<{
 Deno.bench({
   name: "Write Pressure: Import 10 Quads (Deno Kv :memory:)",
   group: "Write Pressure",
+  warmup: writeBenchWarmup,
+  n: writeBenchIterations,
   async fn(benchContext) {
     const { client, kv } = await setupIsolatedClient();
 
@@ -59,6 +80,8 @@ Deno.bench({
 Deno.bench({
   name: "Write Pressure: Import 100 Quads (Deno Kv :memory:)",
   group: "Write Pressure",
+  warmup: writeBenchWarmup,
+  n: writeBenchIterations,
   async fn(benchContext) {
     const { client, kv } = await setupIsolatedClient();
 
@@ -75,6 +98,8 @@ Deno.bench({
 Deno.bench({
   name: "Write Pressure: Import 1000 Quads (Deno Kv :memory:)",
   group: "Write Pressure",
+  warmup: writeBenchWarmup,
+  n: writeBenchIterations,
   async fn(benchContext) {
     const { client, kv } = await setupIsolatedClient();
 
@@ -97,13 +122,9 @@ Deno.bench({
   name: "Deno Kv Hydration: 100 Quads from DB",
   group: "Hydration Scale",
   async fn(benchContext) {
-    const { client, kv } = await createPreloadedDatabase(100);
-
     benchContext.start();
-    await client.export({ format: { kind: "quads" } });
+    await hydrationCorpus100.client.export({ format: { kind: "quads" } });
     benchContext.end();
-
-    kv.close();
   },
 });
 
@@ -111,13 +132,9 @@ Deno.bench({
   name: "Deno Kv Hydration: 1,000 Quads from DB",
   group: "Hydration Scale",
   async fn(benchContext) {
-    const { client, kv } = await createPreloadedDatabase(1000);
-
     benchContext.start();
-    await client.export({ format: { kind: "quads" } });
+    await hydrationCorpus1000.client.export({ format: { kind: "quads" } });
     benchContext.end();
-
-    kv.close();
   },
 });
 
@@ -125,13 +142,9 @@ Deno.bench({
   name: "Deno Kv Hydration: 5,000 Quads from DB",
   group: "Hydration Scale",
   async fn(benchContext) {
-    const { client, kv } = await createPreloadedDatabase(5000);
-
     benchContext.start();
-    await client.export({ format: { kind: "quads" } });
+    await hydrationCorpus5000.client.export({ format: { kind: "quads" } });
     benchContext.end();
-
-    kv.close();
   },
 });
 
@@ -147,18 +160,17 @@ Deno.bench({
   name: "Search: hit after full 2k KV scan (SYNT-1500)",
   group: "Search Speed",
   async fn(benchContext) {
-    const { client, kv } = await createPreloadedDatabase(2000);
     const targetKeyword = "SYNT-1500";
 
     benchContext.start();
-    const response = await client.search({ query: targetKeyword });
+    const response = await searchCorpus.client.search({
+      query: targetKeyword,
+    });
     benchContext.end();
 
     if (!response.results || response.results.length === 0) {
       throw new Error("Search expected a result match.");
     }
-
-    kv.close();
   },
 });
 
@@ -166,14 +178,11 @@ Deno.bench({
   name: "Search: miss after full 2k KV scan (no matches)",
   group: "Search Speed",
   async fn(benchContext) {
-    const { client, kv } = await createPreloadedDatabase(2000);
     const nonExistentWord =
       "nonexistentwordthatcharacteristicallymisseseverything";
 
     benchContext.start();
-    await client.search({ query: nonExistentWord });
+    await searchCorpus.client.search({ query: nonExistentWord });
     benchContext.end();
-
-    kv.close();
   },
 });

--- a/benchmarks/libsql-pressure.bench.ts
+++ b/benchmarks/libsql-pressure.bench.ts
@@ -11,6 +11,10 @@ const payloadSmall = generateSyntheticQuads(10);
 const payloadMedium = generateSyntheticQuads(100);
 const payloadLarge = generateSyntheticQuads(1000);
 
+/** writeBenchIterations stabilizes write-pressure timings across GC between cold DB setups. */
+const writeBenchWarmup = 5;
+const writeBenchIterations = 50;
+
 /**
  * setupIsolatedClient establishes an ephemeral database and initializes the core schema.
  * This prepares a clean testing boundary without contaminating timing measurements.
@@ -30,19 +34,47 @@ async function setupIsolatedClient(): Promise<{
 }
 
 /**
- * createPreloadedDatabase persists a specified number of quads prior to timing trials.
+ * preloadDatabaseOnly imports quads into LibSQL and returns the database handle for hydration benches.
  */
-async function createPreloadedDatabase(count: number): Promise<{
+async function preloadDatabaseOnly(
+  count: number,
+): Promise<ReturnType<typeof createClient>> {
+  const { client, db } = await setupIsolatedClient();
+  await client.import({
+    source: { kind: "quads", quads: generateSyntheticQuads(count) },
+  });
+  return db;
+}
+
+/**
+ * createPreloadedClient persists a specified number of quads and returns a ready search client.
+ */
+async function createPreloadedClient(count: number): Promise<{
   client: Client;
   db: ReturnType<typeof createClient>;
 }> {
   const { client, db } = await setupIsolatedClient();
-  const testQuads = generateSyntheticQuads(count);
   await client.import({
-    source: { kind: "quads", quads: testQuads },
+    source: { kind: "quads", quads: generateSyntheticQuads(count) },
   });
   return { client, db };
 }
+
+console.log("Pre-populating libsql benchmark datasets...");
+
+const hydrationDatabase100 = await preloadDatabaseOnly(100);
+const hydrationDatabase1000 = await preloadDatabaseOnly(1000);
+const hydrationDatabase5000 = await preloadDatabaseOnly(5000);
+const searchCorpus = await createPreloadedClient(2000);
+
+console.log("Libsql benchmark datasets ready.");
+
+globalThis.addEventListener("unload", () => {
+  hydrationDatabase100.close();
+  hydrationDatabase1000.close();
+  hydrationDatabase5000.close();
+  searchCorpus.db.close();
+});
 
 // -----------------------------------------------------------------------------
 // BENCHMARK GROUP 1: Write Pressure (Transactions and Replication)
@@ -52,6 +84,8 @@ async function createPreloadedDatabase(count: number): Promise<{
 Deno.bench({
   name: "Write Pressure: Import 10 Quads (:memory:)",
   group: "Write Pressure",
+  warmup: writeBenchWarmup,
+  n: writeBenchIterations,
   async fn(benchContext) {
     const { client, db } = await setupIsolatedClient();
 
@@ -68,6 +102,8 @@ Deno.bench({
 Deno.bench({
   name: "Write Pressure: Import 100 Quads (:memory:)",
   group: "Write Pressure",
+  warmup: writeBenchWarmup,
+  n: writeBenchIterations,
   async fn(benchContext) {
     const { client, db } = await setupIsolatedClient();
 
@@ -84,6 +120,8 @@ Deno.bench({
 Deno.bench({
   name: "Write Pressure: Import 1000 Quads (:memory:)",
   group: "Write Pressure",
+  warmup: writeBenchWarmup,
+  n: writeBenchIterations,
   async fn(benchContext) {
     const { client, db } = await setupIsolatedClient();
 
@@ -106,14 +144,11 @@ Deno.bench({
   name: "Hydration Scale: 100 Quads from DB",
   group: "Hydration Scale",
   async fn(benchContext) {
-    const { db } = await createPreloadedDatabase(100);
     const targetStore = new Store();
 
     benchContext.start();
-    await hydrateStoreFromLibsql(db, targetStore);
+    await hydrateStoreFromLibsql(hydrationDatabase100, targetStore);
     benchContext.end();
-
-    db.close();
   },
 });
 
@@ -121,14 +156,11 @@ Deno.bench({
   name: "Hydration Scale: 1,000 Quads from DB",
   group: "Hydration Scale",
   async fn(benchContext) {
-    const { db } = await createPreloadedDatabase(1000);
     const targetStore = new Store();
 
     benchContext.start();
-    await hydrateStoreFromLibsql(db, targetStore);
+    await hydrateStoreFromLibsql(hydrationDatabase1000, targetStore);
     benchContext.end();
-
-    db.close();
   },
 });
 
@@ -136,14 +168,11 @@ Deno.bench({
   name: "Hydration Scale: 5,000 Quads from DB",
   group: "Hydration Scale",
   async fn(benchContext) {
-    const { db } = await createPreloadedDatabase(5000);
     const targetStore = new Store();
 
     benchContext.start();
-    await hydrateStoreFromLibsql(db, targetStore);
+    await hydrateStoreFromLibsql(hydrationDatabase5000, targetStore);
     benchContext.end();
-
-    db.close();
   },
 });
 
@@ -156,18 +185,17 @@ Deno.bench({
   name: "Search Queries: Specific Unique Keyword (Single Match)",
   group: "Search Speed",
   async fn(benchContext) {
-    const { client, db } = await createPreloadedDatabase(2000);
     const targetKeyword = "SYNT-1500";
 
     benchContext.start();
-    const response = await client.search({ query: targetKeyword });
+    const response = await searchCorpus.client.search({
+      query: targetKeyword,
+    });
     benchContext.end();
 
     if (!response.results || response.results.length === 0) {
       throw new Error("Search expected a result match for verification token.");
     }
-
-    db.close();
   },
 });
 
@@ -175,14 +203,11 @@ Deno.bench({
   name: "Search Queries: High Occurrence Word (Multi-Match)",
   group: "Search Speed",
   async fn(benchContext) {
-    const { client, db } = await createPreloadedDatabase(2000);
     const commonKeyword = "synthetic";
 
     benchContext.start();
-    await client.search({ query: commonKeyword });
+    await searchCorpus.client.search({ query: commonKeyword });
     benchContext.end();
-
-    db.close();
   },
 });
 
@@ -190,14 +215,11 @@ Deno.bench({
   name: "Search Queries: Miss Target (Zero Matches)",
   group: "Search Speed",
   async fn(benchContext) {
-    const { client, db } = await createPreloadedDatabase(2000);
     const nonExistentWord =
       "nonexistentwordthatcharacteristicallymisseseverything";
 
     benchContext.start();
-    await client.search({ query: nonExistentWord });
+    await searchCorpus.client.search({ query: nonExistentWord });
     benchContext.end();
-
-    db.close();
   },
 });

--- a/benchmarks/sparql-hexastore-crossover.bench.ts
+++ b/benchmarks/sparql-hexastore-crossover.bench.ts
@@ -78,6 +78,19 @@ async function createLibsqlHexastoreSparqlEngine(
 type SparqlQueryShape = "selective" | "fullScan";
 type SparqlBackend = "hydrate+N3" | "libsqlStore";
 
+/** PreloadedSparqlFixture holds a warmed SPARQL engine and its database handle. */
+interface PreloadedSparqlFixture {
+  databaseClient: ReturnType<typeof createClient>;
+  sparqlEngine: SparqlEngineInterface;
+}
+
+function sparqlEngineCacheKey(
+  backend: SparqlBackend,
+  quadCount: number,
+): string {
+  return `${backend}:${quadCount}`;
+}
+
 function sparqlQueryForShape(queryShape: SparqlQueryShape): string {
   return queryShape === "selective"
     ? selectiveSparqlQuery
@@ -87,32 +100,52 @@ function sparqlQueryForShape(queryShape: SparqlQueryShape): string {
 async function createSparqlEngineForBackend(
   backend: SparqlBackend,
   quadCount: number,
-): Promise<{
-  databaseClient: ReturnType<typeof createClient>;
-  sparqlEngine: SparqlEngineInterface;
-}> {
+): Promise<PreloadedSparqlFixture> {
   return backend === "hydrate+N3"
     ? await createHydrateN3SparqlEngine(quadCount)
     : await createLibsqlHexastoreSparqlEngine(quadCount);
 }
 
+console.log("Pre-populating SPARQL crossover engines...");
+
+const preloadedSparqlEngines = new Map<string, PreloadedSparqlFixture>();
+
+for (const quadCount of crossoverScales) {
+  for (const backend of ["hydrate+N3", "libsqlStore"] as const) {
+    const fixture = await createSparqlEngineForBackend(backend, quadCount);
+    preloadedSparqlEngines.set(
+      sparqlEngineCacheKey(backend, quadCount),
+      fixture,
+    );
+  }
+}
+
+console.log("SPARQL crossover engines ready.");
+
+globalThis.addEventListener("unload", () => {
+  for (const fixture of preloadedSparqlEngines.values()) {
+    fixture.databaseClient.close();
+  }
+});
+
 for (const quadCount of crossoverScales) {
   for (const queryShape of ["selective", "fullScan"] as const) {
     for (const backend of ["hydrate+N3", "libsqlStore"] as const) {
       const query = sparqlQueryForShape(queryShape);
+      const cacheKey = sparqlEngineCacheKey(backend, quadCount);
       Deno.bench({
         name:
           `SPARQL Crossover: ${quadCount} quads | ${queryShape} | ${backend}`,
         group: `SPARQL Crossover (${quadCount})`,
         async fn(benchContext) {
-          const { databaseClient, sparqlEngine } =
-            await createSparqlEngineForBackend(backend, quadCount);
+          const fixture = preloadedSparqlEngines.get(cacheKey);
+          if (!fixture) {
+            throw new Error(`Missing preloaded SPARQL fixture: ${cacheKey}`);
+          }
 
           benchContext.start();
-          await sparqlEngine.execute({ query });
+          await fixture.sparqlEngine.execute({ query });
           benchContext.end();
-
-          databaseClient.close();
         },
       });
     }

--- a/src/client/adapters/libsql/hydrate-store-from-libsql.test.ts
+++ b/src/client/adapters/libsql/hydrate-store-from-libsql.test.ts
@@ -278,3 +278,35 @@ Deno.test(
     );
   },
 );
+
+Deno.test(
+  "hydrateStoreFromLibsql - hydrates more than one internal batch without losing quads",
+  async () => {
+    const client = createClient({ url: ":memory:" });
+    await client.execute(defaultLibsqlQueryBuilder.buildLibsqlQuadsTable());
+
+    const rowCount = 1500;
+    for (let index = 0; index < rowCount; index++) {
+      await client.execute({
+        sql:
+          `INSERT INTO quads (id, s, s_type, p, o, o_type, g, g_type) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+        args: [
+          `batch-hash-${index}`,
+          `urn:entity:${index}`,
+          "NamedNode",
+          "urn:p",
+          `value-${index}`,
+          "Literal",
+          "",
+          "DefaultGraph",
+        ],
+      });
+    }
+
+    const targetStore = new Store();
+    const count = await hydrateStoreFromLibsql(client, targetStore);
+
+    assertEquals(count, rowCount);
+    assertEquals(targetStore.size, rowCount);
+  },
+);

--- a/src/client/adapters/libsql/hydrate-store-from-libsql.ts
+++ b/src/client/adapters/libsql/hydrate-store-from-libsql.ts
@@ -7,6 +7,9 @@ import { defaultLibsqlQueryBuilder } from "./libsql-query-builder.ts";
 
 const { namedNode, literal, blankNode, defaultGraph, quad } = DataFactory;
 
+/** DEFAULT_HYDRATION_BATCH_SIZE caps peak heap during hydration by flushing quads into the N3 store in chunks. */
+const DEFAULT_HYDRATION_BATCH_SIZE = 1000;
+
 /**
  * hydrateStoreFromLibsql reconstructs full in-memory state at lightning speeds by deserializing
  * relational tuples directly into Graph nodes, avoiding costly string parsing compute overhead.
@@ -22,6 +25,8 @@ export async function hydrateStoreFromLibsql(
   if (!resultSet.rows.length) return 0;
 
   const batchQuads: rdfjs.Quad[] = [];
+  let hydratedCount = 0;
+
   for (const row of resultSet.rows) {
     try {
       const subject = reconstructSubject(row);
@@ -30,6 +35,12 @@ export async function hydrateStoreFromLibsql(
       const graph = reconstructGraph(row);
 
       batchQuads.push(quad(subject, predicate, object, graph));
+      hydratedCount++;
+
+      if (batchQuads.length >= DEFAULT_HYDRATION_BATCH_SIZE) {
+        target.addQuads(batchQuads);
+        batchQuads.length = 0;
+      }
     } catch (err) {
       console.warn(
         `hydrateStoreFromLibsql: skipping corrupt row s="${row.s}"`,
@@ -42,7 +53,7 @@ export async function hydrateStoreFromLibsql(
     target.addQuads(batchQuads);
   }
 
-  return batchQuads.length;
+  return hydratedCount;
 }
 
 function reconstructSubject(row: Row): rdfjs.Quad_Subject {


### PR DESCRIPTION
## Summary

- Preload benchmark datasets and SPARQL engines at module load so timed iterations measure execute-path cost without per-iteration import/GC spikes.
- Chunk `hydrateStoreFromLibsql` with `DEFAULT_HYDRATION_BATCH_SIZE = 1000` and extend tests for multi-batch hydration.
- Refresh `benchmarks/README.md` with post-preload baselines (pressure, search-comparison, SPARQL crossover) and measurement notes for fair timing and production guidance.

## Test plan

- [x] `deno fmt`
- [x] `deno task ci`
- [x] `deno task bench` (local; post-preload numbers captured in README)
- [ ] Maintainer: spot-check discussion #45 crossover comment after merge