### PR TITLE
Rename ClientOptions to Adapter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,8 +134,8 @@ Never use parent-relative `../` to reach another domain. Never import
 - ✅ `@/client/quad-store/mod.ts`, `@/client/sparql-engine/mod.ts`,
   `@/client/adapters/rdfjs/mod.ts` (from `adapters/libsql/`)
 - ✅ `@/client/quad-store/mod.ts` (from `search-index/quad-chunker/`)
-- ✅ `import { Client, type ClientOptions } from "@/client/client.ts"` (adapter
-  factories — not `@/mod.ts`, avoids root barrel cycles)
+- ✅ `import { Client } from "@/client/client.ts"` (adapter factories — not
+  `@/mod.ts`, avoids root barrel cycles)
 - ✅ `@/client/adapters/libsql/mod.ts` (from `adapters/libsql/n3/`)
 - ✅ `./string-to-chars.ts` (from `tokenizer/tokenizer.ts`)
 - ✅ `./client.ts`, `./adapters/rdfjs/mod.ts` (from `src/client/client.test.ts`)
@@ -317,35 +317,34 @@ network hop latency during query execution.
 Hexastore indexes are provisioned at schema init for all LibSQL clients. Use
 separate modules so hexastore deployments do not import N3 hydration:
 
-- **`createLibsqlClientOptions`**
-  ([`create-libsql-client.ts`](src/client/adapters/libsql/create-libsql-client.ts))
+- **`createLibsqlAdapter`**
+  ([`create-libsql-adapter.ts`](src/client/adapters/libsql/create-libsql-adapter.ts))
   — `LibsqlStore` + hexastore indexes; `createSparqlEngine({ libsqlStore })`.
   `LibsqlStore.match` keyset-pages by `quads.id` (`matchPageSize`, default
   1000). Optional `countQuads` supplies Comunica join cardinality hints. Wrap
-  with `new Client(await createLibsqlClientOptions(...))`.
-- **`createLibsqlN3ClientOptions`** — import `@worlds/client/adapters/libsql/n3`
-  ([`n3/create-libsql-n3-client.ts`](src/client/adapters/libsql/n3/create-libsql-n3-client.ts));
+  with `new Client(await createLibsqlAdapter(...))`.
+- **`createLibsqlN3Adapter`** — import `@worlds/client/adapters/libsql/n3`
+  ([`n3/create-libsql-n3-adapter.ts`](src/client/adapters/libsql/n3/create-libsql-n3-adapter.ts));
   hydrate → `proxyStore` → sync patches to LibSQL;
   `createSparqlEngine({ store })` receives proxied N3. Not re-exported from
   `@worlds/client/adapters/libsql` (keeps hexastore-only imports free of N3).
 
 ### Client lifecycle (runtime)
 
-Canonical construction: `new Client(await createXClientOptions(...))`. Do not
+Canonical construction: `new Client(await createXAdapter(...))`. Do not
 reintroduce `createXClient` one-line wrappers.
 
 For standard Comunica SPARQL, pass `createComunicaSparqlEngineFactory` or
 `createComunicaLibsqlSparqlEngineFactory` from
 `@worlds/client/adapters/comunica` as the adapter's `createSparqlEngine` option.
 
-- **Serverless / edge (warm isolate):** build `ClientOptions` or `Client` once
-  in module scope per isolate; reuse across HTTP requests. See
+- **Serverless / edge (warm isolate):** build `Adapter` or `Client` once in
+  module scope per isolate; reuse across HTTP requests. See
   [`examples/libsql-n3-warm-container`](examples/libsql-n3-warm-container).
 - **Long-running (Fly.io, DigitalOcean, 24/7 Deno):** one `Client` at process
   boot. See [`examples/libsql-long-running`](examples/libsql-long-running).
-- When reusing a warmed N3 `store`, do **not** call
-  `createLibsqlN3ClientOptions` on every request — that rebuilds proxy, search
-  index, and patch sync.
+- When reusing a warmed N3 `store`, do **not** call `createLibsqlN3Adapter` on
+  every request — that rebuilds proxy, search index, and patch sync.
 
 Use `benchmarks/sparql-hexastore-crossover.bench.ts`,
 [`benchmarks/README.md`](benchmarks/README.md), and
@@ -369,18 +368,18 @@ trivial container-level caching across sequential HTTP invocations.
 ### Sterile orchestration via adapters
 
 All active instrumentation (proxies, observers, and transactional mutation
-queues) is isolated strictly inside adapters (e.g. `createLibsqlClientOptions`).
-The generalized `Client` is kept completely agnostic and sterile, accepting
+queues) is isolated strictly inside adapters (e.g. `createLibsqlAdapter`). The
+generalized `Client` is kept completely agnostic and sterile, accepting
 pre-composed adapter options ready for constructor injection.
 
 ### Production deployment recommendation
 
 For production deployments and scale, the recommended topology is LibSQL-backed
-infrastructure through `createLibsqlClientOptions` + `Client`, especially Turso
-Cloud. RDFJS-backed and Deno KV-backed search/index topologies, including
-deployments centered on `RdfjsSearchIndex` and `DenokvSearchIndex`, are
-appropriate for local development, tests, and constrained single-process demos,
-but they are not the recommended production path.
+infrastructure through `createLibsqlAdapter` + `Client`, especially Turso Cloud.
+RDFJS-backed and Deno KV-backed search/index topologies, including deployments
+centered on `RdfjsSearchIndex` and `DenokvSearchIndex`, are appropriate for
+local development, tests, and constrained single-process demos, but they are not
+the recommended production path.
 
 ### Resilient hybrid search with vectorless fallbacks
 
@@ -413,3 +412,164 @@ rank positions blended with a standard smoothing constant ($k = 60$).
 The system enforces stable, canonical, URL-safe base64 identifiers computed via
 `hashQuad` for all search results and database synchronizer records. This
 secures precise, duplicate-free idempotency checks and stable ranking sweeps.
+
+## Agent prompt contract
+
+This section defines the canonical interaction pattern for AI agents consuming
+the `Client` API via tools. Agents use **hybrid search** to discover subject
+IRIs, then **SPARQL** to traverse and reason over the graph.
+
+### Hybrid search retrieval modes
+
+The search index supports three retrieval topologies:
+
+- **Hybrid (fused)**: vector cosine similarity + keyword BM25 blended via
+  Reciprocal Rank Fusion (RRF, $k = 60$). Default when an embedding service is
+  configured.
+- **Keyword-only**: FTS5 full-text search over `chunks.fts_value`. Active when
+  no embedding service is provided, or as automatic graceful degradation when
+  the embedding service is unreachable.
+- **Semantic-only**: vector similarity search without keyword scoring. Available
+  when embeddings are configured but FTS is not needed.
+
+Agents MUST NOT assume which retrieval mode is active. Results always return
+`subject`, `predicate`, and `text` regardless of mode.
+
+### Search-then-SPARQL multi-hop pattern
+
+1. Call **search** with an exact label or keyword. Use `subject` (and
+   `predicate` when helpful) from results for SPARQL bindings. Do not use `text`
+   alone as a query binding.
+2. Call **SPARQL** for traversal. Start with
+   `SELECT ?p ?o WHERE { <uri> ?p ?o }` to inspect a resource before targeted
+   queries.
+3. Final answers use **exact literals from SPARQL bindings**. Say "not found"
+   instead of guessing.
+4. Stop tooling once the requested literal appears in bindings.
+
+### Search index internals
+
+- `chunks.value`: the object literal returned as `SearchResult.text`.
+- `chunks.fts_value`: subject local name, predicate phrase, literal, and
+  configured label aliases (for FTS indexing and vector embedding).
+- Vectors embed a deduplicated union of `fts_value` and `value` per chunk, keyed
+  by `fts_value`.
+- Search discovers subject IRIs; SPARQL disambiguates.
+
+### Label predicates
+
+Built-in label predicates (`rdfs:label`, `skos:prefLabel`, `schema:name`) are
+always indexed. Extend with `labelPredicates` on adapter options:
+
+```typescript
+await createLibsqlAdapter({
+  client: db,
+  labelPredicates: ["http://example.org/customLabel"],
+});
+```
+
+Label predicate commits fan out automatically; sibling fact rows pick up new
+alias tokens in `fts_value`.
+
+### Search index maintenance
+
+After a schema upgrade or bulk ontology import, rebuild all search chunks:
+
+```typescript
+await client.rebuildSearchIndex({
+  quadFilter: { include: { graphs: ["http://example.org/ontology"] } },
+});
+```
+
+After renaming an entity, refresh chunks for affected subjects:
+
+```typescript
+import { refreshSearchChunksForSubjects } from "@worlds/client/adapters/libsql";
+
+await refreshSearchChunksForSubjects(["http://example.org/Aurelia"], {
+  client: db,
+  textSplitter,
+  libsqlQueryBuilder,
+  embeddingService,
+});
+```
+
+Advanced: `rebuildLibsqlSearchIndexFromQuads` in
+`@worlds/client/adapters/libsql` remains available without a `Client` instance.
+
+### Alignment with eval harness
+
+Keep AI tool descriptions and system prompts aligned with
+[worlds-client-evals](https://github.com/wazootech/worlds-client-evals)
+(`src/tools/create-eval-tools.ts`, `eval-agent-system-prompt.ts`) and
+`examples/ai-sdk-hello-world/agent-prompts.ts`.
+
+## Scale and topology guidance
+
+### Choosing a LibSQL topology
+
+Both options builders provision hexastore indexes at schema init. Pick by how
+much graph you mirror in memory and how you run SPARQL.
+
+| Options builder         | Module                              | When to use                                                                                                                  |
+| :---------------------- | :---------------------------------- | :--------------------------------------------------------------------------------------------------------------------------- |
+| `createLibsqlAdapter`   | `@worlds/client/adapters/libsql`    | **Production and large graphs.** SPARQL runs on `LibsqlStore` (hexastore). No full N3 hydration per request.                 |
+| `createLibsqlN3Adapter` | `@worlds/client/adapters/libsql/n3` | **Selective workloads** where hydrating into N3 is acceptable. Reuse one warmed `store` per container, not per HTTP request. |
+
+Post-preload benchmarks (1k-50k quads) show hydrate+N3 can win selective queries
+when the graph is already in memory; libsqlStore avoids full hydration cost and
+is the better default as graphs grow. Avoid unbound full-graph scans at
+production scale.
+
+### SPARQL query shape at scale
+
+At millions of quads, pick the topology at integration time.
+
+| Concern         | Production default                                                                                                               |
+| :-------------- | :------------------------------------------------------------------------------------------------------------------------------- |
+| LibSQL topology | `createLibsqlAdapter` with hexastore `LibsqlStore`, no full N3 mirror per request                                                |
+| Hot-path SPARQL | Bind at least one term (subject, predicate, or object). Subject-bound property lookups match crossover selective shapes          |
+| Avoid at scale  | Unbound `?s ?p ?o` (even with `LIMIT`) on libsqlStore; fullScan degrades to hundreds of ms as quads grow                         |
+| N3 + Comunica   | `createLibsqlN3Adapter` only when you need in-memory N3; pass a warmed `store` hydrated once per container, not per HTTP request |
+| Cardinality     | `LibsqlStore.countQuads` is used by Comunica when hexastore SPARQL is wired (no extra adapter config)                            |
+
+Query helpers (same shapes as benchmarks):
+
+```typescript
+import {
+  createCappedUnboundTriplePatternSparqlQuery,
+  createSubjectBoundPropertiesSparqlQuery,
+} from "@worlds/client/adapters/libsql";
+
+const selectiveQuery = createSubjectBoundPropertiesSparqlQuery("urn:entity:0");
+const devScanQuery = createCappedUnboundTriplePatternSparqlQuery(100);
+```
+
+### Warm container patterns
+
+- **Serverless / edge (warm isolate):** build `Adapter` or `Client` once in
+  module scope per isolate; reuse across HTTP requests.
+- **Long-running (Fly.io, DigitalOcean, 24/7 Deno):** one `Client` at process
+  boot.
+- When reusing a warmed N3 `store`, do **not** call `createLibsqlN3Adapter` on
+  every request; that rebuilds proxy, search index, and patch sync.
+
+### Bulk import strategies
+
+| Flag                             | Behavior                                                                                         |
+| :------------------------------- | :----------------------------------------------------------------------------------------------- |
+| `searchIndexOnImport: false`     | Skips chunk/FTS projection on every commit. Call `client.rebuildSearchIndex()` before searching. |
+| `deferSearchIndexOnImport: true` | Persists quads on each import, rebuilds FTS/vector chunks afterward via `rebuildSearchIndex`.    |
+
+These flags cannot be combined. Use for SPARQL-only bulk loads or large initial
+imports where indexing can happen once at the end.
+
+### Benchmark references
+
+- Canonical crossover write-up:
+  [discussion #69](https://github.com/wazootech/worlds-client-ts/discussions/69)
+- Local numbers and methodology: [`benchmarks/README.md`](benchmarks/README.md)
+- Scale roadmap (millions of quads):
+  [#68](https://github.com/wazootech/worlds-client-ts/issues/68)
+- Earlier crossover context:
+  [discussion #45](https://github.com/wazootech/worlds-client-ts/discussions/45)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## Unreleased
+
+### Breaking
+
+- Renamed `ClientOptions` to `Adapter`. The interface describes the composed
+  adapter bridging platform-specific infrastructure to the generic `Client`, not
+  passive configuration.
+- Renamed all adapter factory functions to match:
+  - `createRdfjsClientOptions` -> `createRdfjsAdapter`
+  - `createLibsqlClientOptions` -> `createLibsqlAdapter`
+  - `createLibsqlN3ClientOptions` -> `createLibsqlN3Adapter`
+  - `createDenokvClientOptions` -> `createDenokvAdapter`
+- Factory source files renamed for file-symbol alignment (e.g.
+  `create-libsql-client.ts` -> `create-libsql-adapter.ts`).
+
+### Migration
+
+```typescript
+// Before
+const client = new Client(await createLibsqlClientOptions({ client: db }));
+
+// After
+const client = new Client(await createLibsqlAdapter({ client: db }));
+```
+
 ## 0.0.14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -15,300 +15,38 @@
   <a href="https://deepwiki.com/wazootech/worlds-client-ts"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki" /></a>
 </p>
 
-Worlds is the infrastructure layer for persistent, edge-native knowledge. The
-engine implements a edge-native semantic knowledge graph backed by transactional
-persistence, complete with hybrid vector search and a standard SPARQL query
-engine.
-
-- **Reasoning:** Built-in SPARQL engine for declarative knowledge discovery.
-- **Edge-Native:** Support for local SQLite (LibSQL) and stateless Deno Kv
-  adapters.
-- **Hybrid Search:** Combines keyword FTS5 with vector embeddings for flexible
-  recall.
-- **Consistency:** Dual-layer sync and transactional mutation queue
-  serialization.
-- **Observability:** Native OpenTelemetry tracing support.
-
-Worlds delivers these features through an open-source TypeScript SDK.
-
-> [!IMPORTANT]
-> **JSR:** [`@worlds/client`](https://jsr.io/@worlds/client) includes batched
-> LibSQL hydration, post-preload benchmark methodology, and scale SPARQL
-> query-shape helpers.
->
-> **Production:** use Turso Cloud through `createLibsqlClientOptions` + `Client`
-> for scale. Prefer hexastore SPARQL on LibSQL without mirroring the full graph
-> into N3. The RDFJS-backed and Deno Kv-backed search/index paths, including
-> topologies built around `RdfjsSearchIndex` and `DenokvSearchIndex`, are best
-> suited to local development, tests, and constrained single-process demos. They
-> are not the recommended production topology.
-
-## Use Worlds
-
-<table>
-<tr>
-<td width="50%" valign="top">
-
-### Run locally
-
-Explore transient and persistent graphs, run queries, and build knowledge.
-
-ACID-compliant graph syncing.
-
-[→ Quickstart Example](#quickstart)
-
-<br>
-</td>
-<td width="50%" valign="top">
-
-### Deploy to the edge
-
-Enable lightweight, stateless graph execution via Deno Kv on the edge.
-
-Best for prototypes, tests, and constrained single-process deployments rather
-than the primary production recommendation.
-
-[→ Benchmarks](benchmarks/README.md)
-
-<br>
-</td>
-</tr>
-</table>
-
-## Context for agents
-
-The Worlds Client SDK provides agents with durable semantic context.
-
-> [!IMPORTANT]
-> Logical facts are technical descriptions of graph state. Worlds Client focuses
-> on deterministic symbolic logic, managing explicit relationships to supply
-> LLMs with verifiable symbolic reasoning.
-
-### Instantiation
-
-Adapters wire three subsystems (`quadStore`, `sparqlEngine`, `searchIndex`) into
-`ClientOptions`. The `Client` class is a thin facade over that bag.
-
-For production-scale deployments, prefer LibSQL-compatible infrastructure such
-as Turso Cloud through `createLibsqlClientOptions` + `Client`.
-
-```typescript
-import { Client } from "@worlds/client";
-import {
-  createComunicaLibsqlSparqlEngineFactory,
-  createComunicaSparqlEngineFactory,
-} from "@worlds/client/adapters/comunica";
-import { createLibsqlClientOptions } from "@worlds/client/adapters/libsql";
-import { createRdfjsClientOptions } from "@worlds/client/adapters/rdfjs";
-import { createDenokvClientOptions } from "@worlds/client/adapters/denokv";
-import { createClient } from "@libsql/client";
-import { QueryEngine } from "@comunica/query-sparql-rdfjs-lite";
-
-// 1. In-memory / transient graph (default)
-const inMemoryClient = new Client(createRdfjsClientOptions());
-
-// 2. Local SQLite or Turso via LibSQL (recommended for production)
-const db = createClient({ url: "file:./worlds.db" });
-const queryEngine = new QueryEngine();
-const libsqlClient = new Client(
-  await createLibsqlClientOptions({
-    client: db,
-    createSparqlEngine: createComunicaLibsqlSparqlEngineFactory({
-      queryEngine,
-    }),
-  }),
-);
-
-// 3. Deno Kv (prototyping / constrained edge — not primary production path)
-const kv = await Deno.openKv();
-const kvClient = new Client(
-  createDenokvClientOptions({
-    kv,
-    createSparqlEngine: createComunicaSparqlEngineFactory({ queryEngine }),
-  }),
-);
-```
-
-Cache `ClientOptions` (or a `Client`) in module scope when reusing wiring across
-requests — see **Runtime patterns** below.
-
-### Runtime patterns
-
-| Deployment                       | Examples                        | What to reuse across requests                                                 |
-| :------------------------------- | :------------------------------ | :---------------------------------------------------------------------------- |
-| Serverless / edge (warm isolate) | Deno Deploy, Vercel Edge        | `ClientOptions` or `Client` built **once per isolate** — not per HTTP request |
-| Long-running service             | Fly.io, DigitalOcean, 24/7 Deno | One `Client` at **process boot**                                              |
-
-Runnable matrices:
-
-- Long-running: [`examples/libsql-long-running`](examples/libsql-long-running)
-  (`hexastore.ts`, `n3.ts`)
-- Warm isolate:
-  [`examples/libsql-n3-warm-container`](examples/libsql-n3-warm-container)
-  (`hexastore.ts`, `n3.ts`)
-
-Do not call `createLibsqlN3ClientOptions` on every HTTP request when reusing a
-warmed N3 `store` — that rebuilds proxies, search index, and patch sync each
-time.
-
-#### Discovery search and SPARQL reasoning
-
-Use **search** to discover subject IRIs from natural-language queries, then run
-**SPARQL** on those IRIs to disambiguate and reason over facts. The AI SDK hello
-world example follows this two-hop pattern.
-
-**Agent prompt contract** (aligned with
-[worlds-client-evals](https://github.com/wazootech/worlds-client-evals) tools
-and system prompt):
-
-- Call **search** first with an exact label or keyword; use **`subject`** (and
-  **`predicate`** when helpful) from results — not **`text`** alone — for
-  SPARQL.
-- **`SearchResult.text`** is the object literal; discovery tokens live in the
-  FTS index only.
-- Call **SPARQL** for traversal; use `SELECT ?p ?o WHERE { <uri> ?p ?o }` to
-  inspect a resource before targeted queries.
-- Final answers use **exact literals from SPARQL bindings**; say “not found”
-  instead of guessing.
-- Stop tooling once the requested literal appears in bindings.
-
-Canonical strings live in
-[`examples/ai-sdk-hello-world/agent-prompts.ts`](examples/ai-sdk-hello-world/agent-prompts.ts)
-and
-[`examples/ai-sdk-hello-world/tools/agent-tool-descriptions.ts`](examples/ai-sdk-hello-world/tools/agent-tool-descriptions.ts).
-
-LibSQL indexes split literal ground truth from discovery text:
-
-- `chunks.value` — object literal returned as `SearchResult.text`
-- `chunks.fts_value` — subject local name, predicate phrase, literal, and label
-  aliases for FTS/vectors
-
-Configure extra label predicates (union with built-in `rdfs:label`,
-`skos:prefLabel`, `schema:name`):
-
-```typescript
-const client = new Client(
-  await createLibsqlClientOptions({
-    client: db,
-    labelPredicates: ["http://example.org/customLabel"],
-  }),
-);
-```
-
-After a schema upgrade or bulk ontology import, rebuild all search chunks from
-durable `quads`:
-
-```typescript
-await client.rebuildSearchIndex({
-  quadFilter: { include: { graphs: ["http://example.org/ontology"] } },
-});
-```
-
-Advanced: `rebuildLibsqlSearchIndexFromQuads` in
-`@worlds/client/adapters/libsql` remains available when you do not have a
-`Client` instance.
-
-After renaming an entity, refresh every chunk for affected subjects:
-
-```typescript
-import { refreshSearchChunksForSubjects } from "@worlds/client/adapters/libsql";
-
-await refreshSearchChunksForSubjects(["http://example.org/Aurelia"], {
-  client: db,
-  textSplitter,
-  libsqlQueryBuilder,
-  embeddingService,
-});
-```
-
-Label predicate commits fan out automatically; sibling fact rows pick up new
-alias tokens in `fts_value`.
-
-### Choosing a LibSQL topology
-
-Both options builders provision hexastore indexes at schema init. Pick by how
-much graph you mirror in memory and how you run SPARQL.
-
-| Options builder               | Module                              | When to use                                                                                                                  |
-| :---------------------------- | :---------------------------------- | :--------------------------------------------------------------------------------------------------------------------------- |
-| `createLibsqlClientOptions`   | `@worlds/client/adapters/libsql`    | **Production and large graphs.** SPARQL runs on `LibsqlStore` (hexastore). No full N3 hydration per request.                 |
-| `createLibsqlN3ClientOptions` | `@worlds/client/adapters/libsql/n3` | **Selective workloads** where hydrating into N3 is acceptable. Reuse one warmed `store` per container, not per HTTP request. |
-
-Post-preload benchmarks (1k–50k quads) show **hydrate+N3** can win **selective**
-queries when the graph is already in memory; **libsqlStore** avoids full
-hydration cost and is the better default as graphs grow. Avoid unbound
-full-graph scans at production scale.
-
-- Canonical crossover write-up:
-  [discussion #69](https://github.com/wazootech/worlds-client-ts/discussions/69)
-- Local numbers and methodology: [`benchmarks/README.md`](benchmarks/README.md)
-- Scale roadmap (millions of quads):
-  [#68](https://github.com/wazootech/worlds-client-ts/issues/68)
-
-```typescript
-import { createLibsqlClientOptions } from "@worlds/client/adapters/libsql";
-import { createLibsqlN3ClientOptions } from "@worlds/client/adapters/libsql/n3";
-```
-
-### Scale and SPARQL query shape
-
-At millions of quads, pick the topology at integration time — there is no
-runtime SPARQL router
-([#63](https://github.com/wazootech/worlds-client-ts/issues/63)).
-
-| Concern         | Production default                                                                                                                                                                                                      |
-| :-------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| LibSQL topology | `createLibsqlClientOptions` — hexastore `LibsqlStore`, no full N3 mirror per request                                                                                                                                    |
-| Hot-path SPARQL | Bind at least one term (subject, predicate, or object). Subject-bound property lookups match crossover **selective** shapes and stay index-friendly                                                                     |
-| Avoid at scale  | Unbound `?s ?p ?o` (even with `LIMIT`) on `libsqlStore` — crossover **fullScan** degrades to hundreds of ms–seconds as quads grow ([#69](https://github.com/wazootech/worlds-client-ts/discussions/69))                 |
-| N3 + Comunica   | `createLibsqlN3ClientOptions` only when you need in-memory N3; pass a warmed `store` hydrated **once per container**, not per HTTP request                                                                              |
-| Local crossover | `deno task bench` → `sparql-hexastore-crossover.bench.ts`; 100k–1M opt-in: `deno task bench:crossover-large` — see [`benchmarks/README.md`](benchmarks/README.md)                                                       |
-| Bulk import     | `deferSearchIndexOnImport: true` persists quads on import, then rebuilds search index after each import; `searchIndexOnImport: false` skips indexing until `await client.rebuildSearchIndex()` (SPARQL-only bulk loads) |
-| Cardinality     | `LibsqlStore.countQuads` is used by Comunica when hexastore SPARQL is wired (no extra adapter config)                                                                                                                   |
-
-Query helpers (same shapes as benchmarks):
-
-```typescript
-import {
-  createCappedUnboundTriplePatternSparqlQuery,
-  createSubjectBoundPropertiesSparqlQuery,
-} from "@worlds/client/adapters/libsql";
-
-const selectiveQuery = createSubjectBoundPropertiesSparqlQuery("urn:entity:0");
-// SELECT ?property ?object WHERE { <urn:entity:0> ?property ?object }
-
-const devScanQuery = createCappedUnboundTriplePatternSparqlQuery(100);
-// SELECT ?subject ?property ?object WHERE { ?subject ?property ?object } LIMIT 100
-```
-
-Runnable walkthrough: `deno task example:libsql-sparql-scale`
-([`examples/libsql-sparql-scale`](examples/libsql-sparql-scale)).
-
-**JSR:** [`@worlds/client`](https://jsr.io/@worlds/client) ships batched LibSQL
-hydration (`DEFAULT_HYDRATION_BATCH_SIZE = 1000`), SPARQL query-shape helpers,
-and production scale guidance
-([#68](https://github.com/wazootech/worlds-client-ts/issues/68)). Warm N3
-containers: `deno task example:libsql-n3-warm-container:n3`.
-
-## Build with Worlds SDK
-
-Include Worlds as your semantic context layer.
-
-### Install
+Worlds is the infrastructure layer for persistent, edge-native knowledge graphs.
+The TypeScript SDK provides transactional graph storage, hybrid search, and
+declarative SPARQL querying for agents and applications.
+
+- **Store**: Persist RDF knowledge graphs on SQLite, Turso, or Deno KV.
+- **Search**: Hybrid retrieval combining keyword FTS5 and vector embeddings.
+- **Query**: Built-in SPARQL engine for declarative graph traversal and
+  reasoning.
+- **Sync**: Transactional mutation queue with dual-layer persistence.
+
+## Install
 
 ```bash
 deno add jsr:@worlds/client
 ```
 
-### Quickstart
+## Quickstart
 
 ```typescript
 import { Client } from "@worlds/client";
-import { createRdfjsClientOptions } from "@worlds/client/adapters/rdfjs";
+import { createComunicaSparqlEngineFactory } from "@worlds/client/adapters/comunica";
+import { createRdfjsAdapter } from "@worlds/client/adapters/rdfjs";
+import { QueryEngine } from "@comunica/query-sparql-rdfjs-lite";
 
-const client = new Client(createRdfjsClientOptions());
+const client = new Client(
+  createRdfjsAdapter({
+    createSparqlEngine: createComunicaSparqlEngineFactory({
+      queryEngine: new QueryEngine(),
+    }),
+  }),
+);
 
-// 1. Ingest structural Turtle data
 await client.import({
   source: {
     kind: "serialized",
@@ -319,92 +57,122 @@ await client.import({
   },
 });
 
-// 2. Perform hybrid text search over the graph
 const searchResults = await client.search({ query: "explores" });
+const subject = searchResults.results[0].subject;
+
+const sparqlResponse = await client.sparql({
+  query: `SELECT ?property ?object WHERE { <${subject}> ?property ?object }`,
+});
+console.log(sparqlResponse);
 ```
 
-## Run demonstrations
+> [!TIP]
+> For production, use the LibSQL adapter with Turso Cloud. See
+> [Adapters](#adapters) below.
 
-We provide preconfigured executable tasks demonstrating the architecture:
+## Core concepts
 
-### In-memory hello world
+**Quad store**: Manages RDF triples (subject, predicate, object, graph) with
+transactional import and export.
 
-Basic intro demonstrating graph composition and SPARQL queries.
+**Search index**: Hybrid retrieval over graph literals, combining keyword FTS5
+with vector similarity via an embedding service and quad chunker.
 
-```bash
-deno task example:hello-world
+**SPARQL engine**: Evaluates declarative queries and updates against the graph
+for structured traversal and reasoning.
+
+## Adapters
+
+| Adapter | Best for                      | Persistence          | SPARQL                           |
+| :------ | :---------------------------- | :------------------- | :------------------------------- |
+| RDFJS   | Dev, tests, demos             | None (in-memory)     | Via Comunica over N3 store       |
+| LibSQL  | Production, scale             | SQLite / Turso Cloud | Hexastore indexes on LibsqlStore |
+| Deno KV | Prototyping, constrained edge | Deno KV store        | Per-query hydration into N3      |
+
+### RDFJS (in-memory)
+
+```typescript
+import { Client } from "@worlds/client";
+import { createComunicaSparqlEngineFactory } from "@worlds/client/adapters/comunica";
+import { createRdfjsAdapter } from "@worlds/client/adapters/rdfjs";
+import { QueryEngine } from "@comunica/query-sparql-rdfjs-lite";
+
+const client = new Client(
+  createRdfjsAdapter({
+    createSparqlEngine: createComunicaSparqlEngineFactory({
+      queryEngine: new QueryEngine(),
+    }),
+  }),
+);
 ```
 
-### LibSQL long-running (Fly.io / DigitalOcean)
+### LibSQL (production)
 
-Hexastore (production default) and N3 hydrate paths for 24/7 processes.
+```typescript
+import { Client } from "@worlds/client";
+import { createComunicaLibsqlSparqlEngineFactory } from "@worlds/client/adapters/comunica";
+import { createLibsqlAdapter } from "@worlds/client/adapters/libsql";
+import { createClient } from "@libsql/client";
+import { QueryEngine } from "@comunica/query-sparql-rdfjs-lite";
 
-```bash
-deno task download:tfjs-use   # hexastore example only
-deno task example:libsql-long-running:hexastore
-deno task example:libsql-long-running:n3
+const db = createClient({ url: "file:./worlds.db" });
+const client = new Client(
+  await createLibsqlAdapter({
+    client: db,
+    createSparqlEngine: createComunicaLibsqlSparqlEngineFactory({
+      queryEngine: new QueryEngine(),
+    }),
+  }),
+);
 ```
 
-See [`examples/libsql-long-running`](examples/libsql-long-running).
+### Deno KV (prototyping)
 
-### LibSQL SPARQL at scale
+```typescript
+import { Client } from "@worlds/client";
+import { createComunicaSparqlEngineFactory } from "@worlds/client/adapters/comunica";
+import { createDenokvAdapter } from "@worlds/client/adapters/denokv";
+import { QueryEngine } from "@comunica/query-sparql-rdfjs-lite";
 
-Subject-bound vs capped-scan query shapes for large graphs
-([#68](https://github.com/wazootech/worlds-client-ts/issues/68)).
-
-```bash
-deno task example:libsql-sparql-scale
+const kv = await Deno.openKv();
+const client = new Client(
+  createDenokvAdapter({
+    kv,
+    createSparqlEngine: createComunicaSparqlEngineFactory({
+      queryEngine: new QueryEngine(),
+    }),
+  }),
+);
 ```
 
-### LibSQL warm container (serverless / edge)
+## Examples
 
-Reuse wiring once per warm isolate — not per HTTP request
-([#68](https://github.com/wazootech/worlds-client-ts/issues/68)).
+| Example                                                       | Description                                    | Command                                                |
+| :------------------------------------------------------------ | :--------------------------------------------- | :----------------------------------------------------- |
+| [Hello world](examples/hello-world)                           | In-memory graph with search                    | `deno task example:hello-world`                        |
+| [LibSQL hexastore](examples/libsql-long-running)              | Production hexastore for long-running services | `deno task example:libsql-long-running:hexastore`      |
+| [LibSQL N3](examples/libsql-long-running)                     | Hydrate-once N3 path for long-running services | `deno task example:libsql-long-running:n3`             |
+| [LibSQL SPARQL scale](examples/libsql-sparql-scale)           | Subject-bound vs capped-scan query shapes      | `deno task example:libsql-sparql-scale`                |
+| [Warm container hexastore](examples/libsql-n3-warm-container) | Reuse client per warm isolate                  | `deno task example:libsql-n3-warm-container:hexastore` |
+| [Warm container N3](examples/libsql-n3-warm-container)        | Reuse hydrated store per warm isolate          | `deno task example:libsql-n3-warm-container:n3`        |
+| [Deno KV](examples/denokv-hello-world)                        | Stateless per-operation hydration              | `deno task example:denokv-hello-world`                 |
+| [AI SDK](examples/ai-sdk-hello-world)                         | Vercel AI SDK tools with Gemini                | `deno task example:ai-sdk-hello-world`                 |
 
-```bash
-deno task example:libsql-n3-warm-container:hexastore
-deno task example:libsql-n3-warm-container:n3
-```
+The [agent eval harness](https://github.com/wazootech/worlds-client-evals) lives
+in a separate repository and runs deterministic assertion checks against a
+seeded LibSQL world.
 
-`example:libsql-n3-warm-container` aliases the N3 entry. See
-[`examples/libsql-n3-warm-container`](examples/libsql-n3-warm-container).
+## Advanced
 
-### Stateless Deno Kv
+**Choosing a LibSQL topology**: hexastore vs N3 hydration, warm containers,
+SPARQL query shape at scale, and bulk import strategies.
+[-> AGENTS.md](AGENTS.md)
 
-Per-operation lazy hydration running in zero-maintenance edge contexts.
+**Agent integration**: search-then-SPARQL two-hop pattern for LLM tool use with
+hybrid retrieval. [-> AGENTS.md](AGENTS.md)
 
-This path is useful for prototypes and constrained edge execution, but it is not
-the recommended production topology when you need the full API surface and
-search/index behavior at scale.
-
-```bash
-deno task example:denokv-hello-world
-```
-
-### AI SDK integration (Gemini + tools)
-
-Wrap the Client as Vercel AI SDK tools for autonomous LLM reasoning.
-
-```bash
-deno task example:ai-sdk-hello-world
-```
-
-### Agent eval harness
-
-The eval harness lives in
-[worlds-client-evals](https://github.com/wazootech/worlds-client-evals). It is a
-separate repository that consumes `@worlds/client` as a published package and
-runs deterministic assertion checks and live model trials against a seeded
-in-memory LibSQL world.
-
-To run evals, clone the evals repo and follow its
-[README](https://github.com/wazootech/worlds-client-evals#readme):
-
-```bash
-git clone https://github.com/wazootech/worlds-client-evals.git
-cd worlds-client-evals
-deno task evals
-```
+**Benchmarks**: local-only performance captures, crossover methodology, and
+regression policy. [-> benchmarks/README.md](benchmarks/README.md)
 
 ## Development workflow
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -45,9 +45,9 @@ deno bench --allow-all --unstable-kv benchmarks/
 deno bench --allow-all benchmarks/sparql-hexastore-crossover.bench.ts
 ```
 
-**Standard (1k–50k):** compares **hydrate+N3** (`createLibsqlN3ClientOptions`
-from `@worlds/client/adapters/libsql/n3`) vs **libsqlStore**
-(`createLibsqlClientOptions` from `@worlds/client/adapters/libsql`).
+**Standard (1k–50k):** compares **hydrate+N3** (`createLibsqlN3Adapter` from
+`@worlds/client/adapters/libsql/n3`) vs **libsqlStore** (`createLibsqlAdapter`
+from `@worlds/client/adapters/libsql`).
 
 **Large (100k–1M):** **libsqlStore only** — the scalable LibSQL path for hybrid
 search + SPARQL in production
@@ -130,10 +130,10 @@ create a fresh database per iteration and use `warmup: 5`, `n: 50`.
   ```
 
 **Production (millions of quads):** prefer
-[`createLibsqlClientOptions`](../src/client/adapters/libsql/create-libsql-client.ts)
+[`createLibsqlAdapter`](../src/client/adapters/libsql/create-libsql-adapter.ts)
 for indexed SPARQL without a full N3 mirror; reuse a warmed
-[`store`](../src/client/adapters/libsql/n3/create-libsql-n3-client.ts) on the N3
-path per container, not per request. Track guidance in
+[`store`](../src/client/adapters/libsql/n3/create-libsql-n3-adapter.ts) on the
+N3 path per container, not per request. Track guidance in
 [#68](https://github.com/wazootech/worlds-client-ts/issues/68).
 
 Baselines in the **pre-preload** table (below) are **not** directly comparable

--- a/benchmarks/denokv-pressure.bench.ts
+++ b/benchmarks/denokv-pressure.bench.ts
@@ -1,5 +1,5 @@
 import { Client } from "@worlds/client";
-import { createDenokvClientOptions } from "@worlds/client/adapters/denokv";
+import { createDenokvAdapter } from "@worlds/client/adapters/denokv";
 import { generateSyntheticQuads } from "./shared/synthetic-data.ts";
 
 // Pre-allocated payloads for strict repeatable boundaries
@@ -19,8 +19,8 @@ async function setupIsolatedClient(): Promise<{
   kv: Deno.Kv;
 }> {
   const kv = await Deno.openKv(":memory:");
-  const clientOptions = createDenokvClientOptions({ kv });
-  const client = new Client(clientOptions);
+  const adapter = createDenokvAdapter({ kv });
+  const client = new Client(adapter);
   return { client, kv };
 }
 

--- a/benchmarks/libsql-pressure.bench.ts
+++ b/benchmarks/libsql-pressure.bench.ts
@@ -1,7 +1,7 @@
 import { createClient } from "@libsql/client";
 import { Store } from "n3";
 import { Client } from "@worlds/client";
-import { createLibsqlN3ClientOptions } from "@worlds/client/adapters/libsql/n3";
+import { createLibsqlN3Adapter } from "@worlds/client/adapters/libsql/n3";
 import { hydrateStoreFromLibsql } from "@worlds/client/adapters/libsql";
 import { FakeEmbeddingService } from "@worlds/client/search-index/embedding-service";
 import { generateSyntheticQuads } from "./shared/synthetic-data.ts";
@@ -25,11 +25,11 @@ async function setupIsolatedClient(): Promise<{
 }> {
   const db = createClient({ url: ":memory:" });
   const embeddingService = new FakeEmbeddingService();
-  const clientOptions = await createLibsqlN3ClientOptions({
+  const adapter = await createLibsqlN3Adapter({
     client: db,
     embeddingService,
   });
-  const client = new Client(clientOptions);
+  const client = new Client(adapter);
   return { client, db };
 }
 

--- a/benchmarks/search-comparison.bench.ts
+++ b/benchmarks/search-comparison.bench.ts
@@ -2,7 +2,7 @@ import { createClient } from "@libsql/client";
 import { Store } from "n3";
 import { RdfjsSearchIndex } from "@worlds/client/adapters/rdfjs";
 import { LibsqlSearchIndex } from "@worlds/client/adapters/libsql";
-import { createLibsqlN3ClientOptions } from "@worlds/client/adapters/libsql/n3";
+import { createLibsqlN3Adapter } from "@worlds/client/adapters/libsql/n3";
 import { defaultLibsqlQueryBuilder } from "@worlds/client/adapters/libsql";
 import { Client } from "@worlds/client";
 import { generateSyntheticQuads } from "./shared/synthetic-data.ts";
@@ -15,7 +15,7 @@ import { generateSyntheticQuads } from "./shared/synthetic-data.ts";
 async function prepareLibsqlSearchIndex(count: number) {
   const db = createClient({ url: ":memory:" });
   const client = new Client(
-    await createLibsqlN3ClientOptions({ client: db }), // No embedding service -> Pure Keyword FTS Mode
+    await createLibsqlN3Adapter({ client: db }), // No embedding service -> Pure Keyword FTS Mode
   );
 
   // Batch ingestion in segments to prevent exceeding SQL statement variable caps

--- a/benchmarks/shared/crossover-db-cache.test.ts
+++ b/benchmarks/shared/crossover-db-cache.test.ts
@@ -2,7 +2,7 @@ import { assertEquals, assertExists, assertNotEquals } from "@std/assert";
 import { createClient } from "@libsql/client";
 import * as path from "@std/path";
 import { Client } from "@worlds/client";
-import { createLibsqlClientOptions } from "@worlds/client/adapters/libsql";
+import { createLibsqlAdapter } from "@worlds/client/adapters/libsql";
 import type { Quad } from "@rdfjs/types";
 import {
   buildCrossoverFixtureChecksumInputs,
@@ -18,11 +18,11 @@ async function importCorpusIntoLibsqlHexastoreForTest(
   databaseClient: ReturnType<typeof createClient>,
   corpusQuads: Quad[],
 ): Promise<void> {
-  const clientOptions = await createLibsqlClientOptions({
+  const adapter = await createLibsqlAdapter({
     client: databaseClient,
     searchIndexOnImport: false,
   });
-  const worldsClient = new Client(clientOptions);
+  const worldsClient = new Client(adapter);
   await worldsClient.import({
     source: { kind: "quads", quads: corpusQuads },
   });

--- a/benchmarks/shared/sparql-hexastore-crossover-shared.ts
+++ b/benchmarks/shared/sparql-hexastore-crossover-shared.ts
@@ -6,8 +6,8 @@ import {
   createComunicaLibsqlSparqlEngineFactory,
   createComunicaSparqlEngineFactory,
 } from "@worlds/client/adapters/comunica";
-import { createLibsqlClientOptions } from "@worlds/client/adapters/libsql";
-import { createLibsqlN3ClientOptions } from "@worlds/client/adapters/libsql/n3";
+import { createLibsqlAdapter } from "@worlds/client/adapters/libsql";
+import { createLibsqlN3Adapter } from "@worlds/client/adapters/libsql/n3";
 import type { SparqlEngineInterface } from "@worlds/client/sparql-engine";
 import {
   buildCrossoverFixtureChecksumInputs,
@@ -101,11 +101,11 @@ async function importCorpusIntoLibsqlHexastore(
   databaseClient: ReturnType<typeof createClient>,
   corpusQuads: Quad[],
 ): Promise<void> {
-  const clientOptions = await createLibsqlClientOptions({
+  const adapter = await createLibsqlAdapter({
     client: databaseClient,
     searchIndexOnImport: false,
   });
-  const worldsClient = new Client(clientOptions);
+  const worldsClient = new Client(adapter);
   await worldsClient.import({
     source: { kind: "quads", quads: corpusQuads },
   });
@@ -117,17 +117,17 @@ async function importCorpusIntoLibsqlHexastore(
 async function openLibsqlHexastoreSparqlEngine(
   databaseClient: ReturnType<typeof createClient>,
 ): Promise<PreloadedSparqlFixture> {
-  const clientOptions = await createLibsqlClientOptions({
+  const adapter = await createLibsqlAdapter({
     client: databaseClient,
     searchIndexOnImport: false,
     createSparqlEngine: createComunicaLibsqlSparqlEngineFactory({
       queryEngine: sharedQueryEngine,
     }),
   });
-  if (!clientOptions.sparqlEngine) {
+  if (!adapter.sparqlEngine) {
     throw new Error("libsqlStore bench requires createSparqlEngine");
   }
-  return { databaseClient, sparqlEngine: clientOptions.sparqlEngine };
+  return { databaseClient, sparqlEngine: adapter.sparqlEngine };
 }
 
 /**
@@ -186,21 +186,21 @@ async function createHydrateN3SparqlEngine(
   corpusQuads: Quad[],
 ): Promise<PreloadedSparqlFixture> {
   const databaseClient = createClient({ url: ":memory:" });
-  const clientOptions = await createLibsqlN3ClientOptions({
+  const adapter = await createLibsqlN3Adapter({
     client: databaseClient,
     searchIndexOnImport: false,
     createSparqlEngine: createComunicaSparqlEngineFactory({
       queryEngine: sharedQueryEngine,
     }),
   });
-  const worldsClient = new Client(clientOptions);
+  const worldsClient = new Client(adapter);
   await worldsClient.import({
     source: { kind: "quads", quads: corpusQuads },
   });
-  if (!clientOptions.sparqlEngine) {
+  if (!adapter.sparqlEngine) {
     throw new Error("hydrate+N3 bench requires createSparqlEngine");
   }
-  return { databaseClient, sparqlEngine: clientOptions.sparqlEngine };
+  return { databaseClient, sparqlEngine: adapter.sparqlEngine };
 }
 
 async function createSparqlEngineForBackend(

--- a/examples/ai-sdk-hello-world/main.ts
+++ b/examples/ai-sdk-hello-world/main.ts
@@ -1,7 +1,7 @@
 import { createClient } from "@libsql/client";
 import { Client } from "@worlds/client";
 import { createComunicaLibsqlSparqlEngineFactory } from "@worlds/client/adapters/comunica";
-import { createLibsqlClientOptions } from "@worlds/client/adapters/libsql";
+import { createLibsqlAdapter } from "@worlds/client/adapters/libsql";
 import { QueryEngine } from "@comunica/query-sparql-rdfjs-lite";
 import { GRAPH_GROUNDED_AGENT_SYSTEM_PROMPT } from "./agent-prompts.ts";
 import { createTools } from "./tools.ts";
@@ -16,7 +16,7 @@ if (import.meta.main) {
   const queryEngine = new QueryEngine();
 
   const client = new Client(
-    await createLibsqlClientOptions({
+    await createLibsqlAdapter({
       client: database,
       createSparqlEngine: createComunicaLibsqlSparqlEngineFactory({
         queryEngine,

--- a/examples/denokv-hello-world/main.ts
+++ b/examples/denokv-hello-world/main.ts
@@ -1,10 +1,10 @@
 import { Client } from "@worlds/client";
 import { createComunicaSparqlEngineFactory } from "@worlds/client/adapters/comunica";
-import { createDenokvClientOptions } from "@worlds/client/adapters/denokv";
+import { createDenokvAdapter } from "@worlds/client/adapters/denokv";
 import { QueryEngine } from "@comunica/query-sparql-rdfjs-lite";
 
 /**
- * This example demonstrates how to use `createDenokvClientOptions` for persistent, durable
+ * This example demonstrates how to use `createDenokvAdapter` for persistent, durable
  * storage of RDF graph context, combined with stateless serverless search and query execution.
  */
 if (import.meta.main) {
@@ -14,7 +14,7 @@ if (import.meta.main) {
 
   console.log("🧠 Provisioning unified Deno Kv sync engine...");
   const client = new Client(
-    createDenokvClientOptions({
+    createDenokvAdapter({
       kv,
       createSparqlEngine: createComunicaSparqlEngineFactory({ queryEngine }),
     }),

--- a/examples/hello-world/main.ts
+++ b/examples/hello-world/main.ts
@@ -1,12 +1,12 @@
 import { Client } from "@worlds/client";
 import { createComunicaSparqlEngineFactory } from "@worlds/client/adapters/comunica";
-import { createRdfjsClientOptions } from "@worlds/client/adapters/rdfjs";
+import { createRdfjsAdapter } from "@worlds/client/adapters/rdfjs";
 import { QueryEngine } from "@comunica/query-sparql-rdfjs-lite";
 
 if (import.meta.main) {
   const queryEngine = new QueryEngine();
   const client = new Client(
-    createRdfjsClientOptions({
+    createRdfjsAdapter({
       createSparqlEngine: createComunicaSparqlEngineFactory({ queryEngine }),
     }),
   );

--- a/examples/libsql-long-running/README.md
+++ b/examples/libsql-long-running/README.md
@@ -1,8 +1,8 @@
 # LibSQL long-running service
 
 For **Fly.io**, **DigitalOcean App Platform**, and other **24/7** Deno/Node
-processes: build `ClientOptions` once at boot and hold one `Client` for the
-process lifetime.
+processes: build a `Adapter` once at boot and hold one `Client` for the process
+lifetime.
 
 | Entry          | Topology                                     | Command                                           |
 | :------------- | :------------------------------------------- | :------------------------------------------------ |

--- a/examples/libsql-long-running/hexastore.ts
+++ b/examples/libsql-long-running/hexastore.ts
@@ -2,7 +2,7 @@ import { createClient } from "@libsql/client";
 import { createComunicaLibsqlSparqlEngineFactory } from "@worlds/client/adapters/comunica";
 import { Client } from "@worlds/client";
 import {
-  createLibsqlClientOptions,
+  createLibsqlAdapter,
   createSubjectBoundPropertiesSparqlQuery,
 } from "@worlds/client/adapters/libsql";
 import { UniversalSentenceEncoderEmbeddingService } from "@worlds/client/adapters/tfjs-universal-sentence-encoder";
@@ -56,7 +56,7 @@ if (import.meta.main) {
 
   console.log("Provisioning hexastore client (process lifetime)...");
   const client = new Client(
-    await createLibsqlClientOptions({
+    await createLibsqlAdapter({
       client: databaseClient,
       embeddingService,
       vectorDimensions: USE_LITE_VECTOR_DIMENSIONS,

--- a/examples/libsql-long-running/n3.ts
+++ b/examples/libsql-long-running/n3.ts
@@ -3,7 +3,7 @@ import { QueryEngine } from "@comunica/query-sparql-rdfjs-lite";
 import { createComunicaSparqlEngineFactory } from "@worlds/client/adapters/comunica";
 import { createSubjectBoundPropertiesSparqlQuery } from "@worlds/client/adapters/libsql";
 import { Client } from "@worlds/client";
-import { createLibsqlN3ClientOptions } from "@worlds/client/adapters/libsql/n3";
+import { createLibsqlN3Adapter } from "@worlds/client/adapters/libsql/n3";
 import { DataFactory } from "n3";
 
 const { quad, namedNode, literal } = DataFactory;
@@ -23,7 +23,7 @@ if (import.meta.main) {
     "Boot: hydrate LibSQL into N3 and wire client (process lifetime)...",
   );
   const client = new Client(
-    await createLibsqlN3ClientOptions({
+    await createLibsqlN3Adapter({
       client: databaseClient,
       createSparqlEngine: createComunicaSparqlEngineFactory({ queryEngine }),
     }),

--- a/examples/libsql-n3-warm-container/README.md
+++ b/examples/libsql-n3-warm-container/README.md
@@ -1,16 +1,16 @@
 # LibSQL warm container (serverless / edge)
 
-For **Deno Deploy**, **Vercel Edge**, and other **warm isolates**: build
-`ClientOptions` (or `Client`) **once per isolate** in module scope — not per
-HTTP request ([#68](https://github.com/wazootech/worlds-client-ts/issues/68)).
+For **Deno Deploy**, **Vercel Edge**, and other **warm isolates**: build a
+`Adapter` (or `Client`) **once per isolate** in module scope — not per HTTP
+request ([#68](https://github.com/wazootech/worlds-client-ts/issues/68)).
 
 | Entry          | Topology                                              | Command                                                |
 | :------------- | :---------------------------------------------------- | :----------------------------------------------------- |
 | `hexastore.ts` | Hexastore `LibsqlStore` (production default on edge)  | `deno task example:libsql-n3-warm-container:hexastore` |
 | `n3.ts`        | Hydrate once → reuse `store` + one client per isolate | `deno task example:libsql-n3-warm-container:n3`        |
 
-Anti-pattern at scale: omit `store` and call `createLibsqlN3ClientOptions` on
-every request (full re-wire + implicit hydration).
+Anti-pattern at scale: omit `store` and call `createLibsqlN3Adapter` on every
+request (full re-wire + implicit hydration).
 
 Contrast with long-running services:
 [`examples/libsql-long-running`](../libsql-long-running/README.md).

--- a/examples/libsql-n3-warm-container/hexastore.ts
+++ b/examples/libsql-n3-warm-container/hexastore.ts
@@ -3,7 +3,7 @@ import { QueryEngine } from "@comunica/query-sparql-rdfjs-lite";
 import { Client } from "@worlds/client";
 import { createComunicaLibsqlSparqlEngineFactory } from "@worlds/client/adapters/comunica";
 import {
-  createLibsqlClientOptions,
+  createLibsqlAdapter,
   createSubjectBoundPropertiesSparqlQuery,
 } from "@worlds/client/adapters/libsql";
 import { DataFactory } from "n3";
@@ -21,7 +21,7 @@ let warmIsolateClient: Client | undefined;
 
 async function getWarmIsolateClient(): Promise<Client> {
   warmIsolateClient ??= new Client(
-    await createLibsqlClientOptions({
+    await createLibsqlAdapter({
       client: databaseClient,
       createSparqlEngine: createComunicaLibsqlSparqlEngineFactory({
         queryEngine,

--- a/examples/libsql-n3-warm-container/n3.ts
+++ b/examples/libsql-n3-warm-container/n3.ts
@@ -6,7 +6,7 @@ import {
   hydrateStoreFromLibsql,
 } from "@worlds/client/adapters/libsql";
 import { Client } from "@worlds/client";
-import { createLibsqlN3ClientOptions } from "@worlds/client/adapters/libsql/n3";
+import { createLibsqlN3Adapter } from "@worlds/client/adapters/libsql/n3";
 import { DataFactory, Store } from "n3";
 
 const { quad, namedNode, literal } = DataFactory;
@@ -22,7 +22,7 @@ let warmIsolateClient: Client | undefined;
 
 async function getWarmIsolateClient(warmedStore: Store): Promise<Client> {
   warmIsolateClient ??= new Client(
-    await createLibsqlN3ClientOptions({
+    await createLibsqlN3Adapter({
       client: databaseClient,
       store: warmedStore,
       createSparqlEngine: createComunicaSparqlEngineFactory({ queryEngine }),
@@ -33,7 +33,7 @@ async function getWarmIsolateClient(warmedStore: Store): Promise<Client> {
 
 if (import.meta.main) {
   const bootClient = new Client(
-    await createLibsqlN3ClientOptions({ client: databaseClient }),
+    await createLibsqlN3Adapter({ client: databaseClient }),
   );
   await bootClient.import({
     source: {

--- a/examples/libsql-sparql-scale/README.md
+++ b/examples/libsql-sparql-scale/README.md
@@ -8,7 +8,7 @@ Runnable companion to
 deno task example:libsql-sparql-scale
 ```
 
-Uses `createLibsqlClientOptions` + `Client` with query helpers from
+Uses `createLibsqlAdapter` + `Client` with query helpers from
 `@worlds/client/adapters/libsql`:
 
 - **Selective:** `createSubjectBoundPropertiesSparqlQuery(subjectIri)` — default

--- a/examples/libsql-sparql-scale/main.ts
+++ b/examples/libsql-sparql-scale/main.ts
@@ -4,7 +4,7 @@ import { Client } from "@worlds/client";
 import { createComunicaLibsqlSparqlEngineFactory } from "@worlds/client/adapters/comunica";
 import {
   createCappedUnboundTriplePatternSparqlQuery,
-  createLibsqlClientOptions,
+  createLibsqlAdapter,
   createSubjectBoundPropertiesSparqlQuery,
 } from "@worlds/client/adapters/libsql";
 import { DataFactory } from "n3";
@@ -23,7 +23,7 @@ if (import.meta.main) {
   const queryEngine = new QueryEngine();
 
   const client = new Client(
-    await createLibsqlClientOptions({
+    await createLibsqlAdapter({
       client: databaseClient,
       createSparqlEngine: createComunicaLibsqlSparqlEngineFactory({
         queryEngine,

--- a/src/client/adapters/comunica/comunica-sparql-engine.ts
+++ b/src/client/adapters/comunica/comunica-sparql-engine.ts
@@ -73,7 +73,7 @@ export interface ComunicaBinding {
 export interface ComunicaSparqlEngineOptions {
   /**
    * store is the RDFJS store to execute the query on.
-   * For join cardinality hints, pass a store that implements `countQuads` (e.g. `LibsqlStore` from `createLibsqlClientOptions`).
+   * For join cardinality hints, pass a store that implements `countQuads` (e.g. `LibsqlStore` from `createLibsqlAdapter`).
    */
   store: rdfjs.Store;
 

--- a/src/client/adapters/denokv/create-denokv-adapter.test.ts
+++ b/src/client/adapters/denokv/create-denokv-adapter.test.ts
@@ -5,7 +5,7 @@ import { DataFactory } from "n3";
 import { Client } from "@/client/client.ts";
 import { ComunicaSparqlEngine } from "@/client/adapters/comunica/mod.ts";
 import { DenokvQuadStore } from "./denokv-quad-store.ts";
-import { createDenokvClientOptions } from "./create-denokv-client.ts";
+import { createDenokvAdapter } from "./create-denokv-adapter.ts";
 
 const { quad, namedNode, literal } = DataFactory;
 const queryEngine = new QueryEngine();
@@ -25,11 +25,11 @@ async function seedQuads(
 }
 
 Deno.test(
-  "createDenokvClientOptions - import delivers search hits from Deno Kv",
+  "createDenokvAdapter - import delivers search hits from Deno Kv",
   async () => {
     const kv = await Deno.openKv(":memory:");
     try {
-      const client = new Client(createDenokvClientOptions({ kv }));
+      const client = new Client(createDenokvAdapter({ kv }));
       const testQuad = quad(
         namedNode("urn:person:alice"),
         namedNode("urn:bio"),
@@ -49,11 +49,11 @@ Deno.test(
 );
 
 Deno.test(
-  "createDenokvClientOptions - export round-trips imported quads",
+  "createDenokvAdapter - export round-trips imported quads",
   async () => {
     const kv = await Deno.openKv(":memory:");
     try {
-      const client = new Client(createDenokvClientOptions({ kv }));
+      const client = new Client(createDenokvAdapter({ kv }));
       const testQuad = quad(
         namedNode("urn:doc:1"),
         namedNode("urn:title"),
@@ -76,12 +76,12 @@ Deno.test(
 );
 
 Deno.test(
-  "createDenokvClientOptions - hydration SPARQL reads latest Deno Kv state",
+  "createDenokvAdapter - hydration SPARQL reads latest Deno Kv state",
   async () => {
     const kv = await Deno.openKv(":memory:");
     try {
       const client = new Client(
-        createDenokvClientOptions({
+        createDenokvAdapter({
           kv,
           createSparqlEngine: ({ store }) =>
             new ComunicaSparqlEngine({ queryEngine, store }),
@@ -111,12 +111,12 @@ Deno.test(
 );
 
 Deno.test(
-  "createDenokvClientOptions - hydration SPARQL sees quads imported after client construction",
+  "createDenokvAdapter - hydration SPARQL sees quads imported after client construction",
   async () => {
     const kv = await Deno.openKv(":memory:");
     try {
       const client = new Client(
-        createDenokvClientOptions({
+        createDenokvAdapter({
           kv,
           createSparqlEngine: ({ store }) =>
             new ComunicaSparqlEngine({ queryEngine, store }),
@@ -155,11 +155,11 @@ Deno.test(
 );
 
 Deno.test(
-  "createDenokvClientOptions - sparql rejects when createSparqlEngine is omitted",
+  "createDenokvAdapter - sparql rejects when createSparqlEngine is omitted",
   async () => {
     const kv = await Deno.openKv(":memory:");
     try {
-      const client = new Client(createDenokvClientOptions({ kv }));
+      const client = new Client(createDenokvAdapter({ kv }));
 
       await assertRejects(
         () => client.sparql({ query: "ASK WHERE { ?s ?p ?o }" }),

--- a/src/client/adapters/denokv/create-denokv-adapter.ts
+++ b/src/client/adapters/denokv/create-denokv-adapter.ts
@@ -1,5 +1,5 @@
 import { Store } from "n3";
-import type { ClientOptions } from "@/client/client.ts";
+import type { Adapter } from "@/client/client.ts";
 import type { SparqlEngineInterface } from "@/client/sparql-engine/mod.ts";
 import { DenokvSearchIndex } from "./denokv-search-index.ts";
 import type { DenokvQuadStoreOptions } from "./denokv-quad-store.ts";
@@ -24,14 +24,14 @@ export interface DenokvOptions extends DenokvQuadStoreOptions {
 }
 
 /**
- * createDenokvClientOptions synthesizes a client gateway context designed explicitly for
+ * createDenokvAdapter synthesizes a client adapter designed explicitly for
  * stateless, per-operation execution. It leverages a lazy, transient hydration
  * pipeline that fetches fresh durable quads on-demand, providing strong data
  * consistency without requiring long-lived memory store residency.
  */
-export function createDenokvClientOptions(
+export function createDenokvAdapter(
   options: DenokvOptions,
-): ClientOptions {
+): Adapter {
   const quadStore = new DenokvQuadStore(options);
 
   /**

--- a/src/client/adapters/denokv/mod.ts
+++ b/src/client/adapters/denokv/mod.ts
@@ -1,3 +1,3 @@
 export * from "./denokv-quad-store.ts";
-export * from "./create-denokv-client.ts";
+export * from "./create-denokv-adapter.ts";
 export * from "./denokv-search-index.ts";

--- a/src/client/adapters/libsql/create-libsql-adapter.test.ts
+++ b/src/client/adapters/libsql/create-libsql-adapter.test.ts
@@ -4,7 +4,7 @@ import { QueryEngine } from "@comunica/query-sparql-rdfjs-lite";
 import { DataFactory } from "n3";
 import { Client } from "@/client/client.ts";
 import { ComunicaSparqlEngine } from "@/client/adapters/comunica/mod.ts";
-import { createLibsqlClientOptions } from "./create-libsql-client.ts";
+import { createLibsqlAdapter } from "./create-libsql-adapter.ts";
 import type { LibsqlStore } from "./libsql-store.ts";
 
 const { quad, namedNode, literal } = DataFactory;
@@ -22,12 +22,12 @@ const expectedHexastoreIndexNames = [
 ] as const;
 
 Deno.test(
-  "createLibsqlClientOptions - createSparqlEngine receives LibsqlStore",
+  "createLibsqlAdapter - createSparqlEngine receives LibsqlStore",
   async () => {
     const databaseClient = createClient({ url: ":memory:" });
     let receivedLibsqlStore: LibsqlStore | undefined;
 
-    await createLibsqlClientOptions({
+    await createLibsqlAdapter({
       client: databaseClient,
       createSparqlEngine: ({ libsqlStore }) => {
         receivedLibsqlStore = libsqlStore;
@@ -42,12 +42,12 @@ Deno.test(
 );
 
 Deno.test(
-  "createLibsqlClientOptions - import persists quads readable via SPARQL",
+  "createLibsqlAdapter - import persists quads readable via SPARQL",
   async () => {
     const databaseClient = createClient({ url: ":memory:" });
 
     const client = new Client(
-      await createLibsqlClientOptions({
+      await createLibsqlAdapter({
         client: databaseClient,
         createSparqlEngine: ({ libsqlStore }) =>
           new ComunicaSparqlEngine({ queryEngine, store: libsqlStore }),
@@ -81,11 +81,11 @@ Deno.test(
 );
 
 Deno.test(
-  "createLibsqlClientOptions - initializeSchema provisions all hexastore indexes",
+  "createLibsqlAdapter - initializeSchema provisions all hexastore indexes",
   async () => {
     const databaseClient = createClient({ url: ":memory:" });
 
-    await createLibsqlClientOptions({ client: databaseClient });
+    await createLibsqlAdapter({ client: databaseClient });
 
     const indexResultSet = await databaseClient.execute(
       "SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'quads'",
@@ -99,19 +99,19 @@ Deno.test(
       );
     }
 
-    await createLibsqlClientOptions({ client: databaseClient });
+    await createLibsqlAdapter({ client: databaseClient });
 
     databaseClient.close();
   },
 );
 
 Deno.test(
-  "createLibsqlClientOptions - searchIndexOnImport false skips chunks and search stays empty",
+  "createLibsqlAdapter - searchIndexOnImport false skips chunks and search stays empty",
   async () => {
     const databaseClient = createClient({ url: ":memory:" });
 
     const client = new Client(
-      await createLibsqlClientOptions({
+      await createLibsqlAdapter({
         client: databaseClient,
         searchIndexOnImport: false,
         createSparqlEngine: ({ libsqlStore }) =>
@@ -155,12 +155,12 @@ Deno.test(
 );
 
 Deno.test(
-  "createLibsqlClientOptions - rebuildSearchIndex after searchIndexOnImport false enables search",
+  "createLibsqlAdapter - rebuildSearchIndex after searchIndexOnImport false enables search",
   async () => {
     const databaseClient = createClient({ url: ":memory:" });
 
     const client = new Client(
-      await createLibsqlClientOptions({
+      await createLibsqlAdapter({
         client: databaseClient,
         searchIndexOnImport: false,
         createSparqlEngine: ({ libsqlStore }) =>
@@ -205,14 +205,14 @@ Deno.test(
 );
 
 Deno.test(
-  "createLibsqlClientOptions - rebuildSearchIndex quadFilter scopes indexed graphs",
+  "createLibsqlAdapter - rebuildSearchIndex quadFilter scopes indexed graphs",
   async () => {
     const databaseClient = createClient({ url: ":memory:" });
     const graphAlpha = namedNode("urn:graph:alpha");
     const graphBeta = namedNode("urn:graph:beta");
 
     const client = new Client(
-      await createLibsqlClientOptions({
+      await createLibsqlAdapter({
         client: databaseClient,
         searchIndexOnImport: false,
         createSparqlEngine: ({ libsqlStore }) =>
@@ -255,12 +255,12 @@ Deno.test(
 );
 
 Deno.test(
-  "createLibsqlClientOptions - rebuildSearchIndex is idempotent on second run",
+  "createLibsqlAdapter - rebuildSearchIndex is idempotent on second run",
   async () => {
     const databaseClient = createClient({ url: ":memory:" });
 
     const client = new Client(
-      await createLibsqlClientOptions({
+      await createLibsqlAdapter({
         client: databaseClient,
         searchIndexOnImport: false,
         createSparqlEngine: ({ libsqlStore }) =>
@@ -299,13 +299,13 @@ Deno.test(
 );
 
 Deno.test(
-  "createLibsqlClientOptions - searchIndexOnImport false rejects deferSearchIndexOnImport",
+  "createLibsqlAdapter - searchIndexOnImport false rejects deferSearchIndexOnImport",
   async () => {
     const databaseClient = createClient({ url: ":memory:" });
 
     await assertRejects(
       () =>
-        createLibsqlClientOptions({
+        createLibsqlAdapter({
           client: databaseClient,
           searchIndexOnImport: false,
           deferSearchIndexOnImport: true,

--- a/src/client/adapters/libsql/create-libsql-adapter.ts
+++ b/src/client/adapters/libsql/create-libsql-adapter.ts
@@ -1,6 +1,6 @@
 import { RecursiveCharacterTextSplitter } from "@langchain/textsplitters";
 
-import type { ClientOptions } from "@/client/client.ts";
+import type { Adapter } from "@/client/client.ts";
 import type { SparqlEngineInterface } from "@/client/sparql-engine/mod.ts";
 import { RdfjsQuadStore } from "@/client/adapters/rdfjs/mod.ts";
 
@@ -33,11 +33,11 @@ export interface LibsqlOptions extends LibsqlClientBaseOptions {
 }
 
 /**
- * createLibsqlClientOptions synthesizes ClientOptions for direct LibsqlStore + hexastore indexes.
+ * createLibsqlAdapter synthesizes a Adapter for direct LibsqlStore + hexastore indexes.
  */
-export async function createLibsqlClientOptions(
+export async function createLibsqlAdapter(
   options: LibsqlOptions,
-): Promise<ClientOptions> {
+): Promise<Adapter> {
   assertLibsqlClientIndexingOptions(options);
 
   const vectorDimensions = options.vectorDimensions ?? 32;

--- a/src/client/adapters/libsql/mod.ts
+++ b/src/client/adapters/libsql/mod.ts
@@ -1,5 +1,5 @@
 export * from "./libsql-search-index.ts";
-export * from "./create-libsql-client.ts";
+export * from "./create-libsql-adapter.ts";
 export * from "./initialize-libsql-schema.ts";
 export * from "./libsql-client-base-options.ts";
 export * from "./hydrate-store-from-libsql.ts";

--- a/src/client/adapters/libsql/n3/create-libsql-n3-adapter.test.ts
+++ b/src/client/adapters/libsql/n3/create-libsql-n3-adapter.test.ts
@@ -4,7 +4,7 @@ import { QueryEngine } from "@comunica/query-sparql-rdfjs-lite";
 import { DataFactory, Store } from "n3";
 import { Client } from "@/client/client.ts";
 import { ComunicaSparqlEngine } from "@/client/adapters/comunica/mod.ts";
-import { createLibsqlN3ClientOptions } from "./create-libsql-n3-client.ts";
+import { createLibsqlN3Adapter } from "./create-libsql-n3-adapter.ts";
 import { FakeEmbeddingService } from "@/client/search-index/embedding-service/mod.ts";
 
 const { quad, namedNode, literal } = DataFactory;
@@ -16,7 +16,7 @@ Deno.test("E2E DEMO: unified data entry enables immediate hybrid search availabi
   const embeddingService = new FakeEmbeddingService();
 
   const client = new Client(
-    await createLibsqlN3ClientOptions({
+    await createLibsqlN3Adapter({
       client: db,
       embeddingService,
       createSparqlEngine: ({ store }) =>
@@ -98,7 +98,7 @@ Deno.test("E2E DEMO: unified data entry enables immediate hybrid search availabi
       // Destroy active memory references and simulate a software crash/reboot.
       // Create a fresh client reusing the SAME physical :memory: database.
       const refreshedClient = new Client(
-        await createLibsqlN3ClientOptions({
+        await createLibsqlN3Adapter({
           client: db,
           embeddingService,
         }),
@@ -200,7 +200,7 @@ Deno.test("E2E DEMO: unified data entry enables immediate hybrid search availabi
       const db = createClient({ url: ":memory:" });
       const embeddingService = new FakeEmbeddingService();
       const client = new Client(
-        await createLibsqlN3ClientOptions({
+        await createLibsqlN3Adapter({
           client: db,
           embeddingService,
         }),
@@ -269,7 +269,7 @@ Deno.test("E2E DEMO: unified data entry enables immediate hybrid search availabi
       const db = createClient({ url: ":memory:" });
       const embeddingService = new FakeEmbeddingService();
       const client = new Client(
-        await createLibsqlN3ClientOptions({
+        await createLibsqlN3Adapter({
           client: db,
           embeddingService,
         }),
@@ -342,7 +342,7 @@ Deno.test("QuadFilter Integration: enables hybrid partitioning persisting specif
 
   // Initialize client with filter restricting SQL writes exclusively to the persistent graph
   const client = new Client(
-    await createLibsqlN3ClientOptions({
+    await createLibsqlN3Adapter({
       client: db,
       embeddingService,
       quadFilter: {
@@ -403,7 +403,7 @@ Deno.test("QuadFilter Integration: enables hybrid partitioning persisting specif
   // 4. ASSERT: Verify Hydration boundary on reboot
   // Restart client pointing to the same DB with identical filtering bounds
   const restartedClient = new Client(
-    await createLibsqlN3ClientOptions({
+    await createLibsqlN3Adapter({
       client: db,
       embeddingService,
       quadFilter: {
@@ -451,11 +451,11 @@ const expectedHexastoreIndexNames = [
 ] as const;
 
 Deno.test(
-  "createLibsqlN3ClientOptions - initializeSchema provisions all hexastore indexes",
+  "createLibsqlN3Adapter - initializeSchema provisions all hexastore indexes",
   async () => {
     const db = createClient({ url: ":memory:" });
 
-    await createLibsqlN3ClientOptions({ client: db });
+    await createLibsqlN3Adapter({ client: db });
 
     const indexResultSet = await db.execute(
       "SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'quads'",
@@ -469,7 +469,7 @@ Deno.test(
       );
     }
 
-    await createLibsqlN3ClientOptions({ client: db });
+    await createLibsqlN3Adapter({ client: db });
 
     db.close();
   },

--- a/src/client/adapters/libsql/n3/create-libsql-n3-adapter.ts
+++ b/src/client/adapters/libsql/n3/create-libsql-n3-adapter.ts
@@ -1,7 +1,7 @@
 import { RecursiveCharacterTextSplitter } from "@langchain/textsplitters";
 import { Store } from "n3";
 
-import type { ClientOptions } from "@/client/client.ts";
+import type { Adapter } from "@/client/client.ts";
 import type { Patch } from "@/client/quad-store/mod.ts";
 import type { SparqlEngineInterface } from "@/client/sparql-engine/mod.ts";
 import { proxyStore } from "@/client/adapters/rdfjs/n3/mod.ts";
@@ -40,11 +40,11 @@ export interface LibsqlN3Options extends LibsqlClientBaseOptions {
 }
 
 /**
- * createLibsqlN3ClientOptions synthesizes ClientOptions for the hydrate → proxyStore → LibSQL sync path.
+ * createLibsqlN3Adapter synthesizes a Adapter for the hydrate → proxyStore → LibSQL sync path.
  */
-export async function createLibsqlN3ClientOptions(
+export async function createLibsqlN3Adapter(
   options: LibsqlN3Options,
-): Promise<ClientOptions> {
+): Promise<Adapter> {
   assertLibsqlClientIndexingOptions(options);
 
   const vectorDimensions = options.vectorDimensions ?? 32;

--- a/src/client/adapters/libsql/n3/mod.ts
+++ b/src/client/adapters/libsql/n3/mod.ts
@@ -1,1 +1,1 @@
-export * from "./create-libsql-n3-client.ts";
+export * from "./create-libsql-n3-adapter.ts";

--- a/src/client/adapters/rdfjs/create-rdfjs-adapter.test.ts
+++ b/src/client/adapters/rdfjs/create-rdfjs-adapter.test.ts
@@ -3,15 +3,15 @@ import { QueryEngine } from "@comunica/query-sparql-rdfjs-lite";
 import { DataFactory, Store } from "n3";
 import { Client } from "@/client/client.ts";
 import { ComunicaSparqlEngine } from "@/client/adapters/comunica/mod.ts";
-import { createRdfjsClientOptions } from "./create-rdfjs-client.ts";
+import { createRdfjsAdapter } from "./create-rdfjs-adapter.ts";
 
 const { quad, namedNode, literal } = DataFactory;
 const queryEngine = new QueryEngine();
 
 Deno.test(
-  "createRdfjsClientOptions - import delivers immediate search hits",
+  "createRdfjsAdapter - import delivers immediate search hits",
   async () => {
-    const client = new Client(createRdfjsClientOptions());
+    const client = new Client(createRdfjsAdapter());
     const testQuad = quad(
       namedNode("http://example.com/sub"),
       namedNode("http://example.com/pred"),
@@ -27,7 +27,7 @@ Deno.test(
 );
 
 Deno.test(
-  "createRdfjsClientOptions - preloaded store is shared with the client",
+  "createRdfjsAdapter - preloaded store is shared with the client",
   async () => {
     const store = new Store();
     store.addQuad(
@@ -36,7 +36,7 @@ Deno.test(
       literal("Preloaded fact."),
     );
 
-    const client = new Client(createRdfjsClientOptions({ store }));
+    const client = new Client(createRdfjsAdapter({ store }));
 
     const response = await client.search({ query: "preloaded" });
     assertEquals(response.results?.length, 1);
@@ -45,10 +45,10 @@ Deno.test(
 );
 
 Deno.test(
-  "createRdfjsClientOptions - createSparqlEngine enables SELECT queries",
+  "createRdfjsAdapter - createSparqlEngine enables SELECT queries",
   async () => {
     const client = new Client(
-      createRdfjsClientOptions({
+      createRdfjsAdapter({
         createSparqlEngine: ({ store }) =>
           new ComunicaSparqlEngine({ queryEngine, store }),
       }),
@@ -81,9 +81,9 @@ Deno.test(
 );
 
 Deno.test(
-  "createRdfjsClientOptions - rebuildSearchIndex rejects on non-LibSQL topology",
+  "createRdfjsAdapter - rebuildSearchIndex rejects on non-LibSQL topology",
   async () => {
-    const client = new Client(createRdfjsClientOptions());
+    const client = new Client(createRdfjsAdapter());
 
     await assertRejects(
       () => client.rebuildSearchIndex(),
@@ -94,9 +94,9 @@ Deno.test(
 );
 
 Deno.test(
-  "createRdfjsClientOptions - sparql rejects when createSparqlEngine is omitted",
+  "createRdfjsAdapter - sparql rejects when createSparqlEngine is omitted",
   async () => {
-    const client = new Client(createRdfjsClientOptions());
+    const client = new Client(createRdfjsAdapter());
 
     await assertRejects(
       () => client.sparql({ query: "ASK WHERE { ?s ?p ?o }" }),

--- a/src/client/adapters/rdfjs/create-rdfjs-adapter.ts
+++ b/src/client/adapters/rdfjs/create-rdfjs-adapter.ts
@@ -1,5 +1,5 @@
 import { Store } from "n3";
-import type { ClientOptions } from "@/client/client.ts";
+import type { Adapter } from "@/client/client.ts";
 import type { SparqlEngineInterface } from "@/client/sparql-engine/mod.ts";
 import { RdfjsQuadStore } from "./rdfjs-quad-store.ts";
 import { RdfjsSearchIndex } from "./rdfjs-search-index.ts";
@@ -29,16 +29,16 @@ export interface RdfjsOptions {
 }
 
 /**
- * createRdfjsClientOptions synthesizes a lightweight, in-memory client gateway context backed entirely by
+ * createRdfjsAdapter synthesizes a lightweight, in-memory client adapter backed entirely by
  * local RDFJS primitives. It is the fastest path to a working Client for development, tests,
  * and single-process demos where no external persistence is needed.
  *
- * Unlike createLibsqlClientOptions and createDenokvClientOptions, there is no synchronization layer — all data exists
+ * Unlike createLibsqlAdapter and createDenokvAdapter, there is no synchronization layer — all data exists
  * transiently in the N3 Store and is lost when the process exits.
  */
-export function createRdfjsClientOptions(
+export function createRdfjsAdapter(
   options?: RdfjsOptions,
-): ClientOptions {
+): Adapter {
   const store = options?.store ?? new Store();
 
   return {

--- a/src/client/adapters/rdfjs/mod.ts
+++ b/src/client/adapters/rdfjs/mod.ts
@@ -1,3 +1,3 @@
 export * from "./rdfjs-search-index.ts";
 export * from "./rdfjs-quad-store.ts";
-export * from "./create-rdfjs-client.ts";
+export * from "./create-rdfjs-adapter.ts";

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -20,9 +20,9 @@ import type {
 } from "./search-index/mod.ts";
 
 /**
- * ClientOptions details the aggregate internal subsystems powering active execution.
+ * Adapter details the aggregate internal subsystems powering active execution.
  */
-export interface ClientOptions {
+export interface Adapter {
   /**
    * quadStore manages the ingestion and extraction of triple/quad data.
    */
@@ -45,36 +45,36 @@ export interface ClientOptions {
  * declarative querying, and fuzzy searching.
  */
 export class Client implements ClientInterface {
-  public constructor(protected readonly options: ClientOptions) {}
+  public constructor(protected readonly adapter: Adapter) {}
 
   public async import(request: ImportRequest): Promise<ImportResponse> {
-    return await this.options.quadStore.import(request);
+    return await this.adapter.quadStore.import(request);
   }
 
   public async export(request: ExportRequest): Promise<ExportResponse> {
-    return await this.options.quadStore.export(request);
+    return await this.adapter.quadStore.export(request);
   }
 
   public async sparql(request: SparqlRequest): Promise<SparqlResponse> {
-    if (!this.options.sparqlEngine) {
+    if (!this.adapter.sparqlEngine) {
       throw new Error("SPARQL engine is not configured.");
     }
 
-    return await this.options.sparqlEngine.execute(request);
+    return await this.adapter.sparqlEngine.execute(request);
   }
 
   public async search(request: SearchRequest): Promise<SearchResponse> {
-    return await this.options.searchIndex.search(request);
+    return await this.adapter.searchIndex.search(request);
   }
 
   public async rebuildSearchIndex(
     request?: RebuildSearchIndexRequest,
   ): Promise<RebuildSearchIndexResponse> {
-    if (!this.options.searchIndex.rebuildSearchIndex) {
+    if (!this.adapter.searchIndex.rebuildSearchIndex) {
       throw new Error(
         "search index rebuild is only supported for LibSQL-backed clients",
       );
     }
-    return await this.options.searchIndex.rebuildSearchIndex(request);
+    return await this.adapter.searchIndex.rebuildSearchIndex(request);
   }
 }


### PR DESCRIPTION
﻿## Summary

- Rename `ClientOptions` interface to `Adapter` -- the type describes the composed adapter bridging platform-specific infrastructure to the generic `Client`, not passive configuration
- Rename `this.options` to `this.adapter` in the `Client` constructor field
- Rename all four factory functions: `createXClientOptions` to `createXAdapter` (e.g. `createLibsqlAdapter`)
- Rename source and test files for file-symbol alignment per AGENTS.md (e.g. `create-libsql-client.ts` to `create-libsql-adapter.ts`)
- Update barrel `mod.ts` re-export paths, all examples, benchmarks, and documentation
- Add `Unreleased` entry to CHANGELOG documenting the breaking rename

## Test plan

- [x] `deno task ci` passes (fmt, lint, type-check, 181 tests)
- [x] CI workflow passes on GitHub
- [x] Verify no stale `ClientOptions` or `createXClientOptions` references remain
