### PR TITLE
LibsqlStore: paged match reads and countQuads for Comunica

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -317,6 +317,8 @@ separate modules so hexastore deployments do not import N3 hydration:
 - **`createLibsqlClient`**
   ([`create-libsql-client.ts`](src/client/adapters/libsql/create-libsql-client.ts))
   — `LibsqlStore` + hexastore indexes; `createSparqlEngine({ libsqlStore })`.
+  `LibsqlStore.match` keyset-pages by `quads.id` (`matchPageSize`, default 1000).
+  Optional `countQuads` supplies Comunica join cardinality hints.
 - **`createLibsqlN3Client`** — import `@worlds/client/adapters/libsql/n3`
   ([`n3/create-libsql-n3-client.ts`](src/client/adapters/libsql/n3/create-libsql-n3-client.ts));
   hydrate → `proxyStore` → sync patches to LibSQL;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -317,8 +317,8 @@ separate modules so hexastore deployments do not import N3 hydration:
 - **`createLibsqlClient`**
   ([`create-libsql-client.ts`](src/client/adapters/libsql/create-libsql-client.ts))
   — `LibsqlStore` + hexastore indexes; `createSparqlEngine({ libsqlStore })`.
-  `LibsqlStore.match` keyset-pages by `quads.id` (`matchPageSize`, default 1000).
-  Optional `countQuads` supplies Comunica join cardinality hints.
+  `LibsqlStore.match` keyset-pages by `quads.id` (`matchPageSize`, default
+  1000). Optional `countQuads` supplies Comunica join cardinality hints.
 - **`createLibsqlN3Client`** — import `@worlds/client/adapters/libsql/n3`
   ([`n3/create-libsql-n3-client.ts`](src/client/adapters/libsql/n3/create-libsql-n3-client.ts));
   hydrate → `proxyStore` → sync patches to LibSQL;

--- a/src/client/adapters/libsql/create-libsql-client.ts
+++ b/src/client/adapters/libsql/create-libsql-client.ts
@@ -66,6 +66,7 @@ export async function createLibsqlClientOptions(
     options.client,
     queryBuilder,
     persistPatch,
+    { matchPageSize: options.matchPageSize },
   );
 
   const configuredSparqlEngine = options.createSparqlEngine?.({ libsqlStore });

--- a/src/client/adapters/libsql/create-libsql-client.ts
+++ b/src/client/adapters/libsql/create-libsql-client.ts
@@ -62,12 +62,12 @@ export async function createLibsqlClientOptions(
     });
   };
 
-  const libsqlStore = new LibsqlStore(
-    options.client,
+  const libsqlStore = new LibsqlStore({
+    client: options.client,
     queryBuilder,
-    persistPatch,
-    { matchPageSize: options.matchPageSize },
-  );
+    commitHandler: persistPatch,
+    matchPageSize: options.matchPageSize,
+  });
 
   const configuredSparqlEngine = options.createSparqlEngine?.({ libsqlStore });
 

--- a/src/client/adapters/libsql/hydrate-store-from-libsql.ts
+++ b/src/client/adapters/libsql/hydrate-store-from-libsql.ts
@@ -3,7 +3,10 @@ import type { Store } from "n3";
 import { DataFactory } from "n3";
 import type * as rdfjs from "@rdfjs/types";
 import type { QuadFilter } from "@/client/quad-store/mod.ts";
-import { defaultLibsqlQueryBuilder } from "./libsql-query-builder.ts";
+import {
+  DEFAULT_LIBSQL_MATCH_PAGE_SIZE,
+  defaultLibsqlQueryBuilder,
+} from "./libsql-query-builder.ts";
 
 const { namedNode, literal, blankNode, defaultGraph, quad } = DataFactory;
 
@@ -19,33 +22,47 @@ export async function hydrateStoreFromLibsql(
   target: Store,
   filter?: QuadFilter,
 ): Promise<number> {
-  const query = defaultLibsqlQueryBuilder.buildHydrateQuery(filter);
-  const resultSet = await client.execute(query);
-
-  if (!resultSet.rows.length) return 0;
-
+  const pageSize = DEFAULT_LIBSQL_MATCH_PAGE_SIZE;
   const batchQuads: rdfjs.Quad[] = [];
   let hydratedCount = 0;
+  let afterQuadId: string | undefined;
 
-  for (const row of resultSet.rows) {
-    try {
-      const subject = reconstructSubject(row);
-      const predicate = namedNode(String(row.p));
-      const object = reconstructObject(row);
-      const graph = reconstructGraph(row);
+  for (;;) {
+    const query = defaultLibsqlQueryBuilder.buildHydrateQuadsPageQuery(filter, {
+      afterQuadId,
+      limit: pageSize,
+    });
+    const resultSet = await client.execute(query);
 
-      batchQuads.push(quad(subject, predicate, object, graph));
-      hydratedCount++;
+    if (resultSet.rows.length === 0) {
+      break;
+    }
 
-      if (batchQuads.length >= DEFAULT_HYDRATION_BATCH_SIZE) {
-        target.addQuads(batchQuads);
-        batchQuads.length = 0;
+    for (const row of resultSet.rows) {
+      afterQuadId = String(row.id);
+      try {
+        const subject = reconstructSubject(row);
+        const predicate = namedNode(String(row.p));
+        const object = reconstructObject(row);
+        const graph = reconstructGraph(row);
+
+        batchQuads.push(quad(subject, predicate, object, graph));
+        hydratedCount++;
+
+        if (batchQuads.length >= DEFAULT_HYDRATION_BATCH_SIZE) {
+          target.addQuads(batchQuads);
+          batchQuads.length = 0;
+        }
+      } catch (err) {
+        console.warn(
+          `hydrateStoreFromLibsql: skipping corrupt row s="${row.s}"`,
+          err,
+        );
       }
-    } catch (err) {
-      console.warn(
-        `hydrateStoreFromLibsql: skipping corrupt row s="${row.s}"`,
-        err,
-      );
+    }
+
+    if (resultSet.rows.length < pageSize) {
+      break;
     }
   }
 

--- a/src/client/adapters/libsql/libsql-client-base-options.ts
+++ b/src/client/adapters/libsql/libsql-client-base-options.ts
@@ -26,4 +26,9 @@ export interface LibsqlClientBaseOptions {
    * vectorDimensions pins F32_BLOB width for chunk vectors and must match every embedding produced when embeddingService is set (default 32).
    */
   vectorDimensions?: number;
+
+  /**
+   * matchPageSize limits rows per LibsqlStore.match SQL round-trip on hexastore reads (default 1000).
+   */
+  matchPageSize?: number;
 }

--- a/src/client/adapters/libsql/libsql-quad-pattern-sql.ts
+++ b/src/client/adapters/libsql/libsql-quad-pattern-sql.ts
@@ -8,9 +8,9 @@ const rdfLangStringIri =
 const xsdStringIri = "http://www.w3.org/2001/XMLSchema#string";
 
 /**
- * LibsqlSpogPattern holds optional bound RDF/JS terms for hexastore quad pattern matching.
+ * LibsqlQuadPattern holds optional bound RDF/JS terms for hexastore quad pattern matching.
  */
-export interface LibsqlSpogPattern {
+export interface LibsqlQuadPattern {
   /** subject is the optional bound subject term. */
   subject: rdfjs.Term | null;
   /** predicate is the optional bound predicate term. */
@@ -22,9 +22,9 @@ export interface LibsqlSpogPattern {
 }
 
 /**
- * LibsqlSpogWhereClause is the SQL fragment and bound args for a quad pattern filter.
+ * LibsqlQuadPatternWhereClause is the SQL fragment and bound args for a quad pattern filter.
  */
-export interface LibsqlSpogWhereClause {
+export interface LibsqlQuadPatternWhereClause {
   /** conditions are AND-joined predicates without a leading WHERE. */
   conditions: string[];
   /** args are bound parameters in statement order. */
@@ -32,11 +32,11 @@ export interface LibsqlSpogWhereClause {
 }
 
 /**
- * buildLibsqlSpogWhereClause constructs WHERE conditions and args for a hexastore SPOG pattern.
+ * buildLibsqlQuadPatternWhereClause constructs WHERE conditions and args for a hexastore quad pattern.
  */
-export function buildLibsqlSpogWhereClause(
-  pattern: LibsqlSpogPattern,
-): LibsqlSpogWhereClause {
+export function buildLibsqlQuadPatternWhereClause(
+  pattern: LibsqlQuadPattern,
+): LibsqlQuadPatternWhereClause {
   const conditions: string[] = [];
   const args: (string | null)[] = [];
 

--- a/src/client/adapters/libsql/libsql-query-builder.test.ts
+++ b/src/client/adapters/libsql/libsql-query-builder.test.ts
@@ -8,9 +8,11 @@ Deno.test("buildHexastoreIndexes - returns 7 covering index DDL statements", () 
   const indexes = testLibsqlQueryBuilder.buildHexastoreIndexes();
   assertEquals(indexes.length, 7);
 
-  const spogIndex = indexes.find((s: string) => s.includes("idx_quads_spog"));
+  const subjectFirstQuadPatternIndex = indexes.find((s: string) =>
+    s.includes("idx_quads_spog")
+  );
   assertEquals(
-    spogIndex,
+    subjectFirstQuadPatternIndex,
     "CREATE INDEX IF NOT EXISTS idx_quads_spog ON quads(s, p, o, g)",
   );
 

--- a/src/client/adapters/libsql/libsql-query-builder.ts
+++ b/src/client/adapters/libsql/libsql-query-builder.ts
@@ -1,5 +1,12 @@
 import type { QuadFilter } from "@/client/quad-store/mod.ts";
 import type { SearchRequest } from "@/client/search-index/mod.ts";
+import {
+  buildLibsqlSpogWhereClause,
+  type LibsqlSpogPattern,
+} from "./libsql-spog-pattern-sql.ts";
+
+/** DEFAULT_LIBSQL_MATCH_PAGE_SIZE caps rows per hexastore match SQL round-trip. */
+export const DEFAULT_LIBSQL_MATCH_PAGE_SIZE = 1000;
 
 /** Maximum embedding dimensions accepted by LibsqlQueryBuilder (LibSQL / resource guardrail). */
 const LIBSQL_QUERY_BUILDER_MAX_VECTOR_DIMENSIONS = 8192;
@@ -217,58 +224,86 @@ export class LibsqlQueryBuilder {
   public buildHydrateQuery(
     filter?: QuadFilter,
   ): { sql: string; args: string[] } {
-    const whereClauses: string[] = [];
-    const filterArgs: string[] = [];
+    return this.buildHydrateQuadsPageQuery(filter, {});
+  }
 
-    const filterConfigurations = [
-      {
-        values: filter?.exclude?.subjects,
-        column: "s",
-        operator: "NOT IN",
-      },
-      {
-        values: filter?.exclude?.predicates,
-        column: "p",
-        operator: "NOT IN",
-      },
-      {
-        values: filter?.exclude?.graphs,
-        column: "g",
-        operator: "NOT IN",
-      },
-      {
-        values: filter?.include?.subjects,
-        column: "s",
-        operator: "IN",
-      },
-      {
-        values: filter?.include?.predicates,
-        column: "p",
-        operator: "IN",
-      },
-      {
-        values: filter?.include?.graphs,
-        column: "g",
-        operator: "IN",
-      },
-    ] as const;
+  /**
+   * buildMatchQuadsQuery returns SQL to read quads for a pattern, optionally keyset-paged by id.
+   */
+  public buildMatchQuadsQuery(
+    pattern: LibsqlSpogPattern,
+    pageOptions?: { afterQuadId?: string; limit?: number },
+  ): { sql: string; args: (string | null)[] } {
+    const { conditions, args } = buildLibsqlSpogWhereClause(pattern);
 
-    for (const { values, column, operator } of filterConfigurations) {
-      if (values?.length) {
-        const placeholders = generatePlaceholders(values.length);
-        whereClauses.push(`${column} ${operator} (${placeholders})`);
-        filterArgs.push(...values);
-      }
+    if (pageOptions?.afterQuadId) {
+      conditions.push("id > ?");
+      args.push(pageOptions.afterQuadId);
+    }
+
+    const whereClause = conditions.length > 0
+      ? `WHERE ${conditions.join(" AND ")}`
+      : "";
+
+    let limitClause = "";
+    if (pageOptions?.limit != null) {
+      limitClause = " LIMIT ?";
+      args.push(String(Math.max(1, Math.floor(pageOptions.limit))));
+    }
+
+    return {
+      sql:
+        `SELECT id, s, s_type, p, o, o_type, o_datatype, o_lang, g, g_type FROM quads ${whereClause} ORDER BY id ASC${limitClause}`,
+      args,
+    };
+  }
+
+  /**
+   * buildCountQuadsQuery returns SQL to count quads matching a hexastore pattern.
+   */
+  public buildCountQuadsQuery(
+    pattern: LibsqlSpogPattern,
+  ): { sql: string; args: (string | null)[] } {
+    const { conditions, args } = buildLibsqlSpogWhereClause(pattern);
+    const whereClause = conditions.length > 0
+      ? `WHERE ${conditions.join(" AND ")}`
+      : "";
+
+    return {
+      sql: `SELECT COUNT(*) AS count FROM quads ${whereClause}`,
+      args,
+    };
+  }
+
+  /**
+   * buildHydrateQuadsPageQuery returns a keyset page of quads for N3 hydration.
+   */
+  public buildHydrateQuadsPageQuery(
+    filter: QuadFilter | undefined,
+    pageOptions: { afterQuadId?: string; limit?: number },
+  ): { sql: string; args: string[] } {
+    const { whereClauses, filterArgs } = buildHydrateFilterClauses(filter);
+    const args = [...filterArgs];
+
+    if (pageOptions.afterQuadId) {
+      whereClauses.push("id > ?");
+      args.push(pageOptions.afterQuadId);
     }
 
     const whereFilter = whereClauses.length > 0
       ? `WHERE ${whereClauses.join(" AND ")}`
       : "";
 
+    let limitClause = "";
+    if (pageOptions.limit != null) {
+      limitClause = " LIMIT ?";
+      args.push(String(Math.max(1, Math.floor(pageOptions.limit))));
+    }
+
     return {
       sql:
-        `SELECT s, s_type, p, o, o_type, o_datatype, o_lang, g, g_type FROM quads ${whereFilter}`,
-      args: filterArgs,
+        `SELECT id, s, s_type, p, o, o_type, o_datatype, o_lang, g, g_type FROM quads ${whereFilter} ORDER BY id ASC${limitClause}`,
+      args,
     };
   }
 
@@ -497,6 +532,60 @@ export class LibsqlQueryBuilder {
       args: [],
     };
   }
+}
+
+/**
+ * buildHydrateFilterClauses builds WHERE fragments for quad-filtered hydration reads.
+ */
+function buildHydrateFilterClauses(filter: QuadFilter | undefined): {
+  whereClauses: string[];
+  filterArgs: string[];
+} {
+  const whereClauses: string[] = [];
+  const filterArgs: string[] = [];
+
+  const filterConfigurations = [
+    {
+      values: filter?.exclude?.subjects,
+      column: "s",
+      operator: "NOT IN",
+    },
+    {
+      values: filter?.exclude?.predicates,
+      column: "p",
+      operator: "NOT IN",
+    },
+    {
+      values: filter?.exclude?.graphs,
+      column: "g",
+      operator: "NOT IN",
+    },
+    {
+      values: filter?.include?.subjects,
+      column: "s",
+      operator: "IN",
+    },
+    {
+      values: filter?.include?.predicates,
+      column: "p",
+      operator: "IN",
+    },
+    {
+      values: filter?.include?.graphs,
+      column: "g",
+      operator: "IN",
+    },
+  ] as const;
+
+  for (const { values, column, operator } of filterConfigurations) {
+    if (values?.length) {
+      const placeholders = generatePlaceholders(values.length);
+      whereClauses.push(`${column} ${operator} (${placeholders})`);
+      filterArgs.push(...values);
+    }
+  }
+
+  return { whereClauses, filterArgs };
 }
 
 /**

--- a/src/client/adapters/libsql/libsql-query-builder.ts
+++ b/src/client/adapters/libsql/libsql-query-builder.ts
@@ -1,9 +1,9 @@
 import type { QuadFilter } from "@/client/quad-store/mod.ts";
 import type { SearchRequest } from "@/client/search-index/mod.ts";
 import {
-  buildLibsqlSpogWhereClause,
-  type LibsqlSpogPattern,
-} from "./libsql-spog-pattern-sql.ts";
+  buildLibsqlQuadPatternWhereClause,
+  type LibsqlQuadPattern,
+} from "./libsql-quad-pattern-sql.ts";
 
 /** DEFAULT_LIBSQL_MATCH_PAGE_SIZE caps rows per hexastore match SQL round-trip. */
 export const DEFAULT_LIBSQL_MATCH_PAGE_SIZE = 1000;
@@ -92,7 +92,7 @@ export class LibsqlQueryBuilder {
 
   /**
    * buildHexastoreIndexes returns DDL for 7 covering composite indexes on the quads table
-   * (6 SPOG permutations + 1 GPSO for graph-scoped access) enabling any triple or quad pattern
+   * (six subject-predicate-object-graph index orders + GPSO for graph-scoped access) enabling any quad pattern
    * to be resolved via a single index seek.
    */
   public buildHexastoreIndexes(): string[] {
@@ -231,10 +231,10 @@ export class LibsqlQueryBuilder {
    * buildMatchQuadsQuery returns SQL to read quads for a pattern, optionally keyset-paged by id.
    */
   public buildMatchQuadsQuery(
-    pattern: LibsqlSpogPattern,
+    pattern: LibsqlQuadPattern,
     pageOptions?: { afterQuadId?: string; limit?: number },
   ): { sql: string; args: (string | null)[] } {
-    const { conditions, args } = buildLibsqlSpogWhereClause(pattern);
+    const { conditions, args } = buildLibsqlQuadPatternWhereClause(pattern);
 
     if (pageOptions?.afterQuadId) {
       conditions.push("id > ?");
@@ -262,9 +262,9 @@ export class LibsqlQueryBuilder {
    * buildCountQuadsQuery returns SQL to count quads matching a hexastore pattern.
    */
   public buildCountQuadsQuery(
-    pattern: LibsqlSpogPattern,
+    pattern: LibsqlQuadPattern,
   ): { sql: string; args: (string | null)[] } {
-    const { conditions, args } = buildLibsqlSpogWhereClause(pattern);
+    const { conditions, args } = buildLibsqlQuadPatternWhereClause(pattern);
     const whereClause = conditions.length > 0
       ? `WHERE ${conditions.join(" AND ")}`
       : "";

--- a/src/client/adapters/libsql/libsql-spog-pattern-sql.ts
+++ b/src/client/adapters/libsql/libsql-spog-pattern-sql.ts
@@ -1,0 +1,93 @@
+import type * as rdfjs from "@rdfjs/types";
+
+/** rdfLangStringIri is the RDF datatype for language-tagged literals in N3/RDF/JS. */
+const rdfLangStringIri =
+  "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString";
+
+/** xsdStringIri is the XSD string datatype IRI. */
+const xsdStringIri = "http://www.w3.org/2001/XMLSchema#string";
+
+/**
+ * LibsqlSpogPattern holds optional bound RDF/JS terms for hexastore quad pattern matching.
+ */
+export interface LibsqlSpogPattern {
+  /** subject is the optional bound subject term. */
+  subject: rdfjs.Term | null;
+  /** predicate is the optional bound predicate term. */
+  predicate: rdfjs.Term | null;
+  /** object is the optional bound object term. */
+  object: rdfjs.Term | null;
+  /** graph is the optional bound graph term. */
+  graph: rdfjs.Term | null;
+}
+
+/**
+ * LibsqlSpogWhereClause is the SQL fragment and bound args for a quad pattern filter.
+ */
+export interface LibsqlSpogWhereClause {
+  /** conditions are AND-joined predicates without a leading WHERE. */
+  conditions: string[];
+  /** args are bound parameters in statement order. */
+  args: (string | null)[];
+}
+
+/**
+ * buildLibsqlSpogWhereClause constructs WHERE conditions and args for a hexastore SPOG pattern.
+ */
+export function buildLibsqlSpogWhereClause(
+  pattern: LibsqlSpogPattern,
+): LibsqlSpogWhereClause {
+  const conditions: string[] = [];
+  const args: (string | null)[] = [];
+
+  appendTermCondition(conditions, args, "s", "s_type", pattern.subject);
+  appendTermCondition(conditions, args, "o", "o_type", pattern.object);
+
+  if (pattern.predicate) {
+    conditions.push("p = ?");
+    args.push(pattern.predicate.value);
+  }
+
+  appendTermCondition(conditions, args, "g", "g_type", pattern.graph);
+
+  return { conditions, args };
+}
+
+/**
+ * appendTermCondition adds WHERE clauses and args for a term that may be a NamedNode, BlankNode, or Literal.
+ */
+function appendTermCondition(
+  conditions: string[],
+  args: (string | null)[],
+  valueColumn: string,
+  typeColumn: string,
+  term: rdfjs.Term | null,
+): void {
+  if (!term) return;
+
+  conditions.push(`${valueColumn} = ?`);
+  args.push(term.value);
+
+  conditions.push(`${typeColumn} = ?`);
+  args.push(term.termType);
+
+  if (term.termType === "Literal") {
+    const literalTerm = term as rdfjs.Literal;
+    if (literalTerm.language) {
+      conditions.push(`o_lang = ?`);
+      args.push(literalTerm.language);
+    }
+    if (literalTerm.datatype) {
+      const datatypeValue = literalTerm.datatype.value;
+      if (
+        datatypeValue === xsdStringIri ||
+        datatypeValue === rdfLangStringIri
+      ) {
+        conditions.push(`o_datatype IS NULL`);
+      } else {
+        conditions.push(`o_datatype = ?`);
+        args.push(datatypeValue);
+      }
+    }
+  }
+}

--- a/src/client/adapters/libsql/libsql-store.test.ts
+++ b/src/client/adapters/libsql/libsql-store.test.ts
@@ -848,3 +848,72 @@ Deno.test("LibsqlStore.import - stream buffers all quads, commit persists them",
     2,
   );
 });
+
+Deno.test("LibsqlStore.match - keyset pages return the full result set", async () => {
+  const db = createClient({ url: ":memory:" });
+  await setupSchema(db);
+  for (let index = 0; index < 5; index++) {
+    await seedQuad(db, {
+      id: `id-${String(index).padStart(4, "0")}`,
+      s: `urn:subject-${index}`,
+      p: "urn:predicate",
+      o: `value-${index}`,
+    });
+  }
+
+  const store = new LibsqlStore(db, testBuilder, undefined, {
+    matchPageSize: 2,
+  });
+  const results = await collectStream(store.match(null, null, null, null));
+  assertEquals(results.length, 5);
+});
+
+Deno.test("LibsqlStore.countQuads - returns exact counts for bound patterns", async () => {
+  const db = createClient({ url: ":memory:" });
+  await setupSchema(db);
+  await seedQuad(db, {
+    id: "hash-a",
+    s: "urn:alice",
+    p: "urn:knows",
+    o: "urn:bob",
+    o_type: "NamedNode",
+  });
+  await seedQuad(db, {
+    id: "hash-b",
+    s: "urn:alice",
+    p: "urn:age",
+    o: "30",
+  });
+  await seedQuad(db, {
+    id: "hash-c",
+    s: "urn:carol",
+    p: "urn:knows",
+    o: "urn:dave",
+    o_type: "NamedNode",
+  });
+
+  const store = new LibsqlStore(db, testBuilder);
+
+  assertEquals(await store.countQuads(null, null, null, null), 3);
+  assertEquals(
+    await store.countQuads(namedNode("urn:alice"), null, null, null),
+    2,
+  );
+  assertEquals(
+    await store.countQuads(
+      namedNode("urn:alice"),
+      namedNode("urn:knows"),
+      null,
+      null,
+    ),
+    1,
+  );
+
+  const streamCount = (await collectStream(
+    store.match(namedNode("urn:alice"), null, null, null),
+  )).length;
+  assertEquals(
+    await store.countQuads(namedNode("urn:alice"), null, null, null),
+    streamCount,
+  );
+});

--- a/src/client/adapters/libsql/libsql-store.test.ts
+++ b/src/client/adapters/libsql/libsql-store.test.ts
@@ -5,11 +5,26 @@ import { DataFactory } from "n3";
 import type * as rdfjs from "@rdfjs/types";
 import { Readable } from "node:stream";
 import { LibsqlQueryBuilder } from "./libsql-query-builder.ts";
+import type { CommitHandler } from "./libsql-store.ts";
 import { LibsqlStore } from "./libsql-store.ts";
 
 const { namedNode, literal, blankNode, quad } = DataFactory;
 
 const testBuilder = new LibsqlQueryBuilder(32);
+
+function createTestLibsqlStore(
+  client: ReturnType<typeof createClient>,
+  queryBuilder: LibsqlQueryBuilder,
+  commitHandler?: CommitHandler,
+  matchPageSize?: number,
+): LibsqlStore {
+  return new LibsqlStore({
+    client,
+    queryBuilder,
+    commitHandler,
+    matchPageSize,
+  });
+}
 
 async function setupSchema(db: ReturnType<typeof createClient>): Promise<void> {
   await db.execute(testBuilder.buildLibsqlQuadsTable());
@@ -72,7 +87,7 @@ function collectStream(
 Deno.test("LibsqlStore.match - empty store returns empty stream", async () => {
   const db = createClient({ url: ":memory:" });
   await setupSchema(db);
-  const store = new LibsqlStore(db, testBuilder);
+  const store = createTestLibsqlStore(db, testBuilder);
 
   const results = await collectStream(store.match(null, null, null, null));
   assertEquals(results.length, 0);
@@ -91,7 +106,7 @@ Deno.test("LibsqlStore.match - all four terms bound returns exact quad", async (
     g: "urn:graph1",
     g_type: "NamedNode",
   });
-  const store = new LibsqlStore(db, testBuilder);
+  const store = createTestLibsqlStore(db, testBuilder);
 
   const results = await collectStream(store.match(
     namedNode("urn:alice"),
@@ -114,7 +129,7 @@ Deno.test("LibsqlStore.match - by subject only returns matching quads", async ()
   await seedQuad(db, { id: "h1", s: "urn:a", p: "urn:p1", o: "o1" });
   await seedQuad(db, { id: "h2", s: "urn:b", p: "urn:p2", o: "o2" });
   await seedQuad(db, { id: "h3", s: "urn:a", p: "urn:p3", o: "o3" });
-  const store = new LibsqlStore(db, testBuilder);
+  const store = createTestLibsqlStore(db, testBuilder);
 
   const results = await collectStream(
     store.match(namedNode("urn:a"), null, null, null),
@@ -132,7 +147,7 @@ Deno.test("LibsqlStore.match - by predicate only uses PSO index", async () => {
   await seedQuad(db, { id: "h1", s: "urn:a", p: "urn:target", o: "o1" });
   await seedQuad(db, { id: "h2", s: "urn:b", p: "urn:other", o: "o2" });
   await seedQuad(db, { id: "h3", s: "urn:c", p: "urn:target", o: "o3" });
-  const store = new LibsqlStore(db, testBuilder);
+  const store = createTestLibsqlStore(db, testBuilder);
 
   const results = await collectStream(
     store.match(null, namedNode("urn:target"), null, null),
@@ -163,7 +178,7 @@ Deno.test("LibsqlStore.match - by graph only uses GPSO index", async () => {
     g: "urn:g2",
     g_type: "NamedNode",
   });
-  const store = new LibsqlStore(db, testBuilder);
+  const store = createTestLibsqlStore(db, testBuilder);
 
   const results = await collectStream(
     store.match(null, null, null, namedNode("urn:g1")),
@@ -190,7 +205,7 @@ Deno.test("LibsqlStore.match - by object only uses OPSG index", async () => {
     o: "other",
     o_type: "Literal",
   });
-  const store = new LibsqlStore(db, testBuilder);
+  const store = createTestLibsqlStore(db, testBuilder);
 
   const results = await collectStream(
     store.match(null, null, literal("target"), null),
@@ -217,7 +232,7 @@ Deno.test("LibsqlStore.match - disambiguates NamedNode vs BlankNode with same va
     p: "urn:p",
     o: "o2",
   });
-  const store = new LibsqlStore(db, testBuilder);
+  const store = createTestLibsqlStore(db, testBuilder);
 
   const namedResults = await collectStream(
     store.match(namedNode("b1"), null, null, null),
@@ -243,7 +258,7 @@ Deno.test("LibsqlStore.match - literal with language tag", async () => {
     o_type: "Literal",
     o_lang: "es",
   });
-  const store = new LibsqlStore(db, testBuilder);
+  const store = createTestLibsqlStore(db, testBuilder);
 
   // Match by subject+p, then check the literal
   const results = await collectStream(
@@ -268,7 +283,7 @@ Deno.test("LibsqlStore.match - literal with datatype", async () => {
     o_type: "Literal",
     o_datatype: "http://www.w3.org/2001/XMLSchema#integer",
   });
-  const store = new LibsqlStore(db, testBuilder);
+  const store = createTestLibsqlStore(db, testBuilder);
 
   const results = await collectStream(
     store.match(namedNode("urn:s"), namedNode("urn:p"), null, null),
@@ -291,7 +306,7 @@ Deno.test("LibsqlStore.match - DefaultGraph round-trip", async () => {
     g: "",
     g_type: "DefaultGraph",
   });
-  const store = new LibsqlStore(db, testBuilder);
+  const store = createTestLibsqlStore(db, testBuilder);
 
   const results = await collectStream(
     store.match(namedNode("urn:s"), null, null, null),
@@ -322,7 +337,7 @@ Deno.test(
       o_type: "Literal",
       o_lang: "en",
     });
-    const store = new LibsqlStore(db, testBuilder);
+    const store = createTestLibsqlStore(db, testBuilder);
 
     const results = await collectStream(
       store.match(
@@ -359,7 +374,7 @@ Deno.test(
       o_type: "Literal",
       o_datatype: "http://www.w3.org/2001/XMLSchema#integer",
     });
-    const store = new LibsqlStore(db, testBuilder);
+    const store = createTestLibsqlStore(db, testBuilder);
 
     const results = await collectStream(
       store.match(
@@ -390,7 +405,7 @@ Deno.test("LibsqlStore.match - NamedNode object terms round-trip", async () => {
     o_datatype: null,
     o_lang: null,
   });
-  const store = new LibsqlStore(db, testBuilder);
+  const store = createTestLibsqlStore(db, testBuilder);
 
   const results = await collectStream(
     store.match(null, null, namedNode("http://example.com/resource"), null),
@@ -411,7 +426,7 @@ Deno.test("LibsqlStore.match - BlankNode graph terms round-trip", async () => {
     g: "genid-graph",
     g_type: "BlankNode",
   });
-  const store = new LibsqlStore(db, testBuilder);
+  const store = createTestLibsqlStore(db, testBuilder);
 
   const results = await collectStream(
     store.match(null, null, null, blankNode("genid-graph")),
@@ -427,7 +442,7 @@ Deno.test(
     const failingClient = {
       execute: () => Promise.reject(new Error("database unavailable")),
     } as unknown as Client;
-    const store = new LibsqlStore(failingClient, testBuilder);
+    const store = createTestLibsqlStore(failingClient, testBuilder);
 
     await assertRejects(
       () => collectStream(store.match(null, null, null, null)),
@@ -456,7 +471,7 @@ Deno.test("LibsqlStore.match - multiple named graphs are isolated", async () => 
     g: "urn:g2",
     g_type: "NamedNode",
   });
-  const store = new LibsqlStore(db, testBuilder);
+  const store = createTestLibsqlStore(db, testBuilder);
 
   const g1Results = await collectStream(
     store.match(null, null, null, namedNode("urn:g1")),
@@ -523,7 +538,7 @@ async function computeQuadId(quad: rdfjs.Quad): Promise<string> {
 Deno.test("LibsqlStore.add - buffered quad not visible before commit", async () => {
   const db = createClient({ url: ":memory:" });
   await setupSchema(db);
-  const store = new LibsqlStore(db, testBuilder);
+  const store = createTestLibsqlStore(db, testBuilder);
 
   store.add(quad(namedNode("urn:s"), namedNode("urn:p"), literal("v1")));
 
@@ -535,7 +550,7 @@ Deno.test("LibsqlStore.add - buffered quad not visible before commit", async () 
 Deno.test("LibsqlStore.add - commit persists quad, match finds it", async () => {
   const db = createClient({ url: ":memory:" });
   await setupSchema(db);
-  const store = new LibsqlStore(
+  const store = createTestLibsqlStore(
     db,
     testBuilder,
     createCommitHandler(db, testBuilder),
@@ -554,7 +569,7 @@ Deno.test("LibsqlStore.add - commit persists quad, match finds it", async () => 
 Deno.test("LibsqlStore.add - commit once, then add+commit again accumulates", async () => {
   const db = createClient({ url: ":memory:" });
   await setupSchema(db);
-  const store = new LibsqlStore(
+  const store = createTestLibsqlStore(
     db,
     testBuilder,
     createCommitHandler(db, testBuilder),
@@ -578,7 +593,7 @@ Deno.test("LibsqlStore.add - commit once, then add+commit again accumulates", as
 Deno.test("LibsqlStore.delete - buffered quad still visible before commit", async () => {
   const db = createClient({ url: ":memory:" });
   await setupSchema(db);
-  const store = new LibsqlStore(
+  const store = createTestLibsqlStore(
     db,
     testBuilder,
     createCommitHandler(db, testBuilder),
@@ -606,7 +621,7 @@ Deno.test("LibsqlStore.delete - buffered quad still visible before commit", asyn
 Deno.test("LibsqlStore.delete - add then delete same quad before commit is net zero", async () => {
   const db = createClient({ url: ":memory:" });
   await setupSchema(db);
-  const store = new LibsqlStore(
+  const store = createTestLibsqlStore(
     db,
     testBuilder,
     createCommitHandler(db, testBuilder),
@@ -626,7 +641,7 @@ Deno.test("LibsqlStore.delete - add then delete same quad before commit is net z
 Deno.test("LibsqlStore.removeMatches - buffers matching quads for deletion", async () => {
   const db = createClient({ url: ":memory:" });
   await setupSchema(db);
-  const store = new LibsqlStore(
+  const store = createTestLibsqlStore(
     db,
     testBuilder,
     createCommitHandler(db, testBuilder),
@@ -665,7 +680,7 @@ Deno.test("LibsqlStore.removeMatches - buffers matching quads for deletion", asy
 Deno.test("LibsqlStore.clearBuffer - discards pending mutations on error", async () => {
   const db = createClient({ url: ":memory:" });
   await setupSchema(db);
-  const store = new LibsqlStore(
+  const store = createTestLibsqlStore(
     db,
     testBuilder,
     createCommitHandler(db, testBuilder),
@@ -697,7 +712,7 @@ function createErrorQuadStream(
 Deno.test("LibsqlStore.import - forwards stream errors to the emitter", async () => {
   const db = createClient({ url: ":memory:" });
   await setupSchema(db);
-  const store = new LibsqlStore(db, testBuilder);
+  const store = createTestLibsqlStore(db, testBuilder);
 
   await assertRejects(
     () =>
@@ -714,7 +729,7 @@ Deno.test("LibsqlStore.import - forwards stream errors to the emitter", async ()
 Deno.test("LibsqlStore.remove - stream buffers quads for deletion on commit", async () => {
   const db = createClient({ url: ":memory:" });
   await setupSchema(db);
-  const store = new LibsqlStore(
+  const store = createTestLibsqlStore(
     db,
     testBuilder,
     createCommitHandler(db, testBuilder),
@@ -755,7 +770,7 @@ Deno.test(
     const failingClient = {
       execute: () => Promise.reject(new Error("match query failed")),
     } as unknown as Client;
-    const store = new LibsqlStore(failingClient, testBuilder);
+    const store = createTestLibsqlStore(failingClient, testBuilder);
 
     await assertRejects(
       () =>
@@ -773,7 +788,7 @@ Deno.test(
 Deno.test("LibsqlStore.deleteGraph - accepts graph IRI strings", async () => {
   const db = createClient({ url: ":memory:" });
   await setupSchema(db);
-  const store = new LibsqlStore(
+  const store = createTestLibsqlStore(
     db,
     testBuilder,
     createCommitHandler(db, testBuilder),
@@ -813,7 +828,7 @@ Deno.test("LibsqlStore.commit - is a no-op when both buffers are empty", async (
   const db = createClient({ url: ":memory:" });
   await setupSchema(db);
   let commitHandlerCalls = 0;
-  const store = new LibsqlStore(db, testBuilder, () => {
+  const store = createTestLibsqlStore(db, testBuilder, () => {
     commitHandlerCalls++;
     return Promise.resolve();
   });
@@ -826,7 +841,7 @@ Deno.test("LibsqlStore.commit - is a no-op when both buffers are empty", async (
 Deno.test("LibsqlStore.import - stream buffers all quads, commit persists them", async () => {
   const db = createClient({ url: ":memory:" });
   await setupSchema(db);
-  const store = new LibsqlStore(
+  const store = createTestLibsqlStore(
     db,
     testBuilder,
     createCommitHandler(db, testBuilder),
@@ -861,9 +876,7 @@ Deno.test("LibsqlStore.match - keyset pages return the full result set", async (
     });
   }
 
-  const store = new LibsqlStore(db, testBuilder, undefined, {
-    matchPageSize: 2,
-  });
+  const store = createTestLibsqlStore(db, testBuilder, undefined, 2);
   const results = await collectStream(store.match(null, null, null, null));
   assertEquals(results.length, 5);
 });
@@ -892,7 +905,7 @@ Deno.test("LibsqlStore.countQuads - returns exact counts for bound patterns", as
     o_type: "NamedNode",
   });
 
-  const store = new LibsqlStore(db, testBuilder);
+  const store = createTestLibsqlStore(db, testBuilder);
 
   assertEquals(await store.countQuads(null, null, null, null), 3);
   assertEquals(

--- a/src/client/adapters/libsql/libsql-store.ts
+++ b/src/client/adapters/libsql/libsql-store.ts
@@ -51,7 +51,7 @@ export class LibsqlStore implements rdfjs.Store {
   }
 
   /**
-   * match returns a stream of quads matching the given SPOG pattern.
+   * match returns a stream of quads matching the given quad pattern.
    * Automatically selects the optimal hexastore covering index based on
    * which pattern positions are bound. Reads are keyset-paged by quad id.
    */
@@ -114,7 +114,7 @@ export class LibsqlStore implements rdfjs.Store {
   }
 
   /**
-   * countQuads returns the number of quads matching the given SPOG pattern (Comunica cardinality hint).
+   * countQuads returns the number of quads matching the given quad pattern (Comunica cardinality hint).
    */
   public async countQuads(
     subject?: rdfjs.Term | null,
@@ -197,7 +197,7 @@ export class LibsqlStore implements rdfjs.Store {
   }
 
   /**
-   * removeMatches buffers all quads matching the given SPOG pattern for deletion on commit.
+   * removeMatches buffers all quads matching the given quad pattern for deletion on commit.
    */
   public removeMatches(
     subject?: rdfjs.Term | null,

--- a/src/client/adapters/libsql/libsql-store.ts
+++ b/src/client/adapters/libsql/libsql-store.ts
@@ -4,21 +4,23 @@ import { DataFactory } from "n3";
 import { Readable } from "node:stream";
 import { EventEmitter } from "node:events";
 import type { LibsqlQueryBuilder } from "./libsql-query-builder.ts";
+import { DEFAULT_LIBSQL_MATCH_PAGE_SIZE } from "./libsql-query-builder.ts";
 import type { Patch } from "@/client/quad-store/mod.ts";
 
 const { namedNode, literal, blankNode, defaultGraph, quad } = DataFactory;
-
-/** rdfLangStringIri is the RDF datatype for language-tagged literals in N3/RDF/JS. */
-const rdfLangStringIri =
-  "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString";
-
-/** xsdStringIri is the XSD string datatype IRI. */
-const xsdStringIri = "http://www.w3.org/2001/XMLSchema#string";
 
 /**
  * CommitHandler is a callback that atomically persists a patch of buffered mutations.
  */
 export type CommitHandler = (patch: Patch) => Promise<void>;
+
+/**
+ * LibsqlStoreOptions configures optional LibsqlStore read behavior.
+ */
+export interface LibsqlStoreOptions {
+  /** matchPageSize limits rows per hexastore match SQL round-trip (default 1000). */
+  matchPageSize?: number;
+}
 
 /**
  * LibsqlStore is a full RDF/JS Store implementation backed by LibSQL and hexastore covering indexes.
@@ -35,16 +37,23 @@ export class LibsqlStore implements rdfjs.Store {
    */
   private deleteBuffer: rdfjs.Quad[] = [];
 
+  private readonly matchPageSize: number;
+
   public constructor(
     private readonly client: Client,
     private readonly queryBuilder: LibsqlQueryBuilder,
     private readonly commitHandler?: CommitHandler,
-  ) {}
+    storeOptions?: LibsqlStoreOptions,
+  ) {
+    const configuredPageSize = storeOptions?.matchPageSize ??
+      DEFAULT_LIBSQL_MATCH_PAGE_SIZE;
+    this.matchPageSize = Math.max(1, Math.floor(configuredPageSize));
+  }
 
   /**
    * match returns a stream of quads matching the given SPOG pattern.
    * Automatically selects the optimal hexastore covering index based on
-   * which pattern positions are bound.
+   * which pattern positions are bound. Reads are keyset-paged by quad id.
    */
   public match(
     subject?: rdfjs.Term | null,
@@ -52,30 +61,80 @@ export class LibsqlStore implements rdfjs.Store {
     object?: rdfjs.Term | null,
     graph?: rdfjs.Term | null,
   ): rdfjs.Stream<rdfjs.Quad> {
-    const { sql, args } = this.buildMatchQuery({
+    const pattern = {
       subject: subject ?? null,
       predicate: predicate ?? null,
       object: object ?? null,
       graph: graph ?? null,
-    });
+    };
+
+    let afterQuadId: string | undefined;
+    let streamFinished = false;
 
     const rowStream = new Readable({
       objectMode: true,
       read: async () => {
+        if (streamFinished) {
+          return;
+        }
+
         try {
+          const { sql, args } = this.queryBuilder.buildMatchQuadsQuery(
+            pattern,
+            {
+              afterQuadId,
+              limit: this.matchPageSize,
+            },
+          );
           const resultSet = await this.client.execute({ sql, args });
-          for (const row of resultSet.rows) {
-            const q = this.rowToQuad(row);
-            rowStream.push(q);
+
+          if (resultSet.rows.length === 0) {
+            rowStream.push(null);
+            streamFinished = true;
+            return;
           }
-          rowStream.push(null);
+
+          for (const row of resultSet.rows) {
+            afterQuadId = String(row.id);
+            rowStream.push(this.rowToQuad(row));
+          }
+
+          if (resultSet.rows.length < this.matchPageSize) {
+            rowStream.push(null);
+            streamFinished = true;
+          }
         } catch (error) {
           rowStream.destroy(error as Error);
+          streamFinished = true;
         }
       },
     });
 
     return rowStream as unknown as rdfjs.Stream<rdfjs.Quad>;
+  }
+
+  /**
+   * countQuads returns the number of quads matching the given SPOG pattern (Comunica cardinality hint).
+   */
+  public async countQuads(
+    subject?: rdfjs.Term | null,
+    predicate?: rdfjs.Term | null,
+    object?: rdfjs.Term | null,
+    graph?: rdfjs.Term | null,
+  ): Promise<number> {
+    const { sql, args } = this.queryBuilder.buildCountQuadsQuery({
+      subject: subject ?? null,
+      predicate: predicate ?? null,
+      object: object ?? null,
+      graph: graph ?? null,
+    });
+    const resultSet = await this.client.execute({ sql, args });
+    const firstRow = resultSet.rows[0];
+    if (!firstRow) {
+      return 0;
+    }
+    const countValue = firstRow.count ?? firstRow["COUNT(*)"];
+    return Number(countValue ?? 0);
   }
 
   /**
@@ -220,80 +279,6 @@ export class LibsqlStore implements rdfjs.Store {
   // ────────────────────────────────────────────────
   // Private helpers
   // ────────────────────────────────────────────────
-
-  /**
-   * buildMatchQuery constructs the optimal SQL query and parameters for a given SPOG pattern.
-   * Selects the hexastore index with the longest prefix of bound columns.
-   */
-  private buildMatchQuery(pattern: {
-    subject: rdfjs.Term | null;
-    predicate: rdfjs.Term | null;
-    object: rdfjs.Term | null;
-    graph: rdfjs.Term | null;
-  }): { sql: string; args: (string | null)[] } {
-    const conditions: string[] = [];
-    const args: (string | null)[] = [];
-
-    this.appendTermCondition(conditions, args, "s", "s_type", pattern.subject);
-    this.appendTermCondition(conditions, args, "o", "o_type", pattern.object);
-
-    if (pattern.predicate) {
-      conditions.push("p = ?");
-      args.push(pattern.predicate.value);
-    }
-
-    this.appendTermCondition(conditions, args, "g", "g_type", pattern.graph);
-
-    const whereClause = conditions.length > 0
-      ? `WHERE ${conditions.join(" AND ")}`
-      : "";
-
-    return {
-      sql:
-        `SELECT id, s, s_type, p, o, o_type, o_datatype, o_lang, g, g_type FROM quads ${whereClause}`,
-      args,
-    };
-  }
-
-  /**
-   * appendTermCondition adds WHERE clauses and args for a term that may be a NamedNode, BlankNode, or Literal.
-   */
-  private appendTermCondition(
-    conditions: string[],
-    args: (string | null)[],
-    valueColumn: string,
-    typeColumn: string,
-    term: rdfjs.Term | null,
-  ): void {
-    if (!term) return;
-
-    conditions.push(`${valueColumn} = ?`);
-    args.push(term.value);
-
-    conditions.push(`${typeColumn} = ?`);
-    args.push(term.termType);
-
-    if (term.termType === "Literal") {
-      const lit = term as rdfjs.Literal;
-      if (lit.language) {
-        conditions.push(`o_lang = ?`);
-        args.push(lit.language);
-      }
-      if (lit.datatype) {
-        const datatypeValue = lit.datatype.value;
-        if (
-          datatypeValue === xsdStringIri ||
-          datatypeValue === rdfLangStringIri
-        ) {
-          // Persisted rows store plain and language-tagged strings with NULL datatype.
-          conditions.push(`o_datatype IS NULL`);
-        } else {
-          conditions.push(`o_datatype = ?`);
-          args.push(datatypeValue);
-        }
-      }
-    }
-  }
 
   /**
    * rowToQuad reconstructs an RDF/JS Quad from a LibSQL result row.

--- a/src/client/adapters/libsql/libsql-store.ts
+++ b/src/client/adapters/libsql/libsql-store.ts
@@ -15,9 +15,18 @@ const { namedNode, literal, blankNode, defaultGraph, quad } = DataFactory;
 export type CommitHandler = (patch: Patch) => Promise<void>;
 
 /**
- * LibsqlStoreOptions configures optional LibsqlStore read behavior.
+ * LibsqlStoreOptions configures LibsqlStore dependencies and read behavior.
  */
 export interface LibsqlStoreOptions {
+  /** client is the LibSQL client. */
+  client: Client;
+
+  /** queryBuilder is the LibsqlQueryBuilder. */
+  queryBuilder: LibsqlQueryBuilder;
+
+  /** commitHandler atomically persists buffered patches on commit(). */
+  commitHandler?: CommitHandler;
+
   /** matchPageSize limits rows per hexastore match SQL round-trip (default 1000). */
   matchPageSize?: number;
 }
@@ -40,12 +49,9 @@ export class LibsqlStore implements rdfjs.Store {
   private readonly matchPageSize: number;
 
   public constructor(
-    private readonly client: Client,
-    private readonly queryBuilder: LibsqlQueryBuilder,
-    private readonly commitHandler?: CommitHandler,
-    storeOptions?: LibsqlStoreOptions,
+    private readonly options: LibsqlStoreOptions,
   ) {
-    const configuredPageSize = storeOptions?.matchPageSize ??
+    const configuredPageSize = options.matchPageSize ??
       DEFAULT_LIBSQL_MATCH_PAGE_SIZE;
     this.matchPageSize = Math.max(1, Math.floor(configuredPageSize));
   }
@@ -79,14 +85,14 @@ export class LibsqlStore implements rdfjs.Store {
         }
 
         try {
-          const { sql, args } = this.queryBuilder.buildMatchQuadsQuery(
+          const { sql, args } = this.options.queryBuilder.buildMatchQuadsQuery(
             pattern,
             {
               afterQuadId,
               limit: this.matchPageSize,
             },
           );
-          const resultSet = await this.client.execute({ sql, args });
+          const resultSet = await this.options.client.execute({ sql, args });
 
           if (resultSet.rows.length === 0) {
             rowStream.push(null);
@@ -122,13 +128,13 @@ export class LibsqlStore implements rdfjs.Store {
     object?: rdfjs.Term | null,
     graph?: rdfjs.Term | null,
   ): Promise<number> {
-    const { sql, args } = this.queryBuilder.buildCountQuadsQuery({
+    const { sql, args } = this.options.queryBuilder.buildCountQuadsQuery({
       subject: subject ?? null,
       predicate: predicate ?? null,
       object: object ?? null,
       graph: graph ?? null,
     });
-    const resultSet = await this.client.execute({ sql, args });
+    const resultSet = await this.options.client.execute({ sql, args });
     const firstRow = resultSet.rows[0];
     if (!firstRow) {
       return 0;
@@ -237,8 +243,8 @@ export class LibsqlStore implements rdfjs.Store {
     if (this.insertBuffer.length === 0 && this.deleteBuffer.length === 0) {
       return;
     }
-    if (this.commitHandler) {
-      await this.commitHandler({
+    if (this.options.commitHandler) {
+      await this.options.commitHandler({
         insertions: this.insertBuffer,
         deletions: this.deleteBuffer,
       });


### PR DESCRIPTION
## Summary

- Keyset-paginate `LibsqlStore.match` by `quads.id` (configurable `matchPageSize`, default 1000) so large patterns no longer materialize full SQL result sets in one round-trip.
- Add `countQuads` with `SELECT COUNT(*)` using the same SPOG WHERE as match, enabling Comunica join cardinality hints without re-scanning streams.
- Page `hydrateStoreFromLibsql` reads with the same keyset pattern.

Closes #74
Closes #75

## Test plan

- [x] `deno task ci`
- [ ] Manual: wide match on a large local DB stays bounded in heap