### PR TITLE
Add Comunica SPARQL engine factory helpers (0.0.14)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -334,6 +334,10 @@ separate modules so hexastore deployments do not import N3 hydration:
 Canonical construction: `new Client(await createXClientOptions(...))`. Do not
 reintroduce `createXClient` one-line wrappers.
 
+For standard Comunica SPARQL, pass `createComunicaSparqlEngineFactory` or
+`createComunicaLibsqlSparqlEngineFactory` from
+`@worlds/client/adapters/comunica` as the adapter's `createSparqlEngine` option.
+
 - **Serverless / edge (warm isolate):** build `ClientOptions` or `Client` once
   in module scope per isolate; reuse across HTTP requests. See
   [`examples/libsql-n3-warm-container`](examples/libsql-n3-warm-container).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.0.14
+
+### Added
+
+- `createComunicaSparqlEngineFactory` and
+  `createComunicaLibsqlSparqlEngineFactory` on
+  `@worlds/client/adapters/comunica` — preset helpers that return typed
+  `createSparqlEngine` callbacks for standard Comunica wiring.
+
 ## 0.0.13
 
 ### Breaking

--- a/README.md
+++ b/README.md
@@ -94,7 +94,10 @@ as Turso Cloud through `createLibsqlClientOptions` + `Client`.
 
 ```typescript
 import { Client } from "@worlds/client";
-import { ComunicaSparqlEngine } from "@worlds/client/adapters/comunica";
+import {
+  createComunicaLibsqlSparqlEngineFactory,
+  createComunicaSparqlEngineFactory,
+} from "@worlds/client/adapters/comunica";
 import { createLibsqlClientOptions } from "@worlds/client/adapters/libsql";
 import { createRdfjsClientOptions } from "@worlds/client/adapters/rdfjs";
 import { createDenokvClientOptions } from "@worlds/client/adapters/denokv";
@@ -110,14 +113,20 @@ const queryEngine = new QueryEngine();
 const libsqlClient = new Client(
   await createLibsqlClientOptions({
     client: db,
-    createSparqlEngine: ({ libsqlStore }) =>
-      new ComunicaSparqlEngine({ queryEngine, store: libsqlStore }),
+    createSparqlEngine: createComunicaLibsqlSparqlEngineFactory({
+      queryEngine,
+    }),
   }),
 );
 
 // 3. Deno Kv (prototyping / constrained edge — not primary production path)
 const kv = await Deno.openKv();
-const kvClient = new Client(createDenokvClientOptions({ kv }));
+const kvClient = new Client(
+  createDenokvClientOptions({
+    kv,
+    createSparqlEngine: createComunicaSparqlEngineFactory({ queryEngine }),
+  }),
+);
 ```
 
 Cache `ClientOptions` (or a `Client`) in module scope when reusing wiring across

--- a/benchmarks/shared/sparql-hexastore-crossover-shared.ts
+++ b/benchmarks/shared/sparql-hexastore-crossover-shared.ts
@@ -2,7 +2,10 @@ import { createClient } from "@libsql/client";
 import type { Quad } from "@rdfjs/types";
 import { QueryEngine } from "@comunica/query-sparql-rdfjs-lite";
 import { Client } from "@worlds/client";
-import { ComunicaSparqlEngine } from "@worlds/client/adapters/comunica";
+import {
+  createComunicaLibsqlSparqlEngineFactory,
+  createComunicaSparqlEngineFactory,
+} from "@worlds/client/adapters/comunica";
 import { createLibsqlClientOptions } from "@worlds/client/adapters/libsql";
 import { createLibsqlN3ClientOptions } from "@worlds/client/adapters/libsql/n3";
 import type { SparqlEngineInterface } from "@worlds/client/sparql-engine";
@@ -117,11 +120,9 @@ async function openLibsqlHexastoreSparqlEngine(
   const clientOptions = await createLibsqlClientOptions({
     client: databaseClient,
     searchIndexOnImport: false,
-    createSparqlEngine: ({ libsqlStore }) =>
-      new ComunicaSparqlEngine({
-        queryEngine: sharedQueryEngine,
-        store: libsqlStore,
-      }),
+    createSparqlEngine: createComunicaLibsqlSparqlEngineFactory({
+      queryEngine: sharedQueryEngine,
+    }),
   });
   if (!clientOptions.sparqlEngine) {
     throw new Error("libsqlStore bench requires createSparqlEngine");
@@ -188,8 +189,9 @@ async function createHydrateN3SparqlEngine(
   const clientOptions = await createLibsqlN3ClientOptions({
     client: databaseClient,
     searchIndexOnImport: false,
-    createSparqlEngine: ({ store }) =>
-      new ComunicaSparqlEngine({ queryEngine: sharedQueryEngine, store }),
+    createSparqlEngine: createComunicaSparqlEngineFactory({
+      queryEngine: sharedQueryEngine,
+    }),
   });
   const worldsClient = new Client(clientOptions);
   await worldsClient.import({

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@worlds/client",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "nodeModulesDir": "auto",
   "exports": {
     ".": "./src/mod.ts",

--- a/examples/ai-sdk-hello-world/main.ts
+++ b/examples/ai-sdk-hello-world/main.ts
@@ -1,6 +1,6 @@
 import { createClient } from "@libsql/client";
 import { Client } from "@worlds/client";
-import { ComunicaSparqlEngine } from "@worlds/client/adapters/comunica";
+import { createComunicaLibsqlSparqlEngineFactory } from "@worlds/client/adapters/comunica";
 import { createLibsqlClientOptions } from "@worlds/client/adapters/libsql";
 import { QueryEngine } from "@comunica/query-sparql-rdfjs-lite";
 import { GRAPH_GROUNDED_AGENT_SYSTEM_PROMPT } from "./agent-prompts.ts";
@@ -18,8 +18,9 @@ if (import.meta.main) {
   const client = new Client(
     await createLibsqlClientOptions({
       client: database,
-      createSparqlEngine: ({ libsqlStore }) =>
-        new ComunicaSparqlEngine({ queryEngine, store: libsqlStore }),
+      createSparqlEngine: createComunicaLibsqlSparqlEngineFactory({
+        queryEngine,
+      }),
     }),
   );
 

--- a/examples/denokv-hello-world/main.ts
+++ b/examples/denokv-hello-world/main.ts
@@ -1,5 +1,5 @@
 import { Client } from "@worlds/client";
-import { ComunicaSparqlEngine } from "@worlds/client/adapters/comunica";
+import { createComunicaSparqlEngineFactory } from "@worlds/client/adapters/comunica";
 import { createDenokvClientOptions } from "@worlds/client/adapters/denokv";
 import { QueryEngine } from "@comunica/query-sparql-rdfjs-lite";
 
@@ -16,8 +16,7 @@ if (import.meta.main) {
   const client = new Client(
     createDenokvClientOptions({
       kv,
-      createSparqlEngine: ({ store }) =>
-        new ComunicaSparqlEngine({ queryEngine, store }),
+      createSparqlEngine: createComunicaSparqlEngineFactory({ queryEngine }),
     }),
   );
   console.log("💡 Stateless gateway operational!");

--- a/examples/hello-world/main.ts
+++ b/examples/hello-world/main.ts
@@ -1,5 +1,5 @@
 import { Client } from "@worlds/client";
-import { ComunicaSparqlEngine } from "@worlds/client/adapters/comunica";
+import { createComunicaSparqlEngineFactory } from "@worlds/client/adapters/comunica";
 import { createRdfjsClientOptions } from "@worlds/client/adapters/rdfjs";
 import { QueryEngine } from "@comunica/query-sparql-rdfjs-lite";
 
@@ -7,8 +7,7 @@ if (import.meta.main) {
   const queryEngine = new QueryEngine();
   const client = new Client(
     createRdfjsClientOptions({
-      createSparqlEngine: ({ store }) =>
-        new ComunicaSparqlEngine({ queryEngine, store }),
+      createSparqlEngine: createComunicaSparqlEngineFactory({ queryEngine }),
     }),
   );
 

--- a/examples/libsql-long-running/hexastore.ts
+++ b/examples/libsql-long-running/hexastore.ts
@@ -1,5 +1,5 @@
 import { createClient } from "@libsql/client";
-import { ComunicaSparqlEngine } from "@worlds/client/adapters/comunica";
+import { createComunicaLibsqlSparqlEngineFactory } from "@worlds/client/adapters/comunica";
 import { Client } from "@worlds/client";
 import {
   createLibsqlClientOptions,
@@ -60,8 +60,9 @@ if (import.meta.main) {
       client: databaseClient,
       embeddingService,
       vectorDimensions: USE_LITE_VECTOR_DIMENSIONS,
-      createSparqlEngine: ({ libsqlStore }) =>
-        new ComunicaSparqlEngine({ queryEngine, store: libsqlStore }),
+      createSparqlEngine: createComunicaLibsqlSparqlEngineFactory({
+        queryEngine,
+      }),
     }),
   );
   console.log("Gateway operational.");

--- a/examples/libsql-long-running/n3.ts
+++ b/examples/libsql-long-running/n3.ts
@@ -1,6 +1,6 @@
 import { createClient } from "@libsql/client";
 import { QueryEngine } from "@comunica/query-sparql-rdfjs-lite";
-import { ComunicaSparqlEngine } from "@worlds/client/adapters/comunica";
+import { createComunicaSparqlEngineFactory } from "@worlds/client/adapters/comunica";
 import { createSubjectBoundPropertiesSparqlQuery } from "@worlds/client/adapters/libsql";
 import { Client } from "@worlds/client";
 import { createLibsqlN3ClientOptions } from "@worlds/client/adapters/libsql/n3";
@@ -25,8 +25,7 @@ if (import.meta.main) {
   const client = new Client(
     await createLibsqlN3ClientOptions({
       client: databaseClient,
-      createSparqlEngine: ({ store }) =>
-        new ComunicaSparqlEngine({ queryEngine, store }),
+      createSparqlEngine: createComunicaSparqlEngineFactory({ queryEngine }),
     }),
   );
 

--- a/examples/libsql-n3-warm-container/hexastore.ts
+++ b/examples/libsql-n3-warm-container/hexastore.ts
@@ -1,7 +1,7 @@
 import { createClient } from "@libsql/client";
 import { QueryEngine } from "@comunica/query-sparql-rdfjs-lite";
 import { Client } from "@worlds/client";
-import { ComunicaSparqlEngine } from "@worlds/client/adapters/comunica";
+import { createComunicaLibsqlSparqlEngineFactory } from "@worlds/client/adapters/comunica";
 import {
   createLibsqlClientOptions,
   createSubjectBoundPropertiesSparqlQuery,
@@ -14,6 +14,7 @@ const { quad, namedNode, literal } = DataFactory;
 const warmSubjectIri = "urn:demo:warm:hexastore:0";
 
 const databaseClient = createClient({ url: ":memory:" });
+const queryEngine = new QueryEngine();
 
 /** warmIsolateClient survives warm isolates (Deno Deploy, Vercel Edge, etc.). */
 let warmIsolateClient: Client | undefined;
@@ -22,11 +23,9 @@ async function getWarmIsolateClient(): Promise<Client> {
   warmIsolateClient ??= new Client(
     await createLibsqlClientOptions({
       client: databaseClient,
-      createSparqlEngine: ({ libsqlStore }) =>
-        new ComunicaSparqlEngine({
-          queryEngine: new QueryEngine(),
-          store: libsqlStore,
-        }),
+      createSparqlEngine: createComunicaLibsqlSparqlEngineFactory({
+        queryEngine,
+      }),
     }),
   );
   return warmIsolateClient;

--- a/examples/libsql-n3-warm-container/n3.ts
+++ b/examples/libsql-n3-warm-container/n3.ts
@@ -1,6 +1,6 @@
 import { createClient } from "@libsql/client";
 import { QueryEngine } from "@comunica/query-sparql-rdfjs-lite";
-import { ComunicaSparqlEngine } from "@worlds/client/adapters/comunica";
+import { createComunicaSparqlEngineFactory } from "@worlds/client/adapters/comunica";
 import {
   createSubjectBoundPropertiesSparqlQuery,
   hydrateStoreFromLibsql,
@@ -15,6 +15,7 @@ const { quad, namedNode, literal } = DataFactory;
 const warmSubjectIri = "urn:demo:warm:entity:0";
 
 const databaseClient = createClient({ url: ":memory:" });
+const queryEngine = new QueryEngine();
 
 /** warmIsolateClient is built once after hydration — not per HTTP request. */
 let warmIsolateClient: Client | undefined;
@@ -24,11 +25,7 @@ async function getWarmIsolateClient(warmedStore: Store): Promise<Client> {
     await createLibsqlN3ClientOptions({
       client: databaseClient,
       store: warmedStore,
-      createSparqlEngine: ({ store }) =>
-        new ComunicaSparqlEngine({
-          queryEngine: new QueryEngine(),
-          store,
-        }),
+      createSparqlEngine: createComunicaSparqlEngineFactory({ queryEngine }),
     }),
   );
   return warmIsolateClient;

--- a/examples/libsql-sparql-scale/main.ts
+++ b/examples/libsql-sparql-scale/main.ts
@@ -1,7 +1,7 @@
 import { createClient } from "@libsql/client";
 import { QueryEngine } from "@comunica/query-sparql-rdfjs-lite";
 import { Client } from "@worlds/client";
-import { ComunicaSparqlEngine } from "@worlds/client/adapters/comunica";
+import { createComunicaLibsqlSparqlEngineFactory } from "@worlds/client/adapters/comunica";
 import {
   createCappedUnboundTriplePatternSparqlQuery,
   createLibsqlClientOptions,
@@ -25,8 +25,9 @@ if (import.meta.main) {
   const client = new Client(
     await createLibsqlClientOptions({
       client: databaseClient,
-      createSparqlEngine: ({ libsqlStore }) =>
-        new ComunicaSparqlEngine({ queryEngine, store: libsqlStore }),
+      createSparqlEngine: createComunicaLibsqlSparqlEngineFactory({
+        queryEngine,
+      }),
     }),
   );
 

--- a/src/client/adapters/comunica/create-comunica-sparql-engine-factory.test.ts
+++ b/src/client/adapters/comunica/create-comunica-sparql-engine-factory.test.ts
@@ -1,0 +1,99 @@
+import { assertEquals } from "@std/assert";
+import { createClient } from "@libsql/client";
+import { RecursiveCharacterTextSplitter } from "@langchain/textsplitters";
+import { DataFactory, Store } from "n3";
+import { QueryEngine } from "@comunica/query-sparql-rdfjs-lite";
+import {
+  commitPatchToLibsql,
+  initializeLibsqlSchema,
+  LibsqlQueryBuilder,
+  LibsqlStore,
+} from "@/client/adapters/libsql/mod.ts";
+import {
+  createComunicaLibsqlSparqlEngineFactory,
+  createComunicaSparqlEngineFactory,
+} from "./create-comunica-sparql-engine-factory.ts";
+
+const queryEngine = new QueryEngine();
+
+Deno.test(
+  "createComunicaSparqlEngineFactory - executes SELECT against an `store` context",
+  async () => {
+    const store = new Store();
+    store.addQuad(
+      DataFactory.namedNode("https://example.com/s"),
+      DataFactory.namedNode("https://example.com/p"),
+      DataFactory.literal("factory-value"),
+    );
+
+    const createSparqlEngine = createComunicaSparqlEngineFactory({
+      queryEngine,
+    });
+    const sparqlEngine = createSparqlEngine({ store });
+    const response = await sparqlEngine.execute({
+      query:
+        "SELECT ?object WHERE { <https://example.com/s> <https://example.com/p> ?object }",
+    });
+
+    if (response.kind !== "select") {
+      throw new Error("Expected select response kind");
+    }
+
+    assertEquals(
+      response.data.results.bindings[0]?.object?.value,
+      "factory-value",
+    );
+  },
+);
+
+Deno.test(
+  "createComunicaLibsqlSparqlEngineFactory - executes SELECT against a `libsqlStore` context",
+  async () => {
+    const databaseClient = createClient({ url: ":memory:" });
+    const libsqlQueryBuilder = new LibsqlQueryBuilder(32);
+    await initializeLibsqlSchema(databaseClient, libsqlQueryBuilder);
+
+    const textSplitter = new RecursiveCharacterTextSplitter({
+      chunkSize: 1000,
+    });
+    const libsqlStore = new LibsqlStore({
+      client: databaseClient,
+      queryBuilder: libsqlQueryBuilder,
+      commitHandler: async (patch) => {
+        await commitPatchToLibsql(patch, {
+          client: databaseClient,
+          textSplitter,
+          libsqlQueryBuilder,
+          skipSearchIndexProjection: true,
+        });
+      },
+    });
+
+    const subjectIri = "urn:factory:entity:0";
+    libsqlStore.addQuad(
+      DataFactory.quad(
+        DataFactory.namedNode(subjectIri),
+        DataFactory.namedNode("urn:factory:predicate"),
+        DataFactory.literal("libsql-factory-value"),
+      ),
+    );
+    await libsqlStore.commit();
+
+    const createSparqlEngine = createComunicaLibsqlSparqlEngineFactory({
+      queryEngine,
+    });
+    const sparqlEngine = createSparqlEngine({ libsqlStore });
+    const response = await sparqlEngine.execute({
+      query: `SELECT ?object WHERE { <${subjectIri}> ?property ?object }`,
+    });
+
+    if (response.kind !== "select") {
+      throw new Error("Expected select response kind");
+    }
+
+    assertEquals(
+      response.data.results.bindings[0]?.object?.value,
+      "libsql-factory-value",
+    );
+  },
+);

--- a/src/client/adapters/comunica/create-comunica-sparql-engine-factory.ts
+++ b/src/client/adapters/comunica/create-comunica-sparql-engine-factory.ts
@@ -1,0 +1,36 @@
+import type * as rdfjs from "@rdfjs/types";
+import type { SparqlEngineInterface } from "@/client/sparql-engine/mod.ts";
+import {
+  type ComunicaQueryEngine,
+  ComunicaSparqlEngine,
+} from "./comunica-sparql-engine.ts";
+
+/**
+ * CreateComunicaSparqlEngineFactoryOptions configures a Comunica-backed createSparqlEngine callback.
+ */
+export interface CreateComunicaSparqlEngineFactoryOptions {
+  /** queryEngine is the caller-owned Comunica-compatible query engine. */
+  queryEngine: ComunicaQueryEngine;
+}
+
+/**
+ * createComunicaSparqlEngineFactory returns a createSparqlEngine callback for adapters exposing `{ store }`.
+ */
+export function createComunicaSparqlEngineFactory(
+  options: CreateComunicaSparqlEngineFactoryOptions,
+): (sparqlEngineOptions: { store: rdfjs.Store }) => SparqlEngineInterface {
+  return ({ store }) =>
+    new ComunicaSparqlEngine({ queryEngine: options.queryEngine, store });
+}
+
+/**
+ * createComunicaLibsqlSparqlEngineFactory returns a createSparqlEngine callback for hexastore LibSQL clients.
+ */
+export function createComunicaLibsqlSparqlEngineFactory(
+  options: CreateComunicaSparqlEngineFactoryOptions,
+): (
+  sparqlEngineOptions: { libsqlStore: rdfjs.Store },
+) => SparqlEngineInterface {
+  const fromStore = createComunicaSparqlEngineFactory(options);
+  return ({ libsqlStore }) => fromStore({ store: libsqlStore });
+}

--- a/src/client/adapters/comunica/mod.ts
+++ b/src/client/adapters/comunica/mod.ts
@@ -1,1 +1,2 @@
 export * from "./comunica-sparql-engine.ts";
+export * from "./create-comunica-sparql-engine-factory.ts";


### PR DESCRIPTION
## Summary

- Adds `createComunicaSparqlEngineFactory` and `createComunicaLibsqlSparqlEngineFactory` on `@worlds/client/adapters/comunica` as typed presets for adapter `createSparqlEngine` wiring.
- Bumps package version to **0.0.14**; updates README, AGENTS, CHANGELOG, examples, and crossover benchmarks to use the helpers.
- Additive release: factory-on-options architecture unchanged; `ComunicaSparqlEngine` remains available for custom wiring.

## Test plan

- [x] `deno task ci` (fmt, lint, check, test)
- [x] New unit tests in `create-comunica-sparql-engine-factory.test.ts`