### PR TITLE
ci: add pull request checks workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: denoland/setup-deno@v2
+        with:
+          cache: true
+      - name: Install dependencies
+        run: deno install
+      - name: Run CI checks
+        run: deno task ci

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -277,8 +277,11 @@ green-passing integration pipeline runs:
   [discussion #69](https://github.com/wazootech/worlds-client-ts/discussions/69);
   do not add committed `baselines.ci.json` or workflow-based bench checks.
 
+- **GitHub Actions CI:** Pull requests and pushes to `main` run
+  [`.github/workflows/ci.yml`](.github/workflows/ci.yml) (`deno task ci`: fmt,
+  lint, check, test). Open PRs show the **CI** check before merge.
 - **JSR publish (`deno publish`):** The package is `@worlds/client` on JSR.
-  Pushes to `main` run
+  Pushes to `main` also run
   [`.github/workflows/publish.yml`](.github/workflows/publish.yml):
   `deno task ci` → `deno task publish:dry` → `deno publish`. Before any release
   or import/`exports` refactor, run the same sequence locally.


### PR DESCRIPTION
## Summary

- Add [\.github/workflows/ci.yml\](.github/workflows/ci.yml) running \deno task ci\ on **pull_request** and **push** to \main\.
- Document in AGENTS.md that PRs get a **CI** check; [\publish.yml\](.github/workflows/publish.yml) stays for JSR release on \main\ only.

## Test plan

- [ ] Merge and confirm next PR shows **CI** check
- [x] Workflow YAML matches existing publish job steps (checkout, setup-deno, deno install, deno task ci)
