### PR TITLE
Opt-in TripletContextEmbeddingService for semantic chunk enrichment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -365,6 +365,11 @@ Semantic-Only, and Keyword-Only. If upstream embedding services time out or are
 completely omitted, the system gracefully degrades to high-speed SQLite FTS5
 keyword searching without service interruption.
 
+Opt-in semantic chunk enrichment: wrap an `EmbeddingService` with
+`TripletContextEmbeddingService` so index-time FTS/vector text includes
+subject/predicate context (`formatChunkText`); default `chunkQuads` behavior is
+unchanged.
+
 ### Stable reciprocal rank fusion relevance blending
 
 To combine vector cosine similarity and Okapi BM25 keyword metrics without

--- a/src/client/adapters/libsql/commit-patch-to-libsql.test.ts
+++ b/src/client/adapters/libsql/commit-patch-to-libsql.test.ts
@@ -3,7 +3,10 @@ import { createClient } from "@libsql/client";
 import { DataFactory } from "n3";
 import { RecursiveCharacterTextSplitter } from "@langchain/textsplitters";
 import { commitPatchToLibsql } from "./commit-patch-to-libsql.ts";
-import { FakeEmbeddingService } from "@/client/search-index/embedding-service/mod.ts";
+import {
+  FakeEmbeddingService,
+  TripletContextEmbeddingService,
+} from "@/client/search-index/embedding-service/mod.ts";
 import { LibsqlQueryBuilder } from "./libsql-query-builder.ts";
 
 const { quad, namedNode, literal } = DataFactory;
@@ -115,6 +118,38 @@ Deno.test("commitPatchToLibsql - supports synchronization when embeddingService 
   // Confirm parent quad still inserted
   const quadRows = await client.execute("SELECT COUNT(*) as total FROM quads");
   assertEquals(quadRows.rows[0].total, 1);
+});
+
+Deno.test("commitPatchToLibsql - TripletContextEmbeddingService stores enriched chunk text", async () => {
+  const client = createClient({ url: ":memory:" });
+  await setupSchema(client);
+
+  const options = {
+    client,
+    embeddingService: new TripletContextEmbeddingService({
+      inner: new FakeEmbeddingService(),
+    }),
+    textSplitter: sharedSplitter,
+    libsqlQueryBuilder: testLibsqlQueryBuilder,
+  };
+
+  const testQuad = quad(
+    namedNode("http://example.org/Aurelia"),
+    namedNode("http://example.org/hasCapital"),
+    literal("Lume"),
+  );
+
+  await commitPatchToLibsql({
+    insertions: [testQuad],
+    deletions: [],
+  }, options);
+
+  const chunkRows = await client.execute("SELECT value FROM chunks");
+  assertEquals(chunkRows.rows.length, 1);
+  assertEquals(
+    chunkRows.rows[0].value,
+    "Factual context about Aurelia: Aurelia has capital Lume.",
+  );
 });
 
 Deno.test(

--- a/src/client/adapters/libsql/commit-patch-to-libsql.ts
+++ b/src/client/adapters/libsql/commit-patch-to-libsql.ts
@@ -8,7 +8,10 @@ import type * as rdfjs from "@rdfjs/types";
 import type { Patch, QuadFilter } from "@/client/quad-store/mod.ts";
 import { filterQuads, hashQuad } from "@/client/quad-store/mod.ts";
 import type { LibsqlQueryBuilder } from "./libsql-query-builder.ts";
-import type { EmbeddingService } from "@/client/search-index/embedding-service/mod.ts";
+import {
+  type EmbeddingService,
+  isChunkTextEmbeddingService,
+} from "@/client/search-index/embedding-service/mod.ts";
 
 /**
  * CommitPatchToLibsqlOptions provides configurations for executing updates against LibSQL durable stores.
@@ -292,6 +295,13 @@ async function buildVectorChunkStatements(
 
   if (chunks.length === 0) {
     return [];
+  }
+
+  const embeddingService = options.embeddingService;
+  if (embeddingService && isChunkTextEmbeddingService(embeddingService)) {
+    for (const chunk of chunks) {
+      chunk.value = embeddingService.formatChunkText(chunk);
+    }
   }
 
   // Step B: Execute Deduplicated External Embedding Sweep (if service available)

--- a/src/client/search-index/embedding-service/chunk-text-embedding-service.ts
+++ b/src/client/search-index/embedding-service/chunk-text-embedding-service.ts
@@ -1,0 +1,22 @@
+import type { ChunkRowPayload } from "@/client/search-index/quad-chunker/mod.ts";
+import type { EmbeddingService } from "./embedding-service.ts";
+
+/**
+ * ChunkTextEmbeddingService extends EmbeddingService with index-time chunk text enrichment.
+ */
+export interface ChunkTextEmbeddingService extends EmbeddingService {
+  /**
+   * formatChunkText returns the text stored in FTS and passed to embed() for a search chunk row.
+   */
+  formatChunkText(chunk: ChunkRowPayload): string;
+}
+
+/**
+ * isChunkTextEmbeddingService narrows services that implement formatChunkText.
+ */
+export function isChunkTextEmbeddingService(
+  service: EmbeddingService,
+): service is ChunkTextEmbeddingService {
+  return typeof (service as ChunkTextEmbeddingService).formatChunkText ===
+    "function";
+}

--- a/src/client/search-index/embedding-service/mod.ts
+++ b/src/client/search-index/embedding-service/mod.ts
@@ -1,2 +1,4 @@
 export * from "./embedding-service.ts";
 export * from "./fake-embedding-service.ts";
+export * from "./chunk-text-embedding-service.ts";
+export * from "./triplet-context-embedding-service.ts";

--- a/src/client/search-index/embedding-service/triplet-context-embedding-service.test.ts
+++ b/src/client/search-index/embedding-service/triplet-context-embedding-service.test.ts
@@ -1,0 +1,35 @@
+import { assertEquals } from "@std/assert";
+import { FakeEmbeddingService } from "./fake-embedding-service.ts";
+import { isChunkTextEmbeddingService } from "./chunk-text-embedding-service.ts";
+import { TripletContextEmbeddingService } from "./triplet-context-embedding-service.ts";
+
+Deno.test("TripletContextEmbeddingService - formatChunkText enriches chunk rows", () => {
+  const service = new TripletContextEmbeddingService({
+    inner: new FakeEmbeddingService(),
+  });
+
+  assertEquals(isChunkTextEmbeddingService(service), true);
+
+  const formatted = service.formatChunkText({
+    quad_id: "id-1",
+    subject: "http://example.org/Aurelia",
+    predicate: "http://example.org/hasCapital",
+    graph: "",
+    value: "Lume",
+  });
+
+  assertEquals(
+    formatted,
+    "Factual context about Aurelia: Aurelia has capital Lume.",
+  );
+});
+
+Deno.test("TripletContextEmbeddingService - embed delegates to inner service", async () => {
+  const service = new TripletContextEmbeddingService({
+    inner: new FakeEmbeddingService(),
+  });
+
+  const vectors = await service.embed(["query text"]);
+  assertEquals(vectors.length, 1);
+  assertEquals(vectors[0]!.length, 32);
+});

--- a/src/client/search-index/embedding-service/triplet-context-embedding-service.ts
+++ b/src/client/search-index/embedding-service/triplet-context-embedding-service.ts
@@ -1,0 +1,40 @@
+import type { ChunkRowPayload } from "@/client/search-index/quad-chunker/mod.ts";
+import { formatQuadChunkText } from "@/client/search-index/quad-chunker/format-quad-chunk-text.ts";
+import type { ChunkTextEmbeddingService } from "./chunk-text-embedding-service.ts";
+import type { EmbeddingService } from "./embedding-service.ts";
+
+/**
+ * TripletContextEmbeddingServiceOptions configures TripletContextEmbeddingService.
+ */
+export interface TripletContextEmbeddingServiceOptions {
+  /** inner is the embedding model used after chunk text enrichment. */
+  inner: EmbeddingService;
+}
+
+/**
+ * TripletContextEmbeddingService wraps an EmbeddingService with subject/predicate chunk enrichment.
+ */
+export class TripletContextEmbeddingService
+  implements ChunkTextEmbeddingService {
+  private readonly inner: EmbeddingService;
+
+  public constructor(options: TripletContextEmbeddingServiceOptions) {
+    this.inner = options.inner;
+  }
+
+  /**
+   * formatChunkText returns a natural-language fact string for hybrid search indexing.
+   */
+  public formatChunkText(chunk: ChunkRowPayload): string {
+    return formatQuadChunkText(chunk);
+  }
+
+  /**
+   * embed delegates vectorization to the wrapped embedding service.
+   */
+  public embed(
+    texts: string[],
+  ): Promise<Array<Float32Array | number[]>> {
+    return this.inner.embed(texts);
+  }
+}

--- a/src/client/search-index/quad-chunker/format-quad-chunk-text.test.ts
+++ b/src/client/search-index/quad-chunker/format-quad-chunk-text.test.ts
@@ -1,0 +1,39 @@
+import { assertEquals } from "@std/assert";
+import { formatQuadChunkText } from "./format-quad-chunk-text.ts";
+
+Deno.test("formatQuadChunkText - enriches subject and predicate around object value", () => {
+  const formatted = formatQuadChunkText({
+    quad_id: "hash-aurelia",
+    subject: "http://example.org/Aurelia",
+    predicate: "http://example.org/hasCapital",
+    graph: "",
+    value: "Lume",
+  });
+
+  assertEquals(
+    formatted,
+    "Factual context about Aurelia: Aurelia has capital Lume.",
+  );
+});
+
+Deno.test("formatQuadChunkText - humanizes underscore and camelCase IRIs", () => {
+  const formatted = formatQuadChunkText({
+    quad_id: "hash-bob",
+    subject: "urn:entity_bob",
+    predicate: "urn:hasBio",
+    graph: "",
+    value: "Bob is a dev",
+  });
+
+  assertEquals(
+    formatted.includes("entity bob"),
+    true,
+    "subject label should decode separators",
+  );
+  assertEquals(
+    formatted.includes("has bio"),
+    true,
+    "predicate phrase should decode camelCase",
+  );
+  assertEquals(formatted.includes("Bob is a dev"), true);
+});

--- a/src/client/search-index/quad-chunker/format-quad-chunk-text.ts
+++ b/src/client/search-index/quad-chunker/format-quad-chunk-text.ts
@@ -1,0 +1,56 @@
+import type { ChunkRowPayload } from "./chunk-quads.ts";
+
+/**
+ * formatQuadChunkText builds a natural-language fact string for embedding and FTS indexing.
+ */
+export function formatQuadChunkText(chunk: ChunkRowPayload): string {
+  const subjectLabel = extractRdfLocalLabel(chunk.subject);
+  const predicatePhrase = formatPredicatePhrase(chunk.predicate);
+  return `Factual context about ${subjectLabel}: ${subjectLabel} ${predicatePhrase} ${chunk.value}.`;
+}
+
+/**
+ * extractRdfLocalLabel returns a short human-readable label from an IRI or term value.
+ */
+export function extractRdfLocalLabel(iri: string): string {
+  const trimmed = iri.trim();
+  if (trimmed.length === 0) {
+    return "unknown entity";
+  }
+
+  const hashIndex = trimmed.lastIndexOf("#");
+  if (hashIndex >= 0 && hashIndex < trimmed.length - 1) {
+    return humanizeToken(trimmed.slice(hashIndex + 1));
+  }
+
+  const slashIndex = trimmed.lastIndexOf("/");
+  if (slashIndex >= 0 && slashIndex < trimmed.length - 1) {
+    return humanizeToken(trimmed.slice(slashIndex + 1));
+  }
+
+  return humanizeToken(trimmed);
+}
+
+/**
+ * formatPredicatePhrase converts a predicate IRI into a short verb phrase.
+ */
+export function formatPredicatePhrase(predicateIri: string): string {
+  const localName = extractRdfLocalLabel(predicateIri);
+  return localName.toLowerCase();
+}
+
+/**
+ * humanizeToken decodes common IRI local-name separators into spaced words.
+ */
+function humanizeToken(token: string): string {
+  const withSpaces = token
+    .replace(/([a-z])([A-Z])/g, "$1 $2")
+    .replace(/[_-]+/g, " ")
+    .trim();
+
+  if (withSpaces.length === 0) {
+    return token;
+  }
+
+  return withSpaces;
+}

--- a/src/client/search-index/quad-chunker/mod.ts
+++ b/src/client/search-index/quad-chunker/mod.ts
@@ -1,1 +1,2 @@
 export * from "./chunk-quads.ts";
+export * from "./format-quad-chunk-text.ts";


### PR DESCRIPTION
## Summary

- Add `formatQuadChunkText` to build natural-language fact strings from chunk metadata (e.g. subject + predicate + literal).
- Add `TripletContextEmbeddingService` wrapping any `EmbeddingService`; implements `formatChunkText` and delegates `embed()`.
- Apply enrichment in `commit-patch-to-libsql` only when the configured service implements `ChunkTextEmbeddingService` (FTS and vectors stay aligned).
- Default `chunkQuads` output is unchanged unless the wrapper is opted in.

Closes #16

## Test plan

- [x] `deno task ci`
- [ ] Re-import a corpus with the wrapper enabled and confirm hybrid search improves on conversational queries
- [ ] Existing deployments: re-index required after enabling the wrapper