### PR TITLE
docs(libsql): scale SPARQL guidance and query-pattern helpers (#68)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 node_modules
-.prior-art
 *.db
 .env
 *.log

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -258,7 +258,10 @@ Use `benchmarks/sparql-hexastore-crossover.bench.ts`,
 context:
 [discussion #45](https://github.com/wazootech/worlds-client-ts/discussions/45).
 Scale guidance for very large graphs:
-[#68](https://github.com/wazootech/worlds-client-ts/issues/68).
+[#68](https://github.com/wazootech/worlds-client-ts/issues/68). SPARQL
+query-shape helpers live in
+[`libsql-sparql-query-patterns.ts`](src/client/adapters/libsql/libsql-sparql-query-patterns.ts);
+see README **Scale and SPARQL query shape** and `examples/libsql-sparql-scale`.
 
 ### Decoupled store lifecycle via dependency injection
 

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ engine.
 Worlds delivers these features through an open-source TypeScript SDK.
 
 > [!IMPORTANT]
-> **JSR:** [`@worlds/client@0.0.5`](https://jsr.io/@worlds/client) is the
-> current published release. `main` may include later improvements (benchmark
-> preload, batched LibSQL hydration) until the next version is published.
+> **JSR:** [`@worlds/client@0.0.6`](https://jsr.io/@worlds/client) includes
+> batched LibSQL hydration, post-preload benchmark methodology, and scale SPARQL
+> query-shape helpers.
 >
 > **Production:** use Turso Cloud through `createLibsqlClient(...)` for scale.
 > Prefer hexastore SPARQL on LibSQL without mirroring the full graph into N3.
@@ -162,6 +162,44 @@ import { createLibsqlClient } from "@worlds/client/adapters/libsql";
 import { createLibsqlN3Client } from "@worlds/client/adapters/libsql/n3";
 ```
 
+### Scale and SPARQL query shape
+
+At millions of quads, pick the factory at integration time — there is no runtime
+SPARQL router ([#63](https://github.com/wazootech/worlds-client-ts/issues/63)).
+
+| Concern         | Production default                                                                                                                                                                                      |
+| :-------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Client factory  | `createLibsqlClient` — hexastore `LibsqlStore`, no full N3 mirror per request                                                                                                                           |
+| Hot-path SPARQL | Bind at least one term (subject, predicate, or object). Subject-bound property lookups match crossover **selective** shapes and stay index-friendly                                                     |
+| Avoid at scale  | Unbound `?s ?p ?o` (even with `LIMIT`) on `libsqlStore` — crossover **fullScan** degrades to hundreds of ms–seconds as quads grow ([#69](https://github.com/wazootech/worlds-client-ts/discussions/69)) |
+| N3 + Comunica   | `createLibsqlN3Client` only when you need in-memory N3; pass a warmed `store` hydrated **once per container**, not per HTTP request                                                                     |
+| Local crossover | `deno task bench` → `sparql-hexastore-crossover.bench.ts`; methodology in [`benchmarks/README.md`](benchmarks/README.md)                                                                                |
+
+Query helpers (same shapes as benchmarks):
+
+```typescript
+import {
+  createCappedUnboundTriplePatternSparqlQuery,
+  createLibsqlClient,
+  createSubjectBoundPropertiesSparqlQuery,
+} from "@worlds/client/adapters/libsql";
+
+const selectiveQuery = createSubjectBoundPropertiesSparqlQuery("urn:entity:0");
+// SELECT ?property ?object WHERE { <urn:entity:0> ?property ?object }
+
+const devScanQuery = createCappedUnboundTriplePatternSparqlQuery(100);
+// SELECT ?subject ?property ?object WHERE { ?subject ?property ?object } LIMIT 100
+```
+
+Runnable walkthrough: `deno task example:libsql-sparql-scale`
+([`examples/libsql-sparql-scale`](examples/libsql-sparql-scale)).
+
+**JSR:** [`@worlds/client@0.0.6`](https://jsr.io/@worlds/client) ships batched
+LibSQL hydration (`DEFAULT_HYDRATION_BATCH_SIZE = 1000`), SPARQL query-shape
+helpers, and production scale guidance
+([#68](https://github.com/wazootech/worlds-client-ts/issues/68)). Warm N3
+containers: `deno task example:libsql-n3-warm-container`.
+
 ## Build with Worlds SDK
 
 Include Worlds as your semantic context layer.
@@ -211,6 +249,24 @@ deno task example:hello-world
 Full disk-based synchronization, ACID mutations, hybrid FTS + vector search, and
 optional SPARQL. This is the production-recommended path, including Turso Cloud
 deployments via `createLibsqlClient(...)`.
+
+### LibSQL SPARQL at scale
+
+Subject-bound vs capped-scan query shapes for large graphs
+([#68](https://github.com/wazootech/worlds-client-ts/issues/68)).
+
+```bash
+deno task example:libsql-sparql-scale
+```
+
+### LibSQL N3 warm container
+
+Reuse one hydrated `store` per process — not per HTTP request
+([#68](https://github.com/wazootech/worlds-client-ts/issues/68)).
+
+```bash
+deno task example:libsql-n3-warm-container
+```
 
 The LibSQL example wires `UniversalSentenceEncoderEmbeddingService` (USE lite,
 512 dimensions). Download offline model artifacts once, then run the example:

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -3,11 +3,11 @@
 Performance benchmarks for `@worlds/client`. **Local only** — there is no CI
 regression gate; compare results manually on the same OS and Deno version.
 
-| Resource                                                                       | Purpose                                             |
-| :----------------------------------------------------------------------------- | :-------------------------------------------------- |
-| [Discussion #69](https://github.com/wazootech/worlds-client-ts/discussions/69) | Canonical post-preload SPARQL crossover write-up    |
-| [Discussion #45](https://github.com/wazootech/worlds-client-ts/discussions/45) | Earlier crossover context (pre-preload methodology) |
-| [#68](https://github.com/wazootech/worlds-client-ts/issues/68)                 | Millions-of-quads production guidance (in progress) |
+| Resource                                                                       | Purpose                                                        |
+| :----------------------------------------------------------------------------- | :------------------------------------------------------------- |
+| [Discussion #69](https://github.com/wazootech/worlds-client-ts/discussions/69) | Canonical post-preload SPARQL crossover write-up               |
+| [Discussion #45](https://github.com/wazootech/worlds-client-ts/discussions/45) | Earlier crossover context (pre-preload methodology)            |
+| [#68](https://github.com/wazootech/worlds-client-ts/issues/68)                 | Millions-of-quads production guidance (README + query helpers) |
 
 Do not comment on closed perf threads
 ([#2](https://github.com/wazootech/worlds-client-ts/issues/2),
@@ -16,7 +16,7 @@ Do not comment on closed perf threads
 [#11](https://github.com/wazootech/worlds-client-ts/issues/11)). File a new
 issue with before/after `deno bench` output instead.
 
-**JSR:** [`@worlds/client@0.0.5`](https://jsr.io/@worlds/client) is published.
+**JSR:** [`@worlds/client@0.0.6`](https://jsr.io/@worlds/client) is published.
 Tables below reflect **main** branch methodology (module preload, batched
 hydration); they are not a substitute for re-running on your machine.
 

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@worlds/client",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "nodeModulesDir": "auto",
   "exports": {
     ".": "./src/mod.ts",
@@ -40,13 +40,14 @@
     "./vendor/jsonld-context-parser"
   ],
   "exclude": [
-    "vendor/jsonld-context-parser/**",
-    ".prior-art"
+    "vendor/jsonld-context-parser/**"
   ],
   "tasks": {
     "download:tfjs-use": "deno run -A ./src/client/adapters/tfjs-universal-sentence-encoder/download-tfjs-use.ts",
     "example:hello-world": "deno -A ./examples/hello-world/main.ts",
     "example:libsql-hello-world": "deno -A ./examples/libsql-hello-world/main.ts",
+    "example:libsql-sparql-scale": "deno -A ./examples/libsql-sparql-scale/main.ts",
+    "example:libsql-n3-warm-container": "deno -A ./examples/libsql-n3-warm-container/main.ts",
     "example:denokv-hello-world": "deno -A --unstable-kv ./examples/denokv-hello-world/main.ts",
     "example:ai-sdk-hello-world": "deno -A --env ./examples/ai-sdk-hello-world/main.ts",
     "fmt": "deno fmt",

--- a/examples/libsql-hello-world/main.ts
+++ b/examples/libsql-hello-world/main.ts
@@ -1,6 +1,9 @@
 import { createClient } from "@libsql/client";
 import { ComunicaSparqlEngine } from "@worlds/client/adapters/comunica";
-import { createLibsqlClient } from "@worlds/client/adapters/libsql";
+import {
+  createLibsqlClient,
+  createSubjectBoundPropertiesSparqlQuery,
+} from "@worlds/client/adapters/libsql";
 import { UniversalSentenceEncoderEmbeddingService } from "@worlds/client/adapters/tfjs-universal-sentence-encoder";
 import { QueryEngine } from "@comunica/query-sparql-rdfjs-lite";
 import { DataFactory } from "n3";
@@ -97,9 +100,9 @@ if (import.meta.main) {
   }
   console.log("\nTop match is the garden/cat quad (hybrid vector search OK).");
 
-  console.log("\nExecuting SPARQL query...");
+  console.log("\nExecuting subject-bound SPARQL query...");
   const sparqlResponse = await client.sparql({
-    query: "SELECT ?s ?p ?o WHERE { ?s ?p ?o }",
+    query: createSubjectBoundPropertiesSparqlQuery("urn:animal:cat"),
   });
   console.log(JSON.stringify(sparqlResponse, null, 2));
 }

--- a/examples/libsql-n3-warm-container/README.md
+++ b/examples/libsql-n3-warm-container/README.md
@@ -1,0 +1,16 @@
+# LibSQL N3 warm container
+
+Demonstrates [#68](https://github.com/wazootech/worlds-client-ts/issues/68):
+hydrate LibSQL into N3 **once per container**, then pass the same `store` into
+`createLibsqlN3Client` for each request.
+
+```bash
+deno task example:libsql-n3-warm-container
+```
+
+Contrast with per-request hydration (anti-pattern at scale): omit `store` and
+let `createLibsqlN3Client` call `hydrateStoreFromLibsql` on every boot.
+
+See README **Scale and SPARQL query shape** and
+`deno task example:libsql-sparql-scale` for hexastore (`createLibsqlClient`)
+guidance.

--- a/examples/libsql-n3-warm-container/main.ts
+++ b/examples/libsql-n3-warm-container/main.ts
@@ -1,0 +1,80 @@
+import { createClient } from "@libsql/client";
+import { QueryEngine } from "@comunica/query-sparql-rdfjs-lite";
+import { ComunicaSparqlEngine } from "@worlds/client/adapters/comunica";
+import {
+  createSubjectBoundPropertiesSparqlQuery,
+  hydrateStoreFromLibsql,
+} from "@worlds/client/adapters/libsql";
+import { createLibsqlN3Client } from "@worlds/client/adapters/libsql/n3";
+import { DataFactory, Store } from "n3";
+
+const { quad, namedNode, literal } = DataFactory;
+
+/** warmSubjectIri is the entity hydrated once and queried across simulated requests. */
+const warmSubjectIri = "urn:demo:warm:entity:0";
+
+/**
+ * Simulates a container that hydrates LibSQL into N3 once, then reuses the same `store`
+ * for every request ([#68](https://github.com/wazootech/worlds-client-ts/issues/68)).
+ */
+async function createRequestClient(
+  databaseClient: ReturnType<typeof createClient>,
+  warmedStore: Store,
+) {
+  return await createLibsqlN3Client({
+    client: databaseClient,
+    store: warmedStore,
+    createSparqlEngine: ({ store }) =>
+      new ComunicaSparqlEngine({
+        queryEngine: new QueryEngine(),
+        store,
+      }),
+  });
+}
+
+if (import.meta.main) {
+  const databaseClient = createClient({ url: ":memory:" });
+
+  const seedClient = await createLibsqlN3Client({ client: databaseClient });
+  await seedClient.import({
+    source: {
+      kind: "quads",
+      quads: [
+        quad(
+          namedNode(warmSubjectIri),
+          namedNode("urn:demo:warm:predicate"),
+          literal("Hydrate once per container; reuse store on each request."),
+        ),
+      ],
+    },
+    mode: "merge",
+  });
+
+  console.log("Container boot: single hydration into N3...");
+  const warmedStore = new Store();
+  const hydratedQuadCount = await hydrateStoreFromLibsql(
+    databaseClient,
+    warmedStore,
+  );
+  console.log(`Hydrated ${hydratedQuadCount} quad(s) into reused store.`);
+
+  console.log("\nSimulated request 1 (no re-hydration):");
+  const firstRequestClient = await createRequestClient(
+    databaseClient,
+    warmedStore,
+  );
+  const firstResponse = await firstRequestClient.sparql({
+    query: createSubjectBoundPropertiesSparqlQuery(warmSubjectIri),
+  });
+  console.log(JSON.stringify(firstResponse, null, 2));
+
+  console.log("\nSimulated request 2 (same warmed store):");
+  const secondRequestClient = await createRequestClient(
+    databaseClient,
+    warmedStore,
+  );
+  const secondResponse = await secondRequestClient.sparql({
+    query: createSubjectBoundPropertiesSparqlQuery(warmSubjectIri),
+  });
+  console.log(JSON.stringify(secondResponse, null, 2));
+}

--- a/examples/libsql-sparql-scale/README.md
+++ b/examples/libsql-sparql-scale/README.md
@@ -1,0 +1,24 @@
+# LibSQL SPARQL at scale
+
+Runnable companion to
+[#68](https://github.com/wazootech/worlds-client-ts/issues/68) and README
+**Scale and SPARQL query shape**.
+
+```bash
+deno task example:libsql-sparql-scale
+```
+
+Uses `createLibsqlClient` with query helpers from
+`@worlds/client/adapters/libsql`:
+
+- **Selective:** `createSubjectBoundPropertiesSparqlQuery(subjectIri)` — default
+  for production hot paths.
+- **Capped scan:** `createCappedUnboundTriplePatternSparqlQuery(limit)` — small
+  graphs and debugging only.
+
+Crossover numbers and methodology:
+[discussion #69](https://github.com/wazootech/worlds-client-ts/discussions/69),
+[`benchmarks/README.md`](../../benchmarks/README.md).
+
+**JSR:** `@worlds/client@0.0.6` ships batched hydration, query-shape helpers,
+and scale guidance.

--- a/examples/libsql-sparql-scale/main.ts
+++ b/examples/libsql-sparql-scale/main.ts
@@ -1,0 +1,68 @@
+import { createClient } from "@libsql/client";
+import { QueryEngine } from "@comunica/query-sparql-rdfjs-lite";
+import { ComunicaSparqlEngine } from "@worlds/client/adapters/comunica";
+import {
+  createCappedUnboundTriplePatternSparqlQuery,
+  createLibsqlClient,
+  createSubjectBoundPropertiesSparqlQuery,
+} from "@worlds/client/adapters/libsql";
+import { DataFactory } from "n3";
+
+const { quad, namedNode, literal } = DataFactory;
+
+/** exampleSubjectIri is the grounded subject used for production-style SPARQL in this demo. */
+const exampleSubjectIri = "urn:demo:entity:0";
+
+/**
+ * Demonstrates LibSQL hexastore SPARQL query shapes recommended at scale ([#68](https://github.com/wazootech/worlds-client-ts/issues/68)):
+ * subject-bound selective queries on `createLibsqlClient`, and why unbound `?s ?p ?o` scans are dev-only.
+ */
+if (import.meta.main) {
+  const databaseClient = createClient({ url: ":memory:" });
+  const queryEngine = new QueryEngine();
+
+  const client = await createLibsqlClient({
+    client: databaseClient,
+    createSparqlEngine: ({ libsqlStore }) =>
+      new ComunicaSparqlEngine({ queryEngine, store: libsqlStore }),
+  });
+
+  await client.import({
+    source: {
+      kind: "quads",
+      quads: [
+        quad(
+          namedNode(exampleSubjectIri),
+          namedNode("urn:demo:predicate"),
+          literal("Production paths bind at least one term in hot-path BGPs."),
+        ),
+        quad(
+          namedNode("urn:demo:entity:1"),
+          namedNode("urn:demo:predicate"),
+          literal(
+            "Other entities stay reachable via bound lookups, not full scans.",
+          ),
+        ),
+      ],
+    },
+    mode: "merge",
+  });
+
+  const selectiveSparqlQuery = createSubjectBoundPropertiesSparqlQuery(
+    exampleSubjectIri,
+  );
+  console.log("Selective (production-style):", selectiveSparqlQuery);
+  const selectiveResponse = await client.sparql({
+    query: selectiveSparqlQuery,
+  });
+  console.log(JSON.stringify(selectiveResponse, null, 2));
+
+  const devOnlyScanQuery = createCappedUnboundTriplePatternSparqlQuery(100);
+  console.log("\nCapped full scan (dev/small graphs only):", devOnlyScanQuery);
+  const scanResponse = await client.sparql({ query: devOnlyScanQuery });
+  console.log(JSON.stringify(scanResponse, null, 2));
+
+  console.log(
+    "\nFor warm N3 containers: deno task example:libsql-n3-warm-container",
+  );
+}

--- a/src/client/adapters/libsql/libsql-sparql-query-patterns.test.ts
+++ b/src/client/adapters/libsql/libsql-sparql-query-patterns.test.ts
@@ -1,0 +1,33 @@
+import { assertEquals } from "@std/assert";
+
+import {
+  createCappedUnboundTriplePatternSparqlQuery,
+  createSubjectBoundPropertiesSparqlQuery,
+} from "./libsql-sparql-query-patterns.ts";
+
+Deno.test(
+  "createSubjectBoundPropertiesSparqlQuery - grounds subject in BGP",
+  () => {
+    const sparqlQuery = createSubjectBoundPropertiesSparqlQuery(
+      "urn:entity:42",
+    );
+    assertEquals(
+      sparqlQuery,
+      "SELECT ?property ?object WHERE { <urn:entity:42> ?property ?object }",
+    );
+  },
+);
+
+Deno.test(
+  "createCappedUnboundTriplePatternSparqlQuery - floors limit to at least 1",
+  () => {
+    assertEquals(
+      createCappedUnboundTriplePatternSparqlQuery(0),
+      "SELECT ?subject ?property ?object WHERE { ?subject ?property ?object } LIMIT 1",
+    );
+    assertEquals(
+      createCappedUnboundTriplePatternSparqlQuery(100),
+      "SELECT ?subject ?property ?object WHERE { ?subject ?property ?object } LIMIT 100",
+    );
+  },
+);

--- a/src/client/adapters/libsql/libsql-sparql-query-patterns.ts
+++ b/src/client/adapters/libsql/libsql-sparql-query-patterns.ts
@@ -1,0 +1,27 @@
+/**
+ * createSubjectBoundPropertiesSparqlQuery builds a hexastore-friendly BGP with a grounded subject IRI.
+ *
+ * Prefer this shape on `createLibsqlClient` / `LibsqlStore` at production scale. Post-preload
+ * benchmarks label it **selective**; see
+ * [discussion #69](https://github.com/wazootech/worlds-client-ts/discussions/69).
+ */
+export function createSubjectBoundPropertiesSparqlQuery(
+  subjectIri: string,
+): string {
+  return `SELECT ?property ?object WHERE { <${subjectIri}> ?property ?object }`;
+}
+
+/**
+ * createCappedUnboundTriplePatternSparqlQuery builds `?s ?p ?o` with a LIMIT cap.
+ *
+ * Suitable for small corpora and local debugging only. On large graphs, libsqlStore pays wide SQL
+ * and row materialization (benchmark **fullScan**); hydrate+N3 still wins that micro-benchmark but
+ * both paths should avoid unbound triple patterns in production hot paths — see
+ * [#68](https://github.com/wazootech/worlds-client-ts/issues/68).
+ */
+export function createCappedUnboundTriplePatternSparqlQuery(
+  resultLimit: number,
+): string {
+  const safeLimit = Math.max(1, Math.floor(resultLimit));
+  return `SELECT ?subject ?property ?object WHERE { ?subject ?property ?object } LIMIT ${safeLimit}`;
+}

--- a/src/client/adapters/libsql/mod.ts
+++ b/src/client/adapters/libsql/mod.ts
@@ -6,3 +6,4 @@ export * from "./hydrate-store-from-libsql.ts";
 export * from "./commit-patch-to-libsql.ts";
 export * from "./libsql-query-builder.ts";
 export * from "./libsql-store.ts";
+export * from "./libsql-sparql-query-patterns.ts";


### PR DESCRIPTION
## Summary

- Add README **Scale and SPARQL query shape** with production defaults from [#68](https://github.com/wazootech/worlds-client-ts/issues/68) and crossover context from [discussion #69](https://github.com/wazootech/worlds-client-ts/discussions/69).
- Export `createSubjectBoundPropertiesSparqlQuery` and `createCappedUnboundTriplePatternSparqlQuery` from `@worlds/client/adapters/libsql`.
- Add `deno task example:libsql-sparql-scale` and `deno task example:libsql-n3-warm-container` (warm `store` reuse).
- Bump to `@worlds/client@0.0.6`; update benchmarks README #68 status.

No CI benchmark gate; no adaptive SPARQL router (#63).

## Test plan

- [x] `deno task ci`
- [x] `deno task example:libsql-sparql-scale`
- [x] `deno task example:libsql-n3-warm-container`