### PR TITLE
feat: Client.rebuildSearchIndex and batched quad INSERTs

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,20 +182,14 @@ After a schema upgrade or bulk ontology import, rebuild all search chunks from
 durable `quads`:
 
 ```typescript
-import { RecursiveCharacterTextSplitter } from "@langchain/textsplitters";
-import {
-  LibsqlQueryBuilder,
-  rebuildLibsqlSearchIndexFromQuads,
-} from "@worlds/client/adapters/libsql";
-
-await rebuildLibsqlSearchIndexFromQuads({
-  client: db,
-  libsqlQueryBuilder: new LibsqlQueryBuilder(vectorDimensions),
-  textSplitter,
-  embeddingService,
-  labelPredicates: ["http://example.org/customLabel"],
+await client.rebuildSearchIndex({
+  quadFilter: { include: { graphs: ["http://example.org/ontology"] } },
 });
 ```
+
+Advanced: `rebuildLibsqlSearchIndexFromQuads` in
+`@worlds/client/adapters/libsql` remains available when you do not have a
+`Client` instance.
 
 After renaming an entity, refresh every chunk for affected subjects:
 
@@ -251,7 +245,7 @@ SPARQL router ([#63](https://github.com/wazootech/worlds-client-ts/issues/63)).
 | Avoid at scale  | Unbound `?s ?p ?o` (even with `LIMIT`) on `libsqlStore` — crossover **fullScan** degrades to hundreds of ms–seconds as quads grow ([#69](https://github.com/wazootech/worlds-client-ts/discussions/69))                 |
 | N3 + Comunica   | `createLibsqlN3Client` only when you need in-memory N3; pass a warmed `store` hydrated **once per container**, not per HTTP request                                                                                     |
 | Local crossover | `deno task bench` → `sparql-hexastore-crossover.bench.ts`; 100k–1M opt-in: `deno task bench:crossover-large` — see [`benchmarks/README.md`](benchmarks/README.md)                                                       |
-| Bulk import     | `deferSearchIndexOnImport: true` persists quads on import, then rebuilds search index after each import; `searchIndexOnImport: false` skips indexing until `rebuildLibsqlSearchIndexFromQuads` (SPARQL-only bulk loads) |
+| Bulk import     | `deferSearchIndexOnImport: true` persists quads on import, then rebuilds search index after each import; `searchIndexOnImport: false` skips indexing until `await client.rebuildSearchIndex()` (SPARQL-only bulk loads) |
 | Cardinality     | `LibsqlStore.countQuads` is used by Comunica when `createLibsqlClient` wires hexastore SPARQL (no extra adapter config)                                                                                                 |
 
 Query helpers (same shapes as benchmarks):

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -55,8 +55,14 @@ search + SPARQL in production
 hydrate+N3.
 
 Crossover preload uses `searchIndexOnImport: false` (quads only; the timed slice
-is `execute()`). Apps that need `search()` at scale use normal import with
-inline indexing or `deferSearchIndexOnImport: true`, then `search()`.
+is `execute()`). Do **not** call `Client.rebuildSearchIndex()` in crossover
+harnesses — it rebuilds FTS/chunks and does not affect execute timings. Batched
+quad `INSERT`s speed the untimed preload / `BENCH_REUSE_DB` cache build.
+
+Apps that need `search()` at scale use normal import with inline indexing,
+`deferSearchIndexOnImport: true` (rebuild after each import), or
+`searchIndexOnImport: false` plus `await client.rebuildSearchIndex()` once after
+bulk load.
 
 ### SPARQL crossover at 100k–1M (opt-in, local only)
 
@@ -80,7 +86,9 @@ Only `sparqlEngine.execute()` is timed inside `Deno.bench`. Paste results into
 
 For full import + search preload timing (not the crossover execute table), use
 `deferSearchIndexOnImport: true` on a dedicated bulk-load client (quads first,
-search index rebuilt after import).
+search index rebuilt after import), or `searchIndexOnImport: false` followed by
+`await client.rebuildSearchIndex()` when you want quads and search repair as
+separate timed steps.
 
 #### Reusing large fixtures (dev only)
 

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@worlds/client",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "nodeModulesDir": "auto",
   "exports": {
     ".": "./src/mod.ts",

--- a/src/client/adapters/libsql/commit-patch-to-libsql.test.ts
+++ b/src/client/adapters/libsql/commit-patch-to-libsql.test.ts
@@ -19,6 +19,37 @@ async function setupSchema(client: ReturnType<typeof createClient>) {
 
 const sharedSplitter = new RecursiveCharacterTextSplitter({ chunkSize: 1000 });
 
+Deno.test(
+  "commitPatchToLibsql - bulk quad INSERT persists expected quads row count",
+  async () => {
+    const client = createClient({ url: ":memory:" });
+    await setupSchema(client);
+
+    const bulkQuadCount = 120;
+    const bulkQuads = Array.from({ length: bulkQuadCount }, (_, index) =>
+      quad(
+        namedNode(`urn:subject:${index}`),
+        namedNode("urn:predicate"),
+        literal(`bulk insert ${index}`),
+      ));
+
+    await commitPatchToLibsql(
+      { insertions: bulkQuads, deletions: [] },
+      {
+        client,
+        textSplitter: sharedSplitter,
+        libsqlQueryBuilder: testLibsqlQueryBuilder,
+        skipSearchIndexProjection: true,
+      },
+    );
+
+    const quadRows = await client.execute(
+      "SELECT COUNT(*) as total FROM quads",
+    );
+    assertEquals(Number(quadRows.rows[0].total), bulkQuadCount);
+  },
+);
+
 Deno.test("commitPatchToLibsql - isolated writes and removals commit correctly to BOTH chunks and quads", async () => {
   const client = createClient({ url: ":memory:" });
   await setupSchema(client);

--- a/src/client/adapters/libsql/commit-patch-to-libsql.ts
+++ b/src/client/adapters/libsql/commit-patch-to-libsql.ts
@@ -480,31 +480,25 @@ function buildRelationalStatements(
   quadIds: string[],
   queryBuilder: LibsqlQueryBuilder,
 ): InStatement[] {
-  const statements: InStatement[] = [];
-  for (let i = 0; i < quads.length; i++) {
-    const quad = quads[i];
-    const id = quadIds[i];
-
-    // Decompose literal nodes explicitly to capture type & lang tags
+  const insertQuadRows = quads.map((quad, index) => {
     const isLiteral = quad.object.termType === "Literal";
-    const literal = isLiteral ? (quad.object as rdfjs.Literal) : null;
+    const literalNode = isLiteral ? (quad.object as rdfjs.Literal) : null;
 
-    statements.push(
-      queryBuilder.buildInsertQuad({
-        quad_id: id,
-        s: quad.subject.value,
-        s_type: quad.subject.termType,
-        p: quad.predicate.value,
-        o: quad.object.value,
-        o_type: quad.object.termType,
-        o_datatype: literal?.datatype?.value,
-        o_lang: literal?.language,
-        g: quad.graph.value,
-        g_type: quad.graph.termType,
-      }),
-    );
-  }
-  return statements;
+    return {
+      quad_id: quadIds[index],
+      s: quad.subject.value,
+      s_type: quad.subject.termType,
+      p: quad.predicate.value,
+      o: quad.object.value,
+      o_type: quad.object.termType,
+      o_datatype: literalNode?.datatype?.value,
+      o_lang: literalNode?.language,
+      g: quad.graph.value,
+      g_type: quad.graph.termType,
+    };
+  });
+
+  return queryBuilder.buildBulkInsertQuads(insertQuadRows);
 }
 
 /**

--- a/src/client/adapters/libsql/create-libsql-client.test.ts
+++ b/src/client/adapters/libsql/create-libsql-client.test.ts
@@ -155,6 +155,150 @@ Deno.test(
 );
 
 Deno.test(
+  "createLibsqlClientOptions - rebuildSearchIndex after searchIndexOnImport false enables search",
+  async () => {
+    const databaseClient = createClient({ url: ":memory:" });
+
+    const client = new Client(
+      await createLibsqlClientOptions({
+        client: databaseClient,
+        searchIndexOnImport: false,
+        createSparqlEngine: ({ libsqlStore }) =>
+          new ComunicaSparqlEngine({ queryEngine, store: libsqlStore }),
+      }),
+    );
+
+    await client.import({
+      source: {
+        kind: "quads",
+        quads: [
+          quad(
+            namedNode("urn:entity:rebuild-me"),
+            namedNode("urn:label"),
+            literal("rebuild search index later"),
+          ),
+        ],
+      },
+    });
+
+    const beforeRebuild = await databaseClient.execute(
+      "SELECT COUNT(*) as total FROM chunks",
+    );
+    assertEquals(Number(beforeRebuild.rows[0].total), 0);
+
+    const rebuildResponse = await client.rebuildSearchIndex();
+    assertEquals(rebuildResponse.processedQuadCount, 1);
+    assertEquals(rebuildResponse.chunkRowCount > 0, true);
+
+    const afterRebuild = await databaseClient.execute(
+      "SELECT COUNT(*) as total FROM chunks",
+    );
+    assertEquals(Number(afterRebuild.rows[0].total) > 0, true);
+
+    const searchResponse = await client.search({
+      query: "rebuild search",
+    });
+    assertEquals(searchResponse.results?.length ?? 0, 1);
+
+    databaseClient.close();
+  },
+);
+
+Deno.test(
+  "createLibsqlClientOptions - rebuildSearchIndex quadFilter scopes indexed graphs",
+  async () => {
+    const databaseClient = createClient({ url: ":memory:" });
+    const graphAlpha = namedNode("urn:graph:alpha");
+    const graphBeta = namedNode("urn:graph:beta");
+
+    const client = new Client(
+      await createLibsqlClientOptions({
+        client: databaseClient,
+        searchIndexOnImport: false,
+        createSparqlEngine: ({ libsqlStore }) =>
+          new ComunicaSparqlEngine({ queryEngine, store: libsqlStore }),
+      }),
+    );
+
+    await client.import({
+      source: {
+        kind: "quads",
+        quads: [
+          quad(
+            namedNode("urn:entity:alpha"),
+            namedNode("urn:label"),
+            literal("alpha graph only"),
+            graphAlpha,
+          ),
+          quad(
+            namedNode("urn:entity:beta"),
+            namedNode("urn:label"),
+            literal("beta graph only"),
+            graphBeta,
+          ),
+        ],
+      },
+    });
+
+    await client.rebuildSearchIndex({
+      quadFilter: { include: { graphs: ["urn:graph:alpha"] } },
+    });
+
+    const alphaSearch = await client.search({ query: "alpha graph" });
+    assertEquals(alphaSearch.results?.length ?? 0, 1);
+
+    const betaSearch = await client.search({ query: "beta graph" });
+    assertEquals(betaSearch.results?.length ?? 0, 0);
+
+    databaseClient.close();
+  },
+);
+
+Deno.test(
+  "createLibsqlClientOptions - rebuildSearchIndex is idempotent on second run",
+  async () => {
+    const databaseClient = createClient({ url: ":memory:" });
+
+    const client = new Client(
+      await createLibsqlClientOptions({
+        client: databaseClient,
+        searchIndexOnImport: false,
+        createSparqlEngine: ({ libsqlStore }) =>
+          new ComunicaSparqlEngine({ queryEngine, store: libsqlStore }),
+      }),
+    );
+
+    await client.import({
+      source: {
+        kind: "quads",
+        quads: [
+          quad(
+            namedNode("urn:entity:idempotent"),
+            namedNode("urn:label"),
+            literal("idempotent rebuild"),
+          ),
+        ],
+      },
+    });
+
+    const firstRebuild = await client.rebuildSearchIndex();
+    const secondRebuild = await client.rebuildSearchIndex();
+
+    assertEquals(firstRebuild.chunkRowCount, secondRebuild.chunkRowCount);
+
+    const chunkRows = await databaseClient.execute(
+      "SELECT COUNT(*) as total FROM chunks",
+    );
+    assertEquals(
+      Number(chunkRows.rows[0].total),
+      secondRebuild.chunkRowCount,
+    );
+
+    databaseClient.close();
+  },
+);
+
+Deno.test(
   "createLibsqlClientOptions - searchIndexOnImport false rejects deferSearchIndexOnImport",
   async () => {
     const databaseClient = createClient({ url: ":memory:" });

--- a/src/client/adapters/libsql/create-libsql-client.ts
+++ b/src/client/adapters/libsql/create-libsql-client.ts
@@ -53,6 +53,10 @@ export async function createLibsqlClientOptions(
     client: options.client,
     embeddingService: options.embeddingService,
     libsqlQueryBuilder: queryBuilder,
+    textSplitter,
+    quadFilter: options.quadFilter,
+    labelPredicates: options.labelPredicates,
+    maxLookupChunkSize: options.maxLookupChunkSize,
   });
 
   const patchSync = createLibsqlPatchSyncState({

--- a/src/client/adapters/libsql/libsql-client-base-options.ts
+++ b/src/client/adapters/libsql/libsql-client-base-options.ts
@@ -39,12 +39,12 @@ export interface LibsqlClientBaseOptions {
 
   /**
    * searchIndexOnImport when false skips chunk/FTS projection on every commit and does not rebuild after import.
-   * Use for SPARQL-only bulk loads; call rebuildLibsqlSearchIndexFromQuads before search().
+   * Use for SPARQL-only bulk loads; call Client.rebuildSearchIndex() before search().
    */
   searchIndexOnImport?: boolean;
 
   /**
-   * deferSearchIndexOnImport persists quads on each import and rebuilds FTS/vector chunks afterward.
+   * deferSearchIndexOnImport persists quads on each import and rebuilds FTS/vector chunks afterward via Client.rebuildSearchIndex().
    * Enable only on LibSQL clients dedicated to large bulk loads; omit for normal incremental use.
    * Cannot be combined with searchIndexOnImport: false.
    */

--- a/src/client/adapters/libsql/libsql-query-builder.test.ts
+++ b/src/client/adapters/libsql/libsql-query-builder.test.ts
@@ -95,3 +95,66 @@ Deno.test("sanitizeFtsQuery - preserves original tokens when the query is stopwo
     `"what" "is" "the"`,
   );
 });
+
+Deno.test(
+  "buildBulkInsertQuads - chunks rows under SQLite host-parameter budget",
+  () => {
+    const insertQuadRows = Array.from({ length: 85 }, (_, index) => ({
+      quad_id: `id-${index}`,
+      s: `urn:s:${index}`,
+      s_type: "NamedNode",
+      p: "urn:p",
+      o: `literal ${index}`,
+      o_type: "Literal",
+      o_datatype: null,
+      o_lang: null,
+      g: "",
+      g_type: "DefaultGraph",
+    }));
+
+    const statements = testLibsqlQueryBuilder.buildBulkInsertQuads(
+      insertQuadRows,
+    );
+    assertEquals(statements.length, 2);
+    assertEquals(
+      (statements[0].sql.match(/\(\?, \?, \?, \?, \?, \?, \?, \?, \?, \?\)/g) ??
+        []).length,
+      80,
+    );
+    assertEquals(statements[0].args.length, 800);
+    assertEquals(
+      (statements[1].sql.match(/\(\?, \?, \?, \?, \?, \?, \?, \?, \?, \?\)/g) ??
+        []).length,
+      5,
+    );
+    assertEquals(statements[1].args.length, 50);
+  },
+);
+
+Deno.test(
+  "buildBulkInsertQuads - single row matches buildInsertQuad shape",
+  () => {
+    const insertQuadRow = {
+      quad_id: "quad-hash",
+      s: "urn:subject",
+      s_type: "NamedNode",
+      p: "urn:predicate",
+      o: "object text",
+      o_type: "Literal",
+      o_datatype: "http://www.w3.org/2001/XMLSchema#string",
+      o_lang: "en",
+      g: "urn:graph",
+      g_type: "NamedNode",
+    };
+
+    const bulkStatement = testLibsqlQueryBuilder.buildBulkInsertQuads([
+      insertQuadRow,
+    ])[0];
+    const singleStatement = testLibsqlQueryBuilder.buildInsertQuad(
+      insertQuadRow,
+    );
+
+    assertEquals(bulkStatement.sql, singleStatement.sql);
+    assertEquals(bulkStatement.args, singleStatement.args);
+  },
+);

--- a/src/client/adapters/libsql/libsql-query-builder.ts
+++ b/src/client/adapters/libsql/libsql-query-builder.ts
@@ -8,6 +8,38 @@ import {
 /** DEFAULT_LIBSQL_MATCH_PAGE_SIZE caps rows per hexastore match SQL round-trip. */
 export const DEFAULT_LIBSQL_MATCH_PAGE_SIZE = 1000;
 
+/** BULK_INSERT_QUAD_COLUMN_COUNT is host parameters per quad row in bulk INSERT statements. */
+const BULK_INSERT_QUAD_COLUMN_COUNT = 10;
+
+/**
+ * BULK_INSERT_QUAD_ROWS_PER_STATEMENT caps rows per INSERT under SQLite 999 host-parameter limit with headroom.
+ */
+export const BULK_INSERT_QUAD_ROWS_PER_STATEMENT = 80;
+
+/** InsertQuadRow is one relational quad row bound for INSERT OR REPLACE into quads. */
+export interface InsertQuadRow {
+  /** quad_id is the stable hash identifier for the quad row. */
+  quad_id: string;
+  /** s is the subject IRI or node value. */
+  s: string;
+  /** s_type is the RDF term type for the subject. */
+  s_type: string;
+  /** p is the predicate IRI. */
+  p: string;
+  /** o is the object value. */
+  o: string;
+  /** o_type is the RDF term type for the object. */
+  o_type: string;
+  /** o_datatype is the literal datatype IRI when the object is typed. */
+  o_datatype?: string | null;
+  /** o_lang is the literal language tag when present. */
+  o_lang?: string | null;
+  /** g is the graph name value. */
+  g: string;
+  /** g_type is the RDF term type for the graph slot. */
+  g_type: string;
+}
+
 /** Maximum embedding dimensions accepted by LibsqlQueryBuilder (LibSQL / resource guardrail). */
 const LIBSQL_QUERY_BUILDER_MAX_VECTOR_DIMENSIONS = 8192;
 const LIBSQL_FTS_STOPWORDS = new Set([
@@ -378,35 +410,70 @@ export class LibsqlQueryBuilder {
     };
   }
 
-  public buildInsertQuad(insertQuadOptions: {
-    quad_id: string;
-    s: string;
-    s_type: string;
-    p: string;
-    o: string;
-    o_type: string;
-    o_datatype?: string | null;
-    o_lang?: string | null;
-    g: string;
-    g_type: string;
-  }): { sql: string; args: (string | null)[] } {
-    return {
-      sql:
-        `INSERT OR REPLACE INTO quads (id, s, s_type, p, o, o_type, o_datatype, o_lang, g, g_type)
-          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-      args: [
-        insertQuadOptions.quad_id,
-        insertQuadOptions.s,
-        insertQuadOptions.s_type,
-        insertQuadOptions.p,
-        insertQuadOptions.o,
-        insertQuadOptions.o_type,
-        insertQuadOptions.o_datatype ?? null,
-        insertQuadOptions.o_lang ?? null,
-        insertQuadOptions.g,
-        insertQuadOptions.g_type,
-      ],
-    };
+  public buildInsertQuad(
+    insertQuadOptions: InsertQuadRow,
+  ): { sql: string; args: (string | null)[] } {
+    return this.buildBulkInsertQuads([insertQuadOptions])[0];
+  }
+
+  /**
+   * buildBulkInsertQuads emits multi-row INSERT OR REPLACE statements chunked under SQLite host-parameter limits.
+   */
+  public buildBulkInsertQuads(
+    insertQuadRows: InsertQuadRow[],
+  ): Array<{ sql: string; args: (string | null)[] }> {
+    if (insertQuadRows.length === 0) {
+      return [];
+    }
+
+    const statements: Array<{ sql: string; args: (string | null)[] }> = [];
+
+    for (
+      let rowOffset = 0;
+      rowOffset < insertQuadRows.length;
+      rowOffset += BULK_INSERT_QUAD_ROWS_PER_STATEMENT
+    ) {
+      const rowBatch = insertQuadRows.slice(
+        rowOffset,
+        rowOffset + BULK_INSERT_QUAD_ROWS_PER_STATEMENT,
+      );
+      const valuePlaceholders = rowBatch
+        .map(() => "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
+        .join(", ");
+      const args: (string | null)[] = [];
+
+      for (const insertQuadRow of rowBatch) {
+        args.push(
+          insertQuadRow.quad_id,
+          insertQuadRow.s,
+          insertQuadRow.s_type,
+          insertQuadRow.p,
+          insertQuadRow.o,
+          insertQuadRow.o_type,
+          insertQuadRow.o_datatype ?? null,
+          insertQuadRow.o_lang ?? null,
+          insertQuadRow.g,
+          insertQuadRow.g_type,
+        );
+      }
+
+      if (
+        args.length > BULK_INSERT_QUAD_ROWS_PER_STATEMENT *
+            BULK_INSERT_QUAD_COLUMN_COUNT
+      ) {
+        throw new Error(
+          `buildBulkInsertQuads: batch exceeds SQLite host-parameter budget (${args.length})`,
+        );
+      }
+
+      statements.push({
+        sql:
+          `INSERT OR REPLACE INTO quads (id, s, s_type, p, o, o_type, o_datatype, o_lang, g, g_type) VALUES ${valuePlaceholders}`,
+        args,
+      });
+    }
+
+    return statements;
   }
 
   public sanitizeFtsQuery(query: string): string {

--- a/src/client/adapters/libsql/libsql-search-index.ts
+++ b/src/client/adapters/libsql/libsql-search-index.ts
@@ -1,14 +1,19 @@
 import type { Client } from "@libsql/client";
 import { DataFactory } from "n3";
+import type { QuadFilter } from "@/client/quad-store/mod.ts";
 import type {
+  RebuildSearchIndexRequest,
+  RebuildSearchIndexResponse,
   SearchIndexInterface,
   SearchRequest,
   SearchResponse,
   SearchResult,
 } from "@/client/search-index/mod.ts";
 import { hashQuad } from "@/client/quad-store/mod.ts";
+import type { TextSplitterInterface } from "@/client/search-index/quad-chunker/mod.ts";
 import type { LibsqlQueryBuilder } from "./libsql-query-builder.ts";
 import type { EmbeddingService } from "@/client/search-index/embedding-service/mod.ts";
+import { rebuildLibsqlSearchIndexFromQuads } from "./rebuild-libsql-search-index-from-quads.ts";
 
 const { literal, namedNode, quad: createQuad, defaultGraph } = DataFactory;
 
@@ -27,6 +32,21 @@ export interface LibsqlSearchIndexOptions {
    * libsqlQueryBuilder must match the schema and commit path used when materializing chunk vectors.
    */
   libsqlQueryBuilder: LibsqlQueryBuilder;
+
+  /** textSplitter is required when rebuildSearchIndex rebuilds chunk rows from quads. */
+  textSplitter?: TextSplitterInterface;
+
+  /** quadFilter is the default inclusion boundary for rebuildSearchIndex when the request omits quadFilter. */
+  quadFilter?: QuadFilter;
+
+  /** labelPredicates extends built-in label IRIs used during rebuildSearchIndex chunk projection. */
+  labelPredicates?: string[];
+
+  /** maxLookupChunkSize caps IN-clause host parameters during rebuildSearchIndex (default 800). */
+  maxLookupChunkSize?: number;
+
+  /** maxWriteBatchSize caps statements per LibSQL batch during rebuildSearchIndex (default 500). */
+  maxWriteBatchSize?: number;
 }
 
 /**
@@ -103,5 +123,33 @@ export class LibsqlSearchIndex implements SearchIndexInterface {
     }
 
     return { results };
+  }
+
+  /**
+   * rebuildSearchIndex rebuilds FTS/vector chunk rows from durable quads without re-importing graph data.
+   */
+  public async rebuildSearchIndex(
+    request?: RebuildSearchIndexRequest,
+  ): Promise<RebuildSearchIndexResponse> {
+    const textSplitter = this.options.textSplitter;
+    if (!textSplitter) {
+      throw new Error(
+        "LibsqlSearchIndex rebuildSearchIndex requires textSplitter in LibsqlSearchIndexOptions",
+      );
+    }
+
+    const quadFilter = request?.quadFilter ?? this.options.quadFilter;
+
+    return await rebuildLibsqlSearchIndexFromQuads({
+      client: this.options.client,
+      libsqlQueryBuilder: this.options.libsqlQueryBuilder,
+      embeddingService: this.options.embeddingService,
+      textSplitter,
+      maxLookupChunkSize: this.options.maxLookupChunkSize,
+      maxWriteBatchSize: this.options.maxWriteBatchSize,
+      quadFilter,
+      labelPredicates: this.options.labelPredicates,
+      readPageSize: request?.readPageSize,
+    });
   }
 }

--- a/src/client/adapters/libsql/n3/create-libsql-n3-client.ts
+++ b/src/client/adapters/libsql/n3/create-libsql-n3-client.ts
@@ -72,6 +72,10 @@ export async function createLibsqlN3ClientOptions(
     client: options.client,
     embeddingService: options.embeddingService,
     libsqlQueryBuilder: queryBuilder,
+    textSplitter,
+    quadFilter: options.quadFilter,
+    labelPredicates: options.labelPredicates,
+    maxLookupChunkSize: options.maxLookupChunkSize,
   });
 
   const patchSync = createLibsqlPatchSyncState({

--- a/src/client/adapters/rdfjs/create-rdfjs-client.test.ts
+++ b/src/client/adapters/rdfjs/create-rdfjs-client.test.ts
@@ -78,6 +78,19 @@ Deno.test(
 );
 
 Deno.test(
+  "createRdfjsClient - rebuildSearchIndex rejects on non-LibSQL topology",
+  async () => {
+    const client = createRdfjsClient();
+
+    await assertRejects(
+      () => client.rebuildSearchIndex(),
+      Error,
+      "search index rebuild is only supported for LibSQL-backed clients",
+    );
+  },
+);
+
+Deno.test(
   "createRdfjsClient - sparql rejects when createSparqlEngine is omitted",
   async () => {
     const client = createRdfjsClient();

--- a/src/client/client-interface.ts
+++ b/src/client/client-interface.ts
@@ -4,7 +4,12 @@ import type {
   ImportRequest,
   ImportResponse,
 } from "./quad-store/mod.ts";
-import type { SearchRequest, SearchResponse } from "./search-index/mod.ts";
+import type {
+  RebuildSearchIndexRequest,
+  RebuildSearchIndexResponse,
+  SearchRequest,
+  SearchResponse,
+} from "./search-index/mod.ts";
 import type { SparqlRequest, SparqlResponse } from "./sparql-engine/mod.ts";
 
 /**
@@ -38,4 +43,13 @@ export interface ClientInterface {
    * @returns A promise that resolves to the search response.
    */
   search(request: SearchRequest): Promise<SearchResponse>;
+
+  /**
+   * rebuildSearchIndex rebuilds the derived search index from durable quads (LibSQL clients only).
+   * @param request optional quadFilter scope and read page size.
+   * @returns A promise that resolves to processed quad and chunk row counts.
+   */
+  rebuildSearchIndex(
+    request?: RebuildSearchIndexRequest,
+  ): Promise<RebuildSearchIndexResponse>;
 }

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -12,6 +12,8 @@ import type {
   SparqlResponse,
 } from "./sparql-engine/mod.ts";
 import type {
+  RebuildSearchIndexRequest,
+  RebuildSearchIndexResponse,
   SearchIndexInterface,
   SearchRequest,
   SearchResponse,
@@ -63,5 +65,16 @@ export class Client implements ClientInterface {
 
   public async search(request: SearchRequest): Promise<SearchResponse> {
     return await this.options.searchIndex.search(request);
+  }
+
+  public async rebuildSearchIndex(
+    request?: RebuildSearchIndexRequest,
+  ): Promise<RebuildSearchIndexResponse> {
+    if (!this.options.searchIndex.rebuildSearchIndex) {
+      throw new Error(
+        "search index rebuild is only supported for LibSQL-backed clients",
+      );
+    }
+    return await this.options.searchIndex.rebuildSearchIndex(request);
   }
 }

--- a/src/client/search-index/search-index-interface.ts
+++ b/src/client/search-index/search-index-interface.ts
@@ -17,6 +17,26 @@ export interface SearchResponse {
 }
 
 /**
+ * RebuildSearchIndexRequest scopes repair to quads matching QuadFilter boundaries.
+ */
+export interface RebuildSearchIndexRequest {
+  /** quadFilter limits which durable quads are scanned (e.g. graphs include). */
+  quadFilter?: QuadFilter;
+  /** readPageSize limits quads per SQL page during scan (default 1000). */
+  readPageSize?: number;
+}
+
+/**
+ * RebuildSearchIndexResponse reports repair counts (idempotent rerun safe).
+ */
+export interface RebuildSearchIndexResponse {
+  /** processedQuadCount is the number of durable quads scanned during repair. */
+  processedQuadCount: number;
+  /** chunkRowCount is the number of chunk rows written to FTS/vector tables. */
+  chunkRowCount: number;
+}
+
+/**
  * SearchResult is a hybrid keyword/vector hit against an RDF literal.
  */
 export interface SearchResult {
@@ -52,4 +72,14 @@ export interface SearchIndexInterface {
    * @returns promise resolving to a set of relevancy-ranked triple matches.
    */
   search(request: SearchRequest): Promise<SearchResponse>;
+
+  /**
+   * rebuildSearchIndex rebuilds FTS/vector chunks from durable quads (LibSQL adapters only).
+   *
+   * @param request optional quadFilter scope and read page size.
+   * @returns promise resolving to processed quad and chunk row counts.
+   */
+  rebuildSearchIndex?(
+    request?: RebuildSearchIndexRequest,
+  ): Promise<RebuildSearchIndexResponse>;
 }


### PR DESCRIPTION
## Summary

- Add `Client.rebuildSearchIndex()` (and types) for LibSQL clients, delegating to `rebuildLibsqlSearchIndexFromQuads` with optional `quadFilter` override and idempotent repair counts.
- Batch quad `INSERT OR REPLACE` via `LibsqlQueryBuilder.buildBulkInsertQuads` (80 rows per statement) to reduce statement count on large imports.
- Bump JSR version to `0.0.12`; update README and factory JSDoc to point at `client.rebuildSearchIndex()`.

Closes #15
Closes #86

## Test plan

- [x] `deno task ci`
- [x] `create-libsql-client` rebuild tests (quads-only import, graph filter, idempotency)
- [x] `buildBulkInsertQuads` chunking + 120-quad commit patch count
- [x] RDFJS client throws on `rebuildSearchIndex()`
