### PR TITLE
Collapse Adapter into Client and Comunica presets for 0.0.16

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -305,10 +305,12 @@ separate modules so hexastore deployments do not import N3 hydration:
 
 - **`createLibsqlClient`**
   ([`create-libsql-adapter.ts`](src/client/adapters/libsql/create-libsql-adapter.ts))
-  — `LibsqlStore` + hexastore indexes; `createSparqlEngine({ libsqlStore })`.
+  — `LibsqlStore` + hexastore indexes; import/export/search only (no SPARQL).
   `LibsqlStore.match` keyset-pages by `quads.id` (`matchPageSize`, default
   1000). Optional `countQuads` supplies Comunica join cardinality hints. Returns
   `Client` directly.
+- **`createLibsqlComunicaClient`** — import
+  `@worlds/client/adapters/libsql/comunica`; Comunica SPARQL over `LibsqlStore`.
 - **`createLibsqlN3Client`** — import `@worlds/client/adapters/libsql-n3`
   ([`create-libsql-n3-adapter.ts`](src/client/adapters/libsql-n3/create-libsql-n3-adapter.ts));
   hydrate → `createProxiedN3Store` → `mergePatches` → `persistPatch` to LibSQL;
@@ -341,10 +343,9 @@ directly. `createXAdapter` remains as a deprecated alias (removed in 0.0.17).
 For advanced composition or tests, use positional constructor injection:
 `new Client(quadStore, searchIndex, sparqlEngine?)`.
 
-For Comunica SPARQL: `createLibsqlN3ComunicaClient` (N3 path),
-`createComunicaLibsqlSparqlEngineFactory` on `createLibsqlClient` (hexastore),
-or `createComunicaSparqlEngineFactory` on `createRdfjsClient` /
-`createDenokvClient`.
+For Comunica SPARQL: `createLibsqlComunicaClient` (hexastore),
+`createLibsqlN3ComunicaClient` (N3 path), or `createComunicaSparqlEngineFactory`
+on `createRdfjsClient` / `createDenokvClient`.
 
 - **Serverless / edge (warm isolate):** build one `Client` in module scope per
   isolate; reuse across HTTP requests. See
@@ -522,7 +523,8 @@ much graph you mirror in memory and how you run SPARQL.
 
 | Options builder                | Module                                       | When to use                                                                                                                  |
 | :----------------------------- | :------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------- |
-| `createLibsqlClient`           | `@worlds/client/adapters/libsql`             | **Production and large graphs.** SPARQL runs on `LibsqlStore` (hexastore). No full N3 hydration per request.                 |
+| `createLibsqlComunicaClient`   | `@worlds/client/adapters/libsql/comunica`    | **Production and large graphs.** SPARQL runs on `LibsqlStore` (hexastore). No full N3 hydration per request.                 |
+| `createLibsqlClient`           | `@worlds/client/adapters/libsql`             | Hexastore import/export/search only (no SPARQL).                                                                             |
 | `createLibsqlN3ComunicaClient` | `@worlds/client/adapters/libsql-n3/comunica` | **Selective workloads** where hydrating into N3 is acceptable. Reuse one warmed `store` per container, not per HTTP request. |
 
 Post-preload benchmarks (1k-50k quads) show hydrate+N3 can win selective queries
@@ -536,7 +538,7 @@ At millions of quads, pick the topology at integration time.
 
 | Concern         | Production default                                                                                                      |
 | :-------------- | :---------------------------------------------------------------------------------------------------------------------- |
-| LibSQL topology | `createLibsqlClient` with hexastore `LibsqlStore`, no full N3 mirror per request                                        |
+| LibSQL topology | `createLibsqlComunicaClient` with hexastore `LibsqlStore`, no full N3 mirror per request                                |
 | Hot-path SPARQL | Bind at least one term (subject, predicate, or object). Subject-bound property lookups match crossover selective shapes |
 | Avoid at scale  | Unbound `?s ?p ?o` (even with `LIMIT`) on libsqlStore; fullScan degrades to hundreds of ms as quads grow                |
 | N3 + Comunica   | `createLibsqlN3ComunicaClient`; pass a warmed `store` hydrated once per container, not per HTTP request                 |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -303,22 +303,25 @@ network hop latency during query execution.
 Hexastore indexes are provisioned at schema init for all LibSQL clients. Use
 separate modules so hexastore deployments do not import N3 hydration:
 
-- **`createLibsqlAdapter`**
+- **`createLibsqlClient`**
   ([`create-libsql-adapter.ts`](src/client/adapters/libsql/create-libsql-adapter.ts))
   — `LibsqlStore` + hexastore indexes; `createSparqlEngine({ libsqlStore })`.
   `LibsqlStore.match` keyset-pages by `quads.id` (`matchPageSize`, default
-  1000). Optional `countQuads` supplies Comunica join cardinality hints. Wrap
-  with `new Client(await createLibsqlAdapter(...))`.
-- **`createLibsqlN3Adapter`** — import `@worlds/client/adapters/libsql-n3`
+  1000). Optional `countQuads` supplies Comunica join cardinality hints. Returns
+  `Client` directly.
+- **`createLibsqlN3Client`** — import `@worlds/client/adapters/libsql-n3`
   ([`create-libsql-n3-adapter.ts`](src/client/adapters/libsql-n3/create-libsql-n3-adapter.ts));
   hydrate → `createProxiedN3Store` → `mergePatches` → `persistPatch` to LibSQL;
-  `createSparqlEngine({ store })` receives proxied N3. Not re-exported from
+  import/export/search only (no SPARQL). Not re-exported from
   `@worlds/client/adapters/libsql` (keeps hexastore-only imports free of N3).
+- **`createLibsqlN3ComunicaClient`** — import
+  `@worlds/client/adapters/libsql-n3/comunica`; Comunica SPARQL over the proxied
+  N3 store. Pass optional `store` for warm-isolate hydration policy.
 
 ### N3 patch capture (libsql-n3 sync path)
 
-`createLibsqlN3Adapter` synchronizes durable LibSQL state from an in-memory N3
-store:
+`createLibsqlN3ComunicaClient` (and search-only `createLibsqlN3Client`)
+synchronize durable LibSQL state from an in-memory N3 store:
 
 1. `hydrateStoreFromLibsql` (skipped when reusing a warmed `store`)
 2. `createProxiedN3Store` from `@worlds/client/quad-store/n3` — captures
@@ -327,25 +330,30 @@ store:
    before persist (no deduplication)
 4. `persistPatch` via libsql sync — writes quads and search-index projections
 
-`createRdfjsAdapter` does not use patch capture; data is transient in memory
+`createRdfjsClient` does not use patch capture; data is transient in memory
 only.
 
 ### Client lifecycle (runtime)
 
-Canonical construction: `new Client(await createXAdapter(...))`. Do not
-reintroduce `createXClient` one-line wrappers.
+Canonical construction: `await createXClient(...)`. Factories return `Client`
+directly. `createXAdapter` remains as a deprecated alias (removed in 0.0.17).
 
-For standard Comunica SPARQL, pass `createComunicaSparqlEngineFactory` or
-`createComunicaLibsqlSparqlEngineFactory` from
-`@worlds/client/adapters/comunica` as the adapter's `createSparqlEngine` option.
+For advanced composition or tests, use positional constructor injection:
+`new Client(quadStore, searchIndex, sparqlEngine?)`.
 
-- **Serverless / edge (warm isolate):** build `Adapter` or `Client` once in
-  module scope per isolate; reuse across HTTP requests. See
+For Comunica SPARQL: `createLibsqlN3ComunicaClient` (N3 path),
+`createComunicaLibsqlSparqlEngineFactory` on `createLibsqlClient` (hexastore),
+or `createComunicaSparqlEngineFactory` on `createRdfjsClient` /
+`createDenokvClient`.
+
+- **Serverless / edge (warm isolate):** build one `Client` in module scope per
+  isolate; reuse across HTTP requests. See
   [`examples/libsql-n3-warm-container`](examples/libsql-n3-warm-container).
 - **Long-running (Fly.io, DigitalOcean, 24/7 Deno):** one `Client` at process
   boot. See [`examples/libsql-long-running`](examples/libsql-long-running).
-- When reusing a warmed N3 `store`, do **not** call `createLibsqlN3Adapter` on
-  every request — that rebuilds proxy, search index, and patch sync.
+- When reusing a warmed N3 `store`, do **not** call
+  `createLibsqlN3ComunicaClient` on every request — that rebuilds proxy, search
+  index, and patch sync.
 
 Use `benchmarks/sparql-hexastore-crossover.bench.ts`,
 [`benchmarks/README.md`](benchmarks/README.md), and
@@ -365,17 +373,18 @@ and hydration of the Graph Store are fully externalized from the generalized
 `Client` factory. The caller injects an initialized `Store` directly, allowing
 trivial container-level caching across sequential HTTP invocations.
 
-### Sterile orchestration via adapters
+### Sterile orchestration via factories
 
 All active instrumentation (proxies, observers, and transactional mutation
-queues) is isolated strictly inside adapters (e.g. `createLibsqlAdapter`). The
-generalized `Client` is kept completely agnostic and sterile, accepting
-pre-composed adapter options ready for constructor injection.
+queues) is isolated inside adapter factories (e.g. `createLibsqlClient`). The
+`Client` class delegates to injected `QuadStoreInterface`,
+`SearchIndexInterface`, and optional `SparqlEngineInterface` without knowing
+persistence topology.
 
 ### Production deployment recommendation
 
 For production deployments and scale, the recommended topology is LibSQL-backed
-infrastructure through `createLibsqlAdapter` + `Client`, especially Turso Cloud.
+infrastructure through `createLibsqlClient`, especially Turso Cloud.
 RDFJS-backed and Deno KV-backed search/index topologies, including deployments
 centered on `RdfjsSearchIndex` and `DenokvSearchIndex`, are appropriate for
 local development, tests, and constrained single-process demos, but they are not
@@ -462,7 +471,7 @@ Built-in label predicates (`rdfs:label`, `skos:prefLabel`, `schema:name`) are
 always indexed. Extend with `labelPredicates` on adapter options:
 
 ```typescript
-await createLibsqlAdapter({
+await createLibsqlClient({
   client: db,
   labelPredicates: ["http://example.org/customLabel"],
 });
@@ -511,10 +520,10 @@ Keep AI tool descriptions and system prompts aligned with
 Both options builders provision hexastore indexes at schema init. Pick by how
 much graph you mirror in memory and how you run SPARQL.
 
-| Options builder         | Module                              | When to use                                                                                                                  |
-| :---------------------- | :---------------------------------- | :--------------------------------------------------------------------------------------------------------------------------- |
-| `createLibsqlAdapter`   | `@worlds/client/adapters/libsql`    | **Production and large graphs.** SPARQL runs on `LibsqlStore` (hexastore). No full N3 hydration per request.                 |
-| `createLibsqlN3Adapter` | `@worlds/client/adapters/libsql-n3` | **Selective workloads** where hydrating into N3 is acceptable. Reuse one warmed `store` per container, not per HTTP request. |
+| Options builder                | Module                                       | When to use                                                                                                                  |
+| :----------------------------- | :------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------- |
+| `createLibsqlClient`           | `@worlds/client/adapters/libsql`             | **Production and large graphs.** SPARQL runs on `LibsqlStore` (hexastore). No full N3 hydration per request.                 |
+| `createLibsqlN3ComunicaClient` | `@worlds/client/adapters/libsql-n3/comunica` | **Selective workloads** where hydrating into N3 is acceptable. Reuse one warmed `store` per container, not per HTTP request. |
 
 Post-preload benchmarks (1k-50k quads) show hydrate+N3 can win selective queries
 when the graph is already in memory; libsqlStore avoids full hydration cost and
@@ -525,13 +534,13 @@ production scale.
 
 At millions of quads, pick the topology at integration time.
 
-| Concern         | Production default                                                                                                               |
-| :-------------- | :------------------------------------------------------------------------------------------------------------------------------- |
-| LibSQL topology | `createLibsqlAdapter` with hexastore `LibsqlStore`, no full N3 mirror per request                                                |
-| Hot-path SPARQL | Bind at least one term (subject, predicate, or object). Subject-bound property lookups match crossover selective shapes          |
-| Avoid at scale  | Unbound `?s ?p ?o` (even with `LIMIT`) on libsqlStore; fullScan degrades to hundreds of ms as quads grow                         |
-| N3 + Comunica   | `createLibsqlN3Adapter` only when you need in-memory N3; pass a warmed `store` hydrated once per container, not per HTTP request |
-| Cardinality     | `LibsqlStore.countQuads` is used by Comunica when hexastore SPARQL is wired (no extra adapter config)                            |
+| Concern         | Production default                                                                                                      |
+| :-------------- | :---------------------------------------------------------------------------------------------------------------------- |
+| LibSQL topology | `createLibsqlClient` with hexastore `LibsqlStore`, no full N3 mirror per request                                        |
+| Hot-path SPARQL | Bind at least one term (subject, predicate, or object). Subject-bound property lookups match crossover selective shapes |
+| Avoid at scale  | Unbound `?s ?p ?o` (even with `LIMIT`) on libsqlStore; fullScan degrades to hundreds of ms as quads grow                |
+| N3 + Comunica   | `createLibsqlN3ComunicaClient`; pass a warmed `store` hydrated once per container, not per HTTP request                 |
+| Cardinality     | `LibsqlStore.countQuads` is used by Comunica when hexastore SPARQL is wired (no extra adapter config)                   |
 
 Query helpers (same shapes as benchmarks):
 
@@ -544,12 +553,13 @@ const devScanQuery =
 
 ### Warm container patterns
 
-- **Serverless / edge (warm isolate):** build `Adapter` or `Client` once in
-  module scope per isolate; reuse across HTTP requests.
+- **Serverless / edge (warm isolate):** build one `Client` once in module scope
+  per isolate; reuse across HTTP requests.
 - **Long-running (Fly.io, DigitalOcean, 24/7 Deno):** one `Client` at process
   boot.
-- When reusing a warmed N3 `store`, do **not** call `createLibsqlN3Adapter` on
-  every request; that rebuilds proxy, search index, and patch sync.
+- When reusing a warmed N3 `store`, do **not** call
+  `createLibsqlN3ComunicaClient` on every request; that rebuilds proxy, search
+  index, and patch sync.
 
 ### Bulk import strategies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,12 @@
   as a deprecated alias (removed in 0.0.17).
 - Renamed `SparqlEngineInterface.execute` to `sparql` (aligns with
   `ClientInterface.sparql`).
-- Removed `createSparqlEngine` from `createLibsqlN3Client`. Use
+- Removed `createSparqlEngine` from `createLibsqlClient` and
+  `createLibsqlN3Client`. Use `createLibsqlComunicaClient` from
+  `@worlds/client/adapters/libsql/comunica` (hexastore) or
   `createLibsqlN3ComunicaClient` from
-  `@worlds/client/adapters/libsql-n3/comunica` for Comunica SPARQL; pass a
-  warmed `store` to control hydration timing.
+  `@worlds/client/adapters/libsql-n3/comunica` (hydrated N3); pass a warmed
+  `store` on the N3 path to control hydration timing.
 
 ### Migration
 
@@ -41,6 +43,21 @@ Advanced composition (tests, custom stores):
 import { Client } from "@worlds/client";
 
 const client = new Client(quadStore, searchIndex, sparqlEngine);
+```
+
+LibSQL hexastore + Comunica:
+
+```typescript
+// Before
+await createLibsqlClient({
+  client: db,
+  createSparqlEngine: createComunicaLibsqlSparqlEngineFactory({ queryEngine }),
+});
+
+// After
+import { createLibsqlComunicaClient } from "@worlds/client/adapters/libsql/comunica";
+
+await createLibsqlComunicaClient({ client: db, queryEngine });
 ```
 
 LibSQL N3 + Comunica:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,62 @@
 
 ## Unreleased
 
+## 0.0.16
+
+### Breaking
+
+- Removed exported `Adapter` interface. `Client` is the sole public runtime
+  type; factories return `Client` directly.
+- Restored `createLibsqlClient`, `createLibsqlN3Client`, `createRdfjsClient`,
+  and `createDenokvClient` as canonical factory names. `createXAdapter` remains
+  as a deprecated alias (removed in 0.0.17).
+- Renamed `SparqlEngineInterface.execute` to `sparql` (aligns with
+  `ClientInterface.sparql`).
+- Removed `createSparqlEngine` from `createLibsqlN3Client`. Use
+  `createLibsqlN3ComunicaClient` from
+  `@worlds/client/adapters/libsql-n3/comunica` for Comunica SPARQL; pass a
+  warmed `store` to control hydration timing.
+
+### Migration
+
+```typescript
+// Before (0.0.15)
+import { Client } from "@worlds/client";
+import { createLibsqlAdapter } from "@worlds/client/adapters/libsql";
+
+const client = new Client(
+  await createLibsqlAdapter({ client: db }),
+);
+
+// After (0.0.16)
+import { createLibsqlClient } from "@worlds/client/adapters/libsql";
+
+const client = await createLibsqlClient({ client: db });
+```
+
+Advanced composition (tests, custom stores):
+
+```typescript
+import { Client } from "@worlds/client";
+
+const client = new Client(quadStore, searchIndex, sparqlEngine);
+```
+
+LibSQL N3 + Comunica:
+
+```typescript
+// Before
+await createLibsqlN3Client({
+  client: db,
+  createSparqlEngine: createComunicaSparqlEngineFactory({ queryEngine }),
+});
+
+// After
+import { createLibsqlN3ComunicaClient } from "@worlds/client/adapters/libsql-n3/comunica";
+
+await createLibsqlN3ComunicaClient({ client: db, queryEngine });
+```
+
 ## 0.0.15
 
 ### Breaking

--- a/README.md
+++ b/README.md
@@ -103,17 +103,14 @@ const client = createRdfjsClient({
 ### LibSQL (production)
 
 ```typescript
-import { createComunicaLibsqlSparqlEngineFactory } from "@worlds/client/adapters/comunica";
-import { createLibsqlClient } from "@worlds/client/adapters/libsql";
+import { createLibsqlComunicaClient } from "@worlds/client/adapters/libsql/comunica";
 import { createClient } from "@libsql/client";
 import { QueryEngine } from "@comunica/query-sparql-rdfjs-lite";
 
 const db = createClient({ url: "file:./worlds.db" });
-const client = await createLibsqlClient({
+const client = await createLibsqlComunicaClient({
   client: db,
-  createSparqlEngine: createComunicaLibsqlSparqlEngineFactory({
-    queryEngine: new QueryEngine(),
-  }),
+  queryEngine: new QueryEngine(),
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -34,18 +34,15 @@ deno add jsr:@worlds/client
 ## Quickstart
 
 ```typescript
-import { Client } from "@worlds/client";
 import { createComunicaSparqlEngineFactory } from "@worlds/client/adapters/comunica";
-import { createRdfjsAdapter } from "@worlds/client/adapters/rdfjs";
+import { createRdfjsClient } from "@worlds/client/adapters/rdfjs";
 import { QueryEngine } from "@comunica/query-sparql-rdfjs-lite";
 
-const client = new Client(
-  createRdfjsAdapter({
-    createSparqlEngine: createComunicaSparqlEngineFactory({
-      queryEngine: new QueryEngine(),
-    }),
+const client = createRdfjsClient({
+  createSparqlEngine: createComunicaSparqlEngineFactory({
+    queryEngine: new QueryEngine(),
   }),
-);
+});
 
 await client.import({
   source: {
@@ -92,57 +89,48 @@ for structured traversal and reasoning.
 ### RDFJS (in-memory)
 
 ```typescript
-import { Client } from "@worlds/client";
 import { createComunicaSparqlEngineFactory } from "@worlds/client/adapters/comunica";
-import { createRdfjsAdapter } from "@worlds/client/adapters/rdfjs";
+import { createRdfjsClient } from "@worlds/client/adapters/rdfjs";
 import { QueryEngine } from "@comunica/query-sparql-rdfjs-lite";
 
-const client = new Client(
-  createRdfjsAdapter({
-    createSparqlEngine: createComunicaSparqlEngineFactory({
-      queryEngine: new QueryEngine(),
-    }),
+const client = createRdfjsClient({
+  createSparqlEngine: createComunicaSparqlEngineFactory({
+    queryEngine: new QueryEngine(),
   }),
-);
+});
 ```
 
 ### LibSQL (production)
 
 ```typescript
-import { Client } from "@worlds/client";
 import { createComunicaLibsqlSparqlEngineFactory } from "@worlds/client/adapters/comunica";
-import { createLibsqlAdapter } from "@worlds/client/adapters/libsql";
+import { createLibsqlClient } from "@worlds/client/adapters/libsql";
 import { createClient } from "@libsql/client";
 import { QueryEngine } from "@comunica/query-sparql-rdfjs-lite";
 
 const db = createClient({ url: "file:./worlds.db" });
-const client = new Client(
-  await createLibsqlAdapter({
-    client: db,
-    createSparqlEngine: createComunicaLibsqlSparqlEngineFactory({
-      queryEngine: new QueryEngine(),
-    }),
+const client = await createLibsqlClient({
+  client: db,
+  createSparqlEngine: createComunicaLibsqlSparqlEngineFactory({
+    queryEngine: new QueryEngine(),
   }),
-);
+});
 ```
 
 ### Deno KV (prototyping)
 
 ```typescript
-import { Client } from "@worlds/client";
 import { createComunicaSparqlEngineFactory } from "@worlds/client/adapters/comunica";
-import { createDenokvAdapter } from "@worlds/client/adapters/denokv";
+import { createDenokvClient } from "@worlds/client/adapters/denokv";
 import { QueryEngine } from "@comunica/query-sparql-rdfjs-lite";
 
 const kv = await Deno.openKv();
-const client = new Client(
-  createDenokvAdapter({
-    kv,
-    createSparqlEngine: createComunicaSparqlEngineFactory({
-      queryEngine: new QueryEngine(),
-    }),
+const client = createDenokvClient({
+  kv,
+  createSparqlEngine: createComunicaSparqlEngineFactory({
+    queryEngine: new QueryEngine(),
   }),
-);
+});
 ```
 
 ## Examples

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -45,9 +45,9 @@ deno bench --allow-all --unstable-kv benchmarks/
 deno bench --allow-all benchmarks/sparql-hexastore-crossover.bench.ts
 ```
 
-**Standard (1k–50k):** compares **hydrate+N3** (`createLibsqlN3Adapter` from
-`@worlds/client/adapters/libsql-n3`) vs **libsqlStore** (`createLibsqlAdapter`
-from `@worlds/client/adapters/libsql`).
+**Standard (1k–50k):** compares **hydrate+N3** (`createLibsqlN3ComunicaClient`
+from `@worlds/client/adapters/libsql-n3`) vs **libsqlStore**
+(`createLibsqlClient` from `@worlds/client/adapters/libsql`).
 
 **Large (100k–1M):** **libsqlStore only** — the scalable LibSQL path for hybrid
 search + SPARQL in production
@@ -82,7 +82,7 @@ deno bench --allow-all --v8-flags=--max-old-space-size=8192 benchmarks/sparql-he
 ```
 
 Module load logs `console.time` lines per scale (`generate`, then each backend).
-Only `sparqlEngine.execute()` is timed inside `Deno.bench`. Paste results into
+Only `sparqlEngine.sparql()` is timed inside `Deno.bench`. Paste results into
 [discussion #69](https://github.com/wazootech/worlds-client-ts/discussions/69).
 
 For full import + search preload timing (not the crossover execute table), use
@@ -131,7 +131,7 @@ create a fresh database per iteration and use `warmup: 5`, `n: 50`.
   ```
 
 **Production (millions of quads):** prefer
-[`createLibsqlAdapter`](../src/client/adapters/libsql/create-libsql-adapter.ts)
+[`createLibsqlClient`](../src/client/adapters/libsql/create-libsql-adapter.ts)
 for indexed SPARQL without a full N3 mirror; reuse a warmed
 [`store`](../src/client/adapters/libsql-n3/create-libsql-n3-adapter.ts) on the
 N3 path per container, not per request. Track guidance in

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -47,7 +47,7 @@ deno bench --allow-all benchmarks/sparql-hexastore-crossover.bench.ts
 
 **Standard (1k–50k):** compares **hydrate+N3** (`createLibsqlN3ComunicaClient`
 from `@worlds/client/adapters/libsql-n3`) vs **libsqlStore**
-(`createLibsqlClient` from `@worlds/client/adapters/libsql`).
+(`createLibsqlComunicaClient` from `@worlds/client/adapters/libsql/comunica`).
 
 **Large (100k–1M):** **libsqlStore only** — the scalable LibSQL path for hybrid
 search + SPARQL in production

--- a/benchmarks/denokv-pressure.bench.ts
+++ b/benchmarks/denokv-pressure.bench.ts
@@ -1,5 +1,5 @@
-import { Client } from "@worlds/client";
-import { createDenokvAdapter } from "@worlds/client/adapters/denokv";
+import type { Client } from "@worlds/client";
+import { createDenokvClient } from "@worlds/client/adapters/denokv";
 import { generateSyntheticQuads } from "./shared/synthetic-data.ts";
 
 // Pre-allocated payloads for strict repeatable boundaries
@@ -19,8 +19,7 @@ async function setupIsolatedClient(): Promise<{
   kv: Deno.Kv;
 }> {
   const kv = await Deno.openKv(":memory:");
-  const adapter = createDenokvAdapter({ kv });
-  const client = new Client(adapter);
+  const client = createDenokvClient({ kv });
   return { client, kv };
 }
 

--- a/benchmarks/libsql-pressure.bench.ts
+++ b/benchmarks/libsql-pressure.bench.ts
@@ -1,7 +1,7 @@
 import { createClient } from "@libsql/client";
 import { Store } from "n3";
-import { Client } from "@worlds/client";
-import { createLibsqlN3Adapter } from "@worlds/client/adapters/libsql-n3";
+import type { Client } from "@worlds/client";
+import { createLibsqlN3Client } from "@worlds/client/adapters/libsql-n3";
 import { hydrateStoreFromLibsql } from "@worlds/client/adapters/libsql-n3";
 import { FakeEmbeddingService } from "@worlds/client/search-index/embedding-service";
 import { generateSyntheticQuads } from "./shared/synthetic-data.ts";
@@ -25,11 +25,10 @@ async function setupIsolatedClient(): Promise<{
 }> {
   const db = createClient({ url: ":memory:" });
   const embeddingService = new FakeEmbeddingService();
-  const adapter = await createLibsqlN3Adapter({
+  const client = await createLibsqlN3Client({
     client: db,
     embeddingService,
   });
-  const client = new Client(adapter);
   return { client, db };
 }
 

--- a/benchmarks/search-comparison.bench.ts
+++ b/benchmarks/search-comparison.bench.ts
@@ -5,8 +5,7 @@ import {
   LibsqlQueryBuilder,
   LibsqlSearchIndex,
 } from "@worlds/client/adapters/libsql";
-import { createLibsqlN3Adapter } from "@worlds/client/adapters/libsql-n3";
-import { Client } from "@worlds/client";
+import { createLibsqlN3Client } from "@worlds/client/adapters/libsql-n3";
 import { generateSyntheticQuads } from "./shared/synthetic-data.ts";
 
 // -----------------------------------------------------------------------------
@@ -16,9 +15,7 @@ import { generateSyntheticQuads } from "./shared/synthetic-data.ts";
 
 async function prepareLibsqlSearchIndex(count: number) {
   const db = createClient({ url: ":memory:" });
-  const client = new Client(
-    await createLibsqlN3Adapter({ client: db }), // No embedding service -> Pure Keyword FTS Mode
-  );
+  const client = await createLibsqlN3Client({ client: db }); // No embedding service -> Pure Keyword FTS Mode
 
   // Batch ingestion in segments to prevent exceeding SQL statement variable caps
   const dataset = generateSyntheticQuads(count);

--- a/benchmarks/shared/crossover-db-cache.test.ts
+++ b/benchmarks/shared/crossover-db-cache.test.ts
@@ -1,8 +1,7 @@
 import { assertEquals, assertExists, assertNotEquals } from "@std/assert";
 import { createClient } from "@libsql/client";
 import * as path from "@std/path";
-import { Client } from "@worlds/client";
-import { createLibsqlAdapter } from "@worlds/client/adapters/libsql";
+import { createLibsqlClient } from "@worlds/client/adapters/libsql";
 import type { Quad } from "@rdfjs/types";
 import {
   buildCrossoverFixtureChecksumInputs,
@@ -18,11 +17,11 @@ async function importCorpusIntoLibsqlHexastoreForTest(
   databaseClient: ReturnType<typeof createClient>,
   corpusQuads: Quad[],
 ): Promise<void> {
-  const adapter = await createLibsqlAdapter({
+  const worldsClient = await createLibsqlClient({
     client: databaseClient,
     searchIndexOnImport: "disabled",
   });
-  const worldsClient = new Client(adapter);
+
   await worldsClient.import({
     source: { kind: "quads", quads: corpusQuads },
   });

--- a/benchmarks/shared/sparql-hexastore-crossover-shared.ts
+++ b/benchmarks/shared/sparql-hexastore-crossover-shared.ts
@@ -1,14 +1,10 @@
 import { createClient } from "@libsql/client";
 import type { Quad } from "@rdfjs/types";
 import { QueryEngine } from "@comunica/query-sparql-rdfjs-lite";
-import { Client } from "@worlds/client";
-import {
-  createComunicaLibsqlSparqlEngineFactory,
-  createComunicaSparqlEngineFactory,
-} from "@worlds/client/adapters/comunica";
-import { createLibsqlAdapter } from "@worlds/client/adapters/libsql";
-import { createLibsqlN3Adapter } from "@worlds/client/adapters/libsql-n3";
-import type { SparqlEngineInterface } from "@worlds/client/sparql-engine";
+import type { Client } from "@worlds/client";
+import { createComunicaLibsqlSparqlEngineFactory } from "@worlds/client/adapters/comunica";
+import { createLibsqlClient } from "@worlds/client/adapters/libsql";
+import { createLibsqlN3ComunicaClient } from "@worlds/client/adapters/libsql-n3/comunica";
 import {
   buildCrossoverFixtureChecksumInputs,
   computeCrossoverFixtureChecksum,
@@ -51,10 +47,10 @@ export const largeCrossoverBackends = [
   "libsqlStore",
 ] as const satisfies readonly SparqlBackend[];
 
-/** PreloadedSparqlFixture holds a warmed SPARQL engine and its database handle. */
+/** PreloadedSparqlFixture holds a warmed Client and its database handle. */
 export interface PreloadedSparqlFixture {
   databaseClient: ReturnType<typeof createClient>;
-  sparqlEngine: SparqlEngineInterface;
+  worldsClient: Client;
 }
 
 /**
@@ -101,11 +97,10 @@ async function importCorpusIntoLibsqlHexastore(
   databaseClient: ReturnType<typeof createClient>,
   corpusQuads: Quad[],
 ): Promise<void> {
-  const adapter = await createLibsqlAdapter({
+  const worldsClient = await createLibsqlClient({
     client: databaseClient,
     searchIndexOnImport: "disabled",
   });
-  const worldsClient = new Client(adapter);
   await worldsClient.import({
     source: { kind: "quads", quads: corpusQuads },
   });
@@ -117,17 +112,14 @@ async function importCorpusIntoLibsqlHexastore(
 async function openLibsqlHexastoreSparqlEngine(
   databaseClient: ReturnType<typeof createClient>,
 ): Promise<PreloadedSparqlFixture> {
-  const adapter = await createLibsqlAdapter({
+  const worldsClient = await createLibsqlClient({
     client: databaseClient,
     searchIndexOnImport: "disabled",
     createSparqlEngine: createComunicaLibsqlSparqlEngineFactory({
       queryEngine: sharedQueryEngine,
     }),
   });
-  if (!adapter.sparqlEngine) {
-    throw new Error("libsqlStore bench requires createSparqlEngine");
-  }
-  return { databaseClient, sparqlEngine: adapter.sparqlEngine };
+  return { databaseClient, worldsClient };
 }
 
 /**
@@ -186,21 +178,15 @@ async function createHydrateN3SparqlEngine(
   corpusQuads: Quad[],
 ): Promise<PreloadedSparqlFixture> {
   const databaseClient = createClient({ url: ":memory:" });
-  const adapter = await createLibsqlN3Adapter({
+  const worldsClient = await createLibsqlN3ComunicaClient({
     client: databaseClient,
     searchIndexOnImport: "disabled",
-    createSparqlEngine: createComunicaSparqlEngineFactory({
-      queryEngine: sharedQueryEngine,
-    }),
+    queryEngine: sharedQueryEngine,
   });
-  const worldsClient = new Client(adapter);
   await worldsClient.import({
     source: { kind: "quads", quads: corpusQuads },
   });
-  if (!adapter.sparqlEngine) {
-    throw new Error("hydrate+N3 bench requires createSparqlEngine");
-  }
-  return { databaseClient, sparqlEngine: adapter.sparqlEngine };
+  return { databaseClient, worldsClient };
 }
 
 async function createSparqlEngineForBackend(
@@ -303,7 +289,7 @@ export function registerSparqlCrossoverBenchmarks(
             }
 
             benchContext.start();
-            await fixture.sparqlEngine.execute({ query });
+            await fixture.worldsClient.sparql({ query });
             benchContext.end();
           },
         });

--- a/benchmarks/shared/sparql-hexastore-crossover-shared.ts
+++ b/benchmarks/shared/sparql-hexastore-crossover-shared.ts
@@ -2,7 +2,7 @@ import { createClient } from "@libsql/client";
 import type { Quad } from "@rdfjs/types";
 import { QueryEngine } from "@comunica/query-sparql-rdfjs-lite";
 import type { Client } from "@worlds/client";
-import { createComunicaLibsqlSparqlEngineFactory } from "@worlds/client/adapters/comunica";
+import { createLibsqlComunicaClient } from "@worlds/client/adapters/libsql/comunica";
 import { createLibsqlClient } from "@worlds/client/adapters/libsql";
 import { createLibsqlN3ComunicaClient } from "@worlds/client/adapters/libsql-n3/comunica";
 import {
@@ -112,12 +112,10 @@ async function importCorpusIntoLibsqlHexastore(
 async function openLibsqlHexastoreSparqlEngine(
   databaseClient: ReturnType<typeof createClient>,
 ): Promise<PreloadedSparqlFixture> {
-  const worldsClient = await createLibsqlClient({
+  const worldsClient = await createLibsqlComunicaClient({
     client: databaseClient,
     searchIndexOnImport: "disabled",
-    createSparqlEngine: createComunicaLibsqlSparqlEngineFactory({
-      queryEngine: sharedQueryEngine,
-    }),
+    queryEngine: sharedQueryEngine,
   });
   return { databaseClient, worldsClient };
 }

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@worlds/client",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "nodeModulesDir": "auto",
   "exports": {
     ".": "./src/mod.ts",
@@ -12,6 +12,7 @@
     "./sparql-engine": "./src/client/sparql-engine/mod.ts",
     "./adapters/libsql": "./src/client/adapters/libsql/mod.ts",
     "./adapters/libsql-n3": "./src/client/adapters/libsql-n3/mod.ts",
+    "./adapters/libsql-n3/comunica": "./src/client/adapters/libsql-n3/comunica/mod.ts",
     "./adapters/tfjs-universal-sentence-encoder": "./src/client/adapters/tfjs-universal-sentence-encoder/mod.ts",
     "./adapters/comunica": "./src/client/adapters/comunica/mod.ts",
     "./adapters/rdfjs": "./src/client/adapters/rdfjs/mod.ts",

--- a/deno.json
+++ b/deno.json
@@ -11,6 +11,7 @@
     "./search-index/quad-chunker": "./src/client/search-index/quad-chunker/mod.ts",
     "./sparql-engine": "./src/client/sparql-engine/mod.ts",
     "./adapters/libsql": "./src/client/adapters/libsql/mod.ts",
+    "./adapters/libsql/comunica": "./src/client/adapters/libsql/comunica/mod.ts",
     "./adapters/libsql-n3": "./src/client/adapters/libsql-n3/mod.ts",
     "./adapters/libsql-n3/comunica": "./src/client/adapters/libsql-n3/comunica/mod.ts",
     "./adapters/tfjs-universal-sentence-encoder": "./src/client/adapters/tfjs-universal-sentence-encoder/mod.ts",

--- a/examples/ai-sdk-hello-world/main.ts
+++ b/examples/ai-sdk-hello-world/main.ts
@@ -1,7 +1,6 @@
 import { createClient } from "@libsql/client";
-import { Client } from "@worlds/client";
 import { createComunicaLibsqlSparqlEngineFactory } from "@worlds/client/adapters/comunica";
-import { createLibsqlAdapter } from "@worlds/client/adapters/libsql";
+import { createLibsqlClient } from "@worlds/client/adapters/libsql";
 import { QueryEngine } from "@comunica/query-sparql-rdfjs-lite";
 import { GRAPH_GROUNDED_AGENT_SYSTEM_PROMPT } from "./agent-prompts.ts";
 import { createTools } from "./tools.ts";
@@ -15,14 +14,12 @@ if (import.meta.main) {
   const database = createClient({ url: ":memory:" });
   const queryEngine = new QueryEngine();
 
-  const client = new Client(
-    await createLibsqlAdapter({
-      client: database,
-      createSparqlEngine: createComunicaLibsqlSparqlEngineFactory({
-        queryEngine,
-      }),
+  const client = await createLibsqlClient({
+    client: database,
+    createSparqlEngine: createComunicaLibsqlSparqlEngineFactory({
+      queryEngine,
     }),
-  );
+  });
 
   console.log("Ingesting initial knowledge...");
   await client.import({

--- a/examples/ai-sdk-hello-world/main.ts
+++ b/examples/ai-sdk-hello-world/main.ts
@@ -1,6 +1,5 @@
 import { createClient } from "@libsql/client";
-import { createComunicaLibsqlSparqlEngineFactory } from "@worlds/client/adapters/comunica";
-import { createLibsqlClient } from "@worlds/client/adapters/libsql";
+import { createLibsqlComunicaClient } from "@worlds/client/adapters/libsql/comunica";
 import { QueryEngine } from "@comunica/query-sparql-rdfjs-lite";
 import { GRAPH_GROUNDED_AGENT_SYSTEM_PROMPT } from "./agent-prompts.ts";
 import { createTools } from "./tools.ts";
@@ -14,11 +13,9 @@ if (import.meta.main) {
   const database = createClient({ url: ":memory:" });
   const queryEngine = new QueryEngine();
 
-  const client = await createLibsqlClient({
+  const client = await createLibsqlComunicaClient({
     client: database,
-    createSparqlEngine: createComunicaLibsqlSparqlEngineFactory({
-      queryEngine,
-    }),
+    queryEngine,
   });
 
   console.log("Ingesting initial knowledge...");

--- a/examples/denokv-hello-world/main.ts
+++ b/examples/denokv-hello-world/main.ts
@@ -1,10 +1,9 @@
-import { Client } from "@worlds/client";
 import { createComunicaSparqlEngineFactory } from "@worlds/client/adapters/comunica";
-import { createDenokvAdapter } from "@worlds/client/adapters/denokv";
+import { createDenokvClient } from "@worlds/client/adapters/denokv";
 import { QueryEngine } from "@comunica/query-sparql-rdfjs-lite";
 
 /**
- * This example demonstrates how to use `createDenokvAdapter` for persistent, durable
+ * This example demonstrates how to use `createDenokvClient` for persistent, durable
  * storage of RDF graph context, combined with stateless serverless search and query execution.
  */
 if (import.meta.main) {
@@ -13,12 +12,10 @@ if (import.meta.main) {
   const queryEngine = new QueryEngine();
 
   console.log("🧠 Provisioning unified Deno Kv sync engine...");
-  const client = new Client(
-    createDenokvAdapter({
-      kv,
-      createSparqlEngine: createComunicaSparqlEngineFactory({ queryEngine }),
-    }),
-  );
+  const client = createDenokvClient({
+    kv,
+    createSparqlEngine: createComunicaSparqlEngineFactory({ queryEngine }),
+  });
   console.log("💡 Stateless gateway operational!");
 
   // 3. Inject initial data if Deno Kv is empty

--- a/examples/hello-world/main.ts
+++ b/examples/hello-world/main.ts
@@ -1,15 +1,7 @@
-import { Client } from "@worlds/client";
-import { createComunicaSparqlEngineFactory } from "@worlds/client/adapters/comunica";
-import { createRdfjsAdapter } from "@worlds/client/adapters/rdfjs";
-import { QueryEngine } from "@comunica/query-sparql-rdfjs-lite";
+import { createRdfjsClient } from "@worlds/client/adapters/rdfjs";
 
 if (import.meta.main) {
-  const queryEngine = new QueryEngine();
-  const client = new Client(
-    createRdfjsAdapter({
-      createSparqlEngine: createComunicaSparqlEngineFactory({ queryEngine }),
-    }),
-  );
+  const client = createRdfjsClient();
 
   await client.import({
     source: {

--- a/examples/libsql-long-running/hexastore.ts
+++ b/examples/libsql-long-running/hexastore.ts
@@ -1,6 +1,5 @@
 import { createClient } from "@libsql/client";
-import { createComunicaLibsqlSparqlEngineFactory } from "@worlds/client/adapters/comunica";
-import { createLibsqlClient } from "@worlds/client/adapters/libsql";
+import { createLibsqlComunicaClient } from "@worlds/client/adapters/libsql/comunica";
 import { UniversalSentenceEncoderEmbeddingService } from "@worlds/client/adapters/tfjs-universal-sentence-encoder";
 import { QueryEngine } from "@comunica/query-sparql-rdfjs-lite";
 import { DataFactory } from "n3";
@@ -51,13 +50,11 @@ if (import.meta.main) {
   const embeddingService = new UniversalSentenceEncoderEmbeddingService();
 
   console.log("Provisioning hexastore client (process lifetime)...");
-  const client = await createLibsqlClient({
+  const client = await createLibsqlComunicaClient({
     client: databaseClient,
     embeddingService,
     vectorDimensions: USE_LITE_VECTOR_DIMENSIONS,
-    createSparqlEngine: createComunicaLibsqlSparqlEngineFactory({
-      queryEngine,
-    }),
+    queryEngine,
   });
   console.log("Gateway operational.");
 

--- a/examples/libsql-long-running/hexastore.ts
+++ b/examples/libsql-long-running/hexastore.ts
@@ -1,7 +1,6 @@
 import { createClient } from "@libsql/client";
 import { createComunicaLibsqlSparqlEngineFactory } from "@worlds/client/adapters/comunica";
-import { Client } from "@worlds/client";
-import { createLibsqlAdapter } from "@worlds/client/adapters/libsql";
+import { createLibsqlClient } from "@worlds/client/adapters/libsql";
 import { UniversalSentenceEncoderEmbeddingService } from "@worlds/client/adapters/tfjs-universal-sentence-encoder";
 import { QueryEngine } from "@comunica/query-sparql-rdfjs-lite";
 import { DataFactory } from "n3";
@@ -52,16 +51,14 @@ if (import.meta.main) {
   const embeddingService = new UniversalSentenceEncoderEmbeddingService();
 
   console.log("Provisioning hexastore client (process lifetime)...");
-  const client = new Client(
-    await createLibsqlAdapter({
-      client: databaseClient,
-      embeddingService,
-      vectorDimensions: USE_LITE_VECTOR_DIMENSIONS,
-      createSparqlEngine: createComunicaLibsqlSparqlEngineFactory({
-        queryEngine,
-      }),
+  const client = await createLibsqlClient({
+    client: databaseClient,
+    embeddingService,
+    vectorDimensions: USE_LITE_VECTOR_DIMENSIONS,
+    createSparqlEngine: createComunicaLibsqlSparqlEngineFactory({
+      queryEngine,
     }),
-  );
+  });
   console.log("Gateway operational.");
 
   console.log("\nIngesting semantically distinct quads...");

--- a/examples/libsql-long-running/n3.ts
+++ b/examples/libsql-long-running/n3.ts
@@ -1,8 +1,6 @@
 import { createClient } from "@libsql/client";
 import { QueryEngine } from "@comunica/query-sparql-rdfjs-lite";
-import { createComunicaSparqlEngineFactory } from "@worlds/client/adapters/comunica";
-import { Client } from "@worlds/client";
-import { createLibsqlN3Adapter } from "@worlds/client/adapters/libsql-n3";
+import { createLibsqlN3ComunicaClient } from "@worlds/client/adapters/libsql-n3/comunica";
 import { DataFactory } from "n3";
 
 const { quad, namedNode, literal } = DataFactory;
@@ -21,12 +19,10 @@ if (import.meta.main) {
   console.log(
     "Boot: hydrate LibSQL into N3 and wire client (process lifetime)...",
   );
-  const client = new Client(
-    await createLibsqlN3Adapter({
-      client: databaseClient,
-      createSparqlEngine: createComunicaSparqlEngineFactory({ queryEngine }),
-    }),
-  );
+  const client = await createLibsqlN3ComunicaClient({
+    client: databaseClient,
+    queryEngine,
+  });
 
   await client.import({
     source: {

--- a/examples/libsql-n3-warm-container/hexastore.ts
+++ b/examples/libsql-n3-warm-container/hexastore.ts
@@ -1,8 +1,8 @@
 import { createClient } from "@libsql/client";
 import { QueryEngine } from "@comunica/query-sparql-rdfjs-lite";
-import { Client } from "@worlds/client";
+import type { Client } from "@worlds/client";
 import { createComunicaLibsqlSparqlEngineFactory } from "@worlds/client/adapters/comunica";
-import { createLibsqlAdapter } from "@worlds/client/adapters/libsql";
+import { createLibsqlClient } from "@worlds/client/adapters/libsql";
 import { DataFactory } from "n3";
 
 const { quad, namedNode, literal } = DataFactory;
@@ -17,14 +17,12 @@ const queryEngine = new QueryEngine();
 let warmIsolateClient: Client | undefined;
 
 async function getWarmIsolateClient(): Promise<Client> {
-  warmIsolateClient ??= new Client(
-    await createLibsqlAdapter({
-      client: databaseClient,
-      createSparqlEngine: createComunicaLibsqlSparqlEngineFactory({
-        queryEngine,
-      }),
+  warmIsolateClient ??= await createLibsqlClient({
+    client: databaseClient,
+    createSparqlEngine: createComunicaLibsqlSparqlEngineFactory({
+      queryEngine,
     }),
-  );
+  });
   return warmIsolateClient;
 }
 

--- a/examples/libsql-n3-warm-container/hexastore.ts
+++ b/examples/libsql-n3-warm-container/hexastore.ts
@@ -1,8 +1,7 @@
 import { createClient } from "@libsql/client";
 import { QueryEngine } from "@comunica/query-sparql-rdfjs-lite";
 import type { Client } from "@worlds/client";
-import { createComunicaLibsqlSparqlEngineFactory } from "@worlds/client/adapters/comunica";
-import { createLibsqlClient } from "@worlds/client/adapters/libsql";
+import { createLibsqlComunicaClient } from "@worlds/client/adapters/libsql/comunica";
 import { DataFactory } from "n3";
 
 const { quad, namedNode, literal } = DataFactory;
@@ -17,11 +16,9 @@ const queryEngine = new QueryEngine();
 let warmIsolateClient: Client | undefined;
 
 async function getWarmIsolateClient(): Promise<Client> {
-  warmIsolateClient ??= await createLibsqlClient({
+  warmIsolateClient ??= await createLibsqlComunicaClient({
     client: databaseClient,
-    createSparqlEngine: createComunicaLibsqlSparqlEngineFactory({
-      queryEngine,
-    }),
+    queryEngine,
   });
   return warmIsolateClient;
 }

--- a/examples/libsql-n3-warm-container/n3.ts
+++ b/examples/libsql-n3-warm-container/n3.ts
@@ -1,11 +1,11 @@
 import { createClient } from "@libsql/client";
 import { QueryEngine } from "@comunica/query-sparql-rdfjs-lite";
-import { createComunicaSparqlEngineFactory } from "@worlds/client/adapters/comunica";
 import {
-  createLibsqlN3Adapter,
+  createLibsqlN3Client,
   hydrateStoreFromLibsql,
 } from "@worlds/client/adapters/libsql-n3";
-import { Client } from "@worlds/client";
+import { createLibsqlN3ComunicaClient } from "@worlds/client/adapters/libsql-n3/comunica";
+import type { Client } from "@worlds/client";
 import { DataFactory, Store } from "n3";
 
 const { quad, namedNode, literal } = DataFactory;
@@ -20,20 +20,16 @@ const queryEngine = new QueryEngine();
 let warmIsolateClient: Client | undefined;
 
 async function getWarmIsolateClient(warmedStore: Store): Promise<Client> {
-  warmIsolateClient ??= new Client(
-    await createLibsqlN3Adapter({
-      client: databaseClient,
-      store: warmedStore,
-      createSparqlEngine: createComunicaSparqlEngineFactory({ queryEngine }),
-    }),
-  );
-  return warmIsolateClient;
+  warmIsolateClient ??= await createLibsqlN3ComunicaClient({
+    client: databaseClient,
+    store: warmedStore,
+    queryEngine,
+  });
+  return warmIsolateClient as Client;
 }
 
 if (import.meta.main) {
-  const bootClient = new Client(
-    await createLibsqlN3Adapter({ client: databaseClient }),
-  );
+  const bootClient = await createLibsqlN3Client({ client: databaseClient });
   await bootClient.import({
     source: {
       kind: "quads",

--- a/examples/libsql-sparql-scale/README.md
+++ b/examples/libsql-sparql-scale/README.md
@@ -8,7 +8,7 @@ Runnable companion to
 deno task example:libsql-sparql-scale
 ```
 
-Uses `createLibsqlClient` with inline SPARQL strings:
+Uses `createLibsqlComunicaClient` with inline SPARQL strings:
 
 - **Selective:** subject-bound `SELECT ?p ?o WHERE { <iri> ?p ?o }` — default
   for production hot paths.

--- a/examples/libsql-sparql-scale/README.md
+++ b/examples/libsql-sparql-scale/README.md
@@ -8,7 +8,7 @@ Runnable companion to
 deno task example:libsql-sparql-scale
 ```
 
-Uses `createLibsqlAdapter` + `Client` with inline SPARQL strings:
+Uses `createLibsqlClient` with inline SPARQL strings:
 
 - **Selective:** subject-bound `SELECT ?p ?o WHERE { <iri> ?p ?o }` — default
   for production hot paths.

--- a/examples/libsql-sparql-scale/main.ts
+++ b/examples/libsql-sparql-scale/main.ts
@@ -1,8 +1,7 @@
 import { createClient } from "@libsql/client";
 import { QueryEngine } from "@comunica/query-sparql-rdfjs-lite";
-import { Client } from "@worlds/client";
 import { createComunicaLibsqlSparqlEngineFactory } from "@worlds/client/adapters/comunica";
-import { createLibsqlAdapter } from "@worlds/client/adapters/libsql";
+import { createLibsqlClient } from "@worlds/client/adapters/libsql";
 import { DataFactory } from "n3";
 
 const { quad, namedNode, literal } = DataFactory;
@@ -18,14 +17,12 @@ if (import.meta.main) {
   const databaseClient = createClient({ url: ":memory:" });
   const queryEngine = new QueryEngine();
 
-  const client = new Client(
-    await createLibsqlAdapter({
-      client: databaseClient,
-      createSparqlEngine: createComunicaLibsqlSparqlEngineFactory({
-        queryEngine,
-      }),
+  const client = await createLibsqlClient({
+    client: databaseClient,
+    createSparqlEngine: createComunicaLibsqlSparqlEngineFactory({
+      queryEngine,
     }),
-  );
+  });
 
   await client.import({
     source: {

--- a/examples/libsql-sparql-scale/main.ts
+++ b/examples/libsql-sparql-scale/main.ts
@@ -1,7 +1,6 @@
 import { createClient } from "@libsql/client";
 import { QueryEngine } from "@comunica/query-sparql-rdfjs-lite";
-import { createComunicaLibsqlSparqlEngineFactory } from "@worlds/client/adapters/comunica";
-import { createLibsqlClient } from "@worlds/client/adapters/libsql";
+import { createLibsqlComunicaClient } from "@worlds/client/adapters/libsql/comunica";
 import { DataFactory } from "n3";
 
 const { quad, namedNode, literal } = DataFactory;
@@ -17,11 +16,9 @@ if (import.meta.main) {
   const databaseClient = createClient({ url: ":memory:" });
   const queryEngine = new QueryEngine();
 
-  const client = await createLibsqlClient({
+  const client = await createLibsqlComunicaClient({
     client: databaseClient,
-    createSparqlEngine: createComunicaLibsqlSparqlEngineFactory({
-      queryEngine,
-    }),
+    queryEngine,
   });
 
   await client.import({

--- a/src/client/adapters/comunica/comunica-sparql-engine.test.ts
+++ b/src/client/adapters/comunica/comunica-sparql-engine.test.ts
@@ -222,7 +222,7 @@ Deno.test(
       },
     });
 
-    const response = await sparqlEngine.execute({
+    const response = await sparqlEngine.sparql({
       query: `INSERT DATA { <urn:onvoid> <urn:flag> "set" . }`,
     });
 
@@ -429,7 +429,7 @@ Deno.test(
       queryEngine,
       store: libsqlStore,
     });
-    const response = await sparqlEngine.execute({
+    const response = await sparqlEngine.sparql({
       query:
         `SELECT ?property ?object WHERE { <${subjectIri}> ?property ?object }`,
     });

--- a/src/client/adapters/comunica/comunica-sparql-engine.ts
+++ b/src/client/adapters/comunica/comunica-sparql-engine.ts
@@ -96,7 +96,7 @@ export class ComunicaSparqlEngine implements SparqlEngineInterface {
     private readonly options: ComunicaSparqlEngineOptions,
   ) {}
 
-  public async execute(request: SparqlRequest): Promise<SparqlResponse> {
+  public async sparql(request: SparqlRequest): Promise<SparqlResponse> {
     const response = await executeSparql(
       this.options.queryEngine,
       this.options.store,

--- a/src/client/adapters/comunica/create-comunica-sparql-engine-factory.test.ts
+++ b/src/client/adapters/comunica/create-comunica-sparql-engine-factory.test.ts
@@ -30,7 +30,7 @@ Deno.test(
       queryEngine,
     });
     const sparqlEngine = createSparqlEngine({ store });
-    const response = await sparqlEngine.execute({
+    const response = await sparqlEngine.sparql({
       query:
         "SELECT ?object WHERE { <https://example.com/s> <https://example.com/p> ?object }",
     });
@@ -83,7 +83,7 @@ Deno.test(
       queryEngine,
     });
     const sparqlEngine = createSparqlEngine({ libsqlStore });
-    const response = await sparqlEngine.execute({
+    const response = await sparqlEngine.sparql({
       query: `SELECT ?object WHERE { <${subjectIri}> ?property ?object }`,
     });
 

--- a/src/client/adapters/comunica/create-comunica-sparql-engine-factory.ts
+++ b/src/client/adapters/comunica/create-comunica-sparql-engine-factory.ts
@@ -24,7 +24,7 @@ export function createComunicaSparqlEngineFactory(
 }
 
 /**
- * createComunicaLibsqlSparqlEngineFactory returns a createSparqlEngine callback for hexastore LibSQL clients.
+ * createComunicaLibsqlSparqlEngineFactory returns a createSparqlEngine callback for hexastore LibSQL clients (prefer createLibsqlComunicaClient).
  */
 export function createComunicaLibsqlSparqlEngineFactory(
   options: CreateComunicaSparqlEngineFactoryOptions,

--- a/src/client/adapters/denokv/create-denokv-adapter.test.ts
+++ b/src/client/adapters/denokv/create-denokv-adapter.test.ts
@@ -2,10 +2,9 @@ import { assertEquals, assertExists, assertRejects } from "@std/assert";
 import type * as rdfjs from "@rdfjs/types";
 import { QueryEngine } from "@comunica/query-sparql-rdfjs-lite";
 import { DataFactory } from "n3";
-import { Client } from "@/client/client.ts";
 import { ComunicaSparqlEngine } from "@/client/adapters/comunica/mod.ts";
 import { DenokvQuadStore } from "./denokv-quad-store.ts";
-import { createDenokvAdapter } from "./create-denokv-adapter.ts";
+import { createDenokvClient } from "./create-denokv-adapter.ts";
 
 const { quad, namedNode, literal } = DataFactory;
 const queryEngine = new QueryEngine();
@@ -25,11 +24,11 @@ async function seedQuads(
 }
 
 Deno.test(
-  "createDenokvAdapter - import delivers search hits from Deno Kv",
+  "createDenokvClient - import delivers search hits from Deno Kv",
   async () => {
     const kv = await Deno.openKv(":memory:");
     try {
-      const client = new Client(createDenokvAdapter({ kv }));
+      const client = createDenokvClient({ kv });
       const testQuad = quad(
         namedNode("urn:person:alice"),
         namedNode("urn:bio"),
@@ -49,11 +48,11 @@ Deno.test(
 );
 
 Deno.test(
-  "createDenokvAdapter - export round-trips imported quads",
+  "createDenokvClient - export round-trips imported quads",
   async () => {
     const kv = await Deno.openKv(":memory:");
     try {
-      const client = new Client(createDenokvAdapter({ kv }));
+      const client = createDenokvClient({ kv });
       const testQuad = quad(
         namedNode("urn:doc:1"),
         namedNode("urn:title"),
@@ -76,17 +75,15 @@ Deno.test(
 );
 
 Deno.test(
-  "createDenokvAdapter - hydration SPARQL reads latest Deno Kv state",
+  "createDenokvClient - hydration SPARQL reads latest Deno Kv state",
   async () => {
     const kv = await Deno.openKv(":memory:");
     try {
-      const client = new Client(
-        createDenokvAdapter({
-          kv,
-          createSparqlEngine: ({ store }) =>
-            new ComunicaSparqlEngine({ queryEngine, store }),
-        }),
-      );
+      const client = createDenokvClient({
+        kv,
+        createSparqlEngine: ({ store }) =>
+          new ComunicaSparqlEngine({ queryEngine, store }),
+      });
 
       await seedQuads(kv, [
         quad(
@@ -111,17 +108,15 @@ Deno.test(
 );
 
 Deno.test(
-  "createDenokvAdapter - hydration SPARQL sees quads imported after client construction",
+  "createDenokvClient - hydration SPARQL sees quads imported after client construction",
   async () => {
     const kv = await Deno.openKv(":memory:");
     try {
-      const client = new Client(
-        createDenokvAdapter({
-          kv,
-          createSparqlEngine: ({ store }) =>
-            new ComunicaSparqlEngine({ queryEngine, store }),
-        }),
-      );
+      const client = createDenokvClient({
+        kv,
+        createSparqlEngine: ({ store }) =>
+          new ComunicaSparqlEngine({ queryEngine, store }),
+      });
 
       await client.import({
         source: {
@@ -155,11 +150,11 @@ Deno.test(
 );
 
 Deno.test(
-  "createDenokvAdapter - sparql rejects when createSparqlEngine is omitted",
+  "createDenokvClient - sparql rejects when createSparqlEngine is omitted",
   async () => {
     const kv = await Deno.openKv(":memory:");
     try {
-      const client = new Client(createDenokvAdapter({ kv }));
+      const client = createDenokvClient({ kv });
 
       await assertRejects(
         () => client.sparql({ query: "ASK WHERE { ?s ?p ?o }" }),

--- a/src/client/adapters/denokv/create-denokv-adapter.ts
+++ b/src/client/adapters/denokv/create-denokv-adapter.ts
@@ -1,6 +1,9 @@
 import { Store } from "n3";
-import type { Adapter } from "@/client/client.ts";
-import type { SparqlEngineInterface } from "@/client/sparql-engine/mod.ts";
+import { Client } from "@/client/client.ts";
+import type {
+  SparqlEngineInterface,
+  SparqlRequest,
+} from "@/client/sparql-engine/mod.ts";
 import { DenokvSearchIndex } from "./denokv-search-index.ts";
 import type { DenokvQuadStoreOptions } from "./denokv-quad-store.ts";
 import { DenokvQuadStore } from "./denokv-quad-store.ts";
@@ -16,14 +19,14 @@ export interface DenokvOptions extends DenokvQuadStoreOptions {
 }
 
 /**
- * createDenokvAdapter synthesizes a client adapter designed explicitly for
- * stateless, per-operation execution. It leverages a lazy, transient hydration
- * pipeline that fetches fresh durable quads on-demand, providing strong data
- * consistency without requiring long-lived memory store residency.
+ * createDenokvClient synthesizes a Client designed explicitly for stateless,
+ * per-operation execution. It leverages a lazy, transient hydration pipeline that
+ * fetches fresh durable quads on-demand, providing strong data consistency without
+ * requiring long-lived memory store residency.
  */
-export function createDenokvAdapter(
+export function createDenokvClient(
   options: DenokvOptions,
-): Adapter {
+): Client {
   const quadStore = new DenokvQuadStore(options);
 
   /**
@@ -41,22 +44,23 @@ export function createDenokvAdapter(
     return store;
   };
 
-  return {
-    quadStore,
+  const sparqlEngine = options.createSparqlEngine
+    ? {
+      sparql: async (request: SparqlRequest) => {
+        const workspace = await hydrateWorkspace();
+        const engine = options.createSparqlEngine?.({ store: workspace });
+        if (!engine) {
+          throw new Error("SPARQL engine is not configured.");
+        }
+        return await engine.sparql(request);
+      },
+    }
+    : undefined;
 
-    searchIndex: new DenokvSearchIndex(options),
-
-    sparqlEngine: options.createSparqlEngine
-      ? {
-        execute: async (request) => {
-          const workspace = await hydrateWorkspace();
-          const engine = options.createSparqlEngine?.({ store: workspace });
-          if (!engine) {
-            throw new Error("SPARQL engine is not configured.");
-          }
-          return await engine.execute(request);
-        },
-      }
-      : undefined,
-  };
+  return new Client(quadStore, new DenokvSearchIndex(options), sparqlEngine);
 }
+
+/**
+ * createDenokvAdapter is deprecated; use createDenokvClient. Removed in 0.0.17.
+ */
+export const createDenokvAdapter = createDenokvClient;

--- a/src/client/adapters/libsql-n3/comunica/create-libsql-n3-comunica-client.ts
+++ b/src/client/adapters/libsql-n3/comunica/create-libsql-n3-comunica-client.ts
@@ -1,0 +1,31 @@
+import type { Client } from "@/client/client.ts";
+import {
+  type ComunicaQueryEngine,
+  ComunicaSparqlEngine,
+} from "@/client/adapters/comunica/mod.ts";
+import {
+  assembleLibsqlN3Client,
+  type LibsqlN3AdapterOptions,
+} from "../create-libsql-n3-adapter.ts";
+
+/**
+ * LibsqlN3ComunicaClientOptions configures hydrate, proxied N3, and LibSQL sync with Comunica SPARQL.
+ */
+export interface LibsqlN3ComunicaClientOptions extends LibsqlN3AdapterOptions {
+  /** queryEngine is the caller-owned Comunica-compatible query engine. */
+  queryEngine: ComunicaQueryEngine;
+}
+
+/**
+ * createLibsqlN3ComunicaClient synthesizes a Client with Comunica SPARQL over the proxied N3 store.
+ * Pass a warmed `store` to skip hydration (edge isolates); omit `store` to hydrate once at construction.
+ */
+export async function createLibsqlN3ComunicaClient(
+  options: LibsqlN3ComunicaClientOptions,
+): Promise<Client> {
+  const { queryEngine, ...libsqlN3Options } = options;
+  return await assembleLibsqlN3Client(
+    libsqlN3Options,
+    ({ store }) => new ComunicaSparqlEngine({ queryEngine, store }),
+  );
+}

--- a/src/client/adapters/libsql-n3/comunica/create-libsql-n3-comunica-client.ts
+++ b/src/client/adapters/libsql-n3/comunica/create-libsql-n3-comunica-client.ts
@@ -9,7 +9,7 @@ import {
 } from "../create-libsql-n3-adapter.ts";
 
 /**
- * LibsqlN3ComunicaClientOptions configures hydrate, proxied N3, and LibSQL sync with Comunica SPARQL.
+ * LibsqlN3ComunicaClientOptions configures hydrated N3 execution with Comunica SPARQL.
  */
 export interface LibsqlN3ComunicaClientOptions extends LibsqlN3AdapterOptions {
   /** queryEngine is the caller-owned Comunica-compatible query engine. */
@@ -18,7 +18,6 @@ export interface LibsqlN3ComunicaClientOptions extends LibsqlN3AdapterOptions {
 
 /**
  * createLibsqlN3ComunicaClient synthesizes a Client with Comunica SPARQL over the proxied N3 store.
- * Pass a warmed `store` to skip hydration (edge isolates); omit `store` to hydrate once at construction.
  */
 export async function createLibsqlN3ComunicaClient(
   options: LibsqlN3ComunicaClientOptions,

--- a/src/client/adapters/libsql-n3/comunica/mod.ts
+++ b/src/client/adapters/libsql-n3/comunica/mod.ts
@@ -1,0 +1,1 @@
+export * from "./create-libsql-n3-comunica-client.ts";

--- a/src/client/adapters/libsql-n3/create-libsql-n3-adapter.test.ts
+++ b/src/client/adapters/libsql-n3/create-libsql-n3-adapter.test.ts
@@ -2,9 +2,8 @@ import { assertEquals, assertExists } from "@std/assert";
 import { createClient } from "@libsql/client";
 import { QueryEngine } from "@comunica/query-sparql-rdfjs-lite";
 import { DataFactory, Store } from "n3";
-import { Client } from "@/client/client.ts";
-import { ComunicaSparqlEngine } from "@/client/adapters/comunica/mod.ts";
-import { createLibsqlN3Adapter } from "./create-libsql-n3-adapter.ts";
+import { createLibsqlN3Client } from "./create-libsql-n3-adapter.ts";
+import { createLibsqlN3ComunicaClient } from "./comunica/create-libsql-n3-comunica-client.ts";
 import { FakeEmbeddingService } from "@/client/search-index/embedding-service/mod.ts";
 
 const { quad, namedNode, literal } = DataFactory;
@@ -15,14 +14,11 @@ Deno.test("E2E DEMO: unified data entry enables immediate hybrid search availabi
   const db = createClient({ url: ":memory:" });
   const embeddingService = new FakeEmbeddingService();
 
-  const client = new Client(
-    await createLibsqlN3Adapter({
-      client: db,
-      embeddingService,
-      createSparqlEngine: ({ store }) =>
-        new ComunicaSparqlEngine({ queryEngine, store }),
-    }),
-  );
+  const client = await createLibsqlN3ComunicaClient({
+    client: db,
+    embeddingService,
+    queryEngine,
+  });
 
   await t.step(
     "Scenario 1: client.import delivers immediate index observability",
@@ -97,12 +93,10 @@ Deno.test("E2E DEMO: unified data entry enables immediate hybrid search availabi
     async () => {
       // Destroy active memory references and simulate a software crash/reboot.
       // Create a fresh client reusing the SAME physical :memory: database.
-      const refreshedClient = new Client(
-        await createLibsqlN3Adapter({
-          client: db,
-          embeddingService,
-        }),
-      );
+      const refreshedClient = await createLibsqlN3Client({
+        client: db,
+        embeddingService,
+      });
 
       // Perform a search directly on the new client.
       // Expected: Hydrator recovered facts from 'quads' table -> re-rendered memory -> enabled lookups!
@@ -199,12 +193,10 @@ Deno.test("E2E DEMO: unified data entry enables immediate hybrid search availabi
     async () => {
       const db = createClient({ url: ":memory:" });
       const embeddingService = new FakeEmbeddingService();
-      const client = new Client(
-        await createLibsqlN3Adapter({
-          client: db,
-          embeddingService,
-        }),
-      );
+      const client = await createLibsqlN3Client({
+        client: db,
+        embeddingService,
+      });
 
       const staleQuad = quad(
         namedNode("urn:person:erin"),
@@ -268,12 +260,10 @@ Deno.test("E2E DEMO: unified data entry enables immediate hybrid search availabi
     async () => {
       const db = createClient({ url: ":memory:" });
       const embeddingService = new FakeEmbeddingService();
-      const client = new Client(
-        await createLibsqlN3Adapter({
-          client: db,
-          embeddingService,
-        }),
-      );
+      const client = await createLibsqlN3Client({
+        client: db,
+        embeddingService,
+      });
 
       const staleQuad = quad(
         namedNode("urn:person:gina"),
@@ -341,15 +331,13 @@ Deno.test("QuadFilter Integration: enables hybrid partitioning persisting specif
   const EPHEMERAL_GRAPH = "http://worlds.wazoo.dev/.well-known/ephemeral";
 
   // Initialize client with filter restricting SQL writes exclusively to the persistent graph
-  const client = new Client(
-    await createLibsqlN3Adapter({
-      client: db,
-      embeddingService,
-      include: {
-        graphs: [PERSISTENT_GRAPH],
-      },
-    }),
-  );
+  const client = await createLibsqlN3Client({
+    client: db,
+    embeddingService,
+    include: {
+      graphs: [PERSISTENT_GRAPH],
+    },
+  });
 
   // 1. Stage both durable and ephemeral facts
   const durableQuad = quad(
@@ -400,15 +388,13 @@ Deno.test("QuadFilter Integration: enables hybrid partitioning persisting specif
 
   // 4. ASSERT: Verify Hydration boundary on reboot
   // Restart client pointing to the same DB with identical filtering bounds
-  const restartedClient = new Client(
-    await createLibsqlN3Adapter({
-      client: db,
-      embeddingService,
-      include: {
-        graphs: [PERSISTENT_GRAPH],
-      },
-    }),
-  );
+  const restartedClient = await createLibsqlN3Client({
+    client: db,
+    embeddingService,
+    include: {
+      graphs: [PERSISTENT_GRAPH],
+    },
+  });
 
   const rebootSearchDurable = await restartedClient.search({
     query: "durable",
@@ -447,11 +433,11 @@ const expectedHexastoreIndexNames = [
 ] as const;
 
 Deno.test(
-  "createLibsqlN3Adapter - initializeSchema provisions all hexastore indexes",
+  "createLibsqlN3Client - initializeSchema provisions all hexastore indexes",
   async () => {
     const db = createClient({ url: ":memory:" });
 
-    await createLibsqlN3Adapter({ client: db });
+    await createLibsqlN3Client({ client: db });
 
     const indexResultSet = await db.execute(
       "SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'quads'",
@@ -465,7 +451,7 @@ Deno.test(
       );
     }
 
-    await createLibsqlN3Adapter({ client: db });
+    await createLibsqlN3Client({ client: db });
 
     db.close();
   },

--- a/src/client/adapters/libsql-n3/create-libsql-n3-adapter.ts
+++ b/src/client/adapters/libsql-n3/create-libsql-n3-adapter.ts
@@ -1,9 +1,13 @@
 import { RecursiveCharacterTextSplitter } from "@langchain/textsplitters";
 import { Store } from "n3";
 
-import type { Adapter } from "@/client/client.ts";
+import { Client } from "@/client/client.ts";
+import type { ExportRequest, ImportRequest } from "@/client/quad-store/mod.ts";
 import { mergePatches } from "@/client/quad-store/mod.ts";
-import type { SparqlEngineInterface } from "@/client/sparql-engine/mod.ts";
+import type {
+  SparqlEngineInterface,
+  SparqlRequest,
+} from "@/client/sparql-engine/mod.ts";
 import { createProxiedN3Store } from "@/client/quad-store/n3/mod.ts";
 import { RdfjsQuadStore } from "@/client/adapters/rdfjs/mod.ts";
 import type { LibsqlClientBaseOptions } from "@/client/adapters/libsql/mod.ts";
@@ -21,19 +25,23 @@ import { hydrateStoreFromLibsql } from "./hydrate-store-from-libsql.ts";
 export interface LibsqlN3AdapterOptions extends LibsqlClientBaseOptions {
   /** store is an optional starting store, useful for serverless environments where the store is already initialized. */
   store?: Store;
-
-  /** createSparqlEngine optionally attaches a caller-provided SPARQL engine over the hydrated N3 store. */
-  createSparqlEngine?: (
-    options: { store: Store },
-  ) => SparqlEngineInterface;
 }
 
 /**
- * createLibsqlN3Adapter synthesizes a Adapter for the hydrate → createProxiedN3Store → LibSQL sync path.
+ * AttachLibsqlN3SparqlEngine wires a SPARQL engine after the proxied N3 store exists (in-repo preset use only).
  */
-export async function createLibsqlN3Adapter(
+export type AttachLibsqlN3SparqlEngine = (
+  options: { store: Store },
+) => SparqlEngineInterface;
+
+/**
+ * assembleLibsqlN3Client builds a Client for the hydrate → createProxiedN3Store → LibSQL sync path.
+ * Prefer createLibsqlN3Client (search/import) or createLibsqlN3ComunicaClient (Comunica SPARQL).
+ */
+export async function assembleLibsqlN3Client(
   options: LibsqlN3AdapterOptions,
-): Promise<Adapter> {
+  attachSparqlEngine?: AttachLibsqlN3SparqlEngine,
+): Promise<Client> {
   const vectorDimensions = options.vectorDimensions ?? 32;
   const queryBuilder = new LibsqlQueryBuilder(vectorDimensions);
 
@@ -50,7 +58,7 @@ export async function createLibsqlN3Adapter(
   }
 
   const { store, drainPatches } = createProxiedN3Store(initialStore);
-  const configuredSparqlEngine = options.createSparqlEngine?.({ store });
+  const configuredSparqlEngine = attachSparqlEngine?.({ store });
 
   const textSplitter = options.textSplitter ??
     new RecursiveCharacterTextSplitter({ chunkSize: 1000 });
@@ -76,26 +84,41 @@ export async function createLibsqlN3Adapter(
 
   const quadStore = new RdfjsQuadStore(store);
 
-  return {
-    quadStore: {
-      export: (request) => quadStore.export(request),
-      import: async (request) => {
-        patchSync.beforeImport();
-        const response = await quadStore.import(request);
+  const wrappedQuadStore = {
+    export: (request: ExportRequest) => quadStore.export(request),
+    import: async (request: ImportRequest) => {
+      patchSync.beforeImport();
+      const response = await quadStore.import(request);
+      await commitChanges();
+      await patchSync.afterImport();
+      return response;
+    },
+  };
+
+  const wrappedSparqlEngine = configuredSparqlEngine
+    ? {
+      sparql: async (request: SparqlRequest) => {
+        const response = await configuredSparqlEngine.sparql(request);
         await commitChanges();
-        await patchSync.afterImport();
         return response;
       },
-    },
-    sparqlEngine: configuredSparqlEngine
-      ? {
-        execute: async (request) => {
-          const response = await configuredSparqlEngine.execute(request);
-          await commitChanges();
-          return response;
-        },
-      }
-      : undefined,
-    searchIndex,
-  };
+    }
+    : undefined;
+
+  return new Client(wrappedQuadStore, searchIndex, wrappedSparqlEngine);
 }
+
+/**
+ * createLibsqlN3Client synthesizes a Client for import, export, and search without SPARQL.
+ * For Comunica SPARQL, use createLibsqlN3ComunicaClient from `@worlds/client/adapters/libsql-n3/comunica`.
+ */
+export async function createLibsqlN3Client(
+  options: LibsqlN3AdapterOptions,
+): Promise<Client> {
+  return await assembleLibsqlN3Client(options);
+}
+
+/**
+ * createLibsqlN3Adapter is deprecated; use createLibsqlN3Client. Removed in 0.0.17.
+ */
+export const createLibsqlN3Adapter = createLibsqlN3Client;

--- a/src/client/adapters/libsql/comunica/create-libsql-comunica-client.ts
+++ b/src/client/adapters/libsql/comunica/create-libsql-comunica-client.ts
@@ -1,0 +1,31 @@
+import type { Client } from "@/client/client.ts";
+import {
+  type ComunicaQueryEngine,
+  ComunicaSparqlEngine,
+} from "@/client/adapters/comunica/mod.ts";
+import {
+  assembleLibsqlClient,
+  type LibsqlAdapterOptions,
+} from "../create-libsql-adapter.ts";
+
+/**
+ * LibsqlComunicaClientOptions configures LibsqlStore hexastore execution with Comunica SPARQL.
+ */
+export interface LibsqlComunicaClientOptions extends LibsqlAdapterOptions {
+  /** queryEngine is the caller-owned Comunica-compatible query engine. */
+  queryEngine: ComunicaQueryEngine;
+}
+
+/**
+ * createLibsqlComunicaClient synthesizes a Client with Comunica SPARQL over LibsqlStore.
+ */
+export async function createLibsqlComunicaClient(
+  options: LibsqlComunicaClientOptions,
+): Promise<Client> {
+  const { queryEngine, ...libsqlOptions } = options;
+  return await assembleLibsqlClient(
+    libsqlOptions,
+    ({ libsqlStore }) =>
+      new ComunicaSparqlEngine({ queryEngine, store: libsqlStore }),
+  );
+}

--- a/src/client/adapters/libsql/comunica/mod.ts
+++ b/src/client/adapters/libsql/comunica/mod.ts
@@ -1,0 +1,1 @@
+export * from "./create-libsql-comunica-client.ts";

--- a/src/client/adapters/libsql/create-libsql-adapter.test.ts
+++ b/src/client/adapters/libsql/create-libsql-adapter.test.ts
@@ -1,10 +1,9 @@
-import { assertEquals, assertExists } from "@std/assert";
+import { assertEquals } from "@std/assert";
 import { createClient } from "@libsql/client";
 import { QueryEngine } from "@comunica/query-sparql-rdfjs-lite";
 import { DataFactory } from "n3";
-import { ComunicaSparqlEngine } from "@/client/adapters/comunica/mod.ts";
 import { createLibsqlClient } from "./create-libsql-adapter.ts";
-import type { LibsqlStore } from "@/client/adapters/libsql/store/mod.ts";
+import { createLibsqlComunicaClient } from "./comunica/create-libsql-comunica-client.ts";
 
 const { quad, namedNode, literal } = DataFactory;
 const queryEngine = new QueryEngine();
@@ -21,34 +20,13 @@ const expectedHexastoreIndexNames = [
 ] as const;
 
 Deno.test(
-  "createLibsqlClient - createSparqlEngine receives LibsqlStore",
-  async () => {
-    const databaseClient = createClient({ url: ":memory:" });
-    let receivedLibsqlStore: LibsqlStore | undefined;
-
-    await createLibsqlClient({
-      client: databaseClient,
-      createSparqlEngine: ({ libsqlStore }) => {
-        receivedLibsqlStore = libsqlStore;
-        return new ComunicaSparqlEngine({ queryEngine, store: libsqlStore });
-      },
-    });
-
-    assertExists(receivedLibsqlStore);
-
-    databaseClient.close();
-  },
-);
-
-Deno.test(
-  "createLibsqlClient - import persists quads readable via SPARQL",
+  "createLibsqlComunicaClient - import persists quads readable via SPARQL",
   async () => {
     const databaseClient = createClient({ url: ":memory:" });
 
-    const client = await createLibsqlClient({
+    const client = await createLibsqlComunicaClient({
       client: databaseClient,
-      createSparqlEngine: ({ libsqlStore }) =>
-        new ComunicaSparqlEngine({ queryEngine, store: libsqlStore }),
+      queryEngine,
     });
 
     await client.import({
@@ -107,11 +85,10 @@ Deno.test(
   async () => {
     const databaseClient = createClient({ url: ":memory:" });
 
-    const client = await createLibsqlClient({
+    const client = await createLibsqlComunicaClient({
       client: databaseClient,
       searchIndexOnImport: "disabled",
-      createSparqlEngine: ({ libsqlStore }) =>
-        new ComunicaSparqlEngine({ queryEngine, store: libsqlStore }),
+      queryEngine,
     });
 
     await client.import({
@@ -157,8 +134,6 @@ Deno.test(
     const client = await createLibsqlClient({
       client: databaseClient,
       searchIndexOnImport: "disabled",
-      createSparqlEngine: ({ libsqlStore }) =>
-        new ComunicaSparqlEngine({ queryEngine, store: libsqlStore }),
     });
 
     await client.import({
@@ -207,8 +182,6 @@ Deno.test(
     const client = await createLibsqlClient({
       client: databaseClient,
       searchIndexOnImport: "disabled",
-      createSparqlEngine: ({ libsqlStore }) =>
-        new ComunicaSparqlEngine({ queryEngine, store: libsqlStore }),
     });
 
     await client.import({
@@ -253,8 +226,6 @@ Deno.test(
     const client = await createLibsqlClient({
       client: databaseClient,
       searchIndexOnImport: "disabled",
-      createSparqlEngine: ({ libsqlStore }) =>
-        new ComunicaSparqlEngine({ queryEngine, store: libsqlStore }),
     });
 
     await client.import({

--- a/src/client/adapters/libsql/create-libsql-adapter.test.ts
+++ b/src/client/adapters/libsql/create-libsql-adapter.test.ts
@@ -2,9 +2,8 @@ import { assertEquals, assertExists } from "@std/assert";
 import { createClient } from "@libsql/client";
 import { QueryEngine } from "@comunica/query-sparql-rdfjs-lite";
 import { DataFactory } from "n3";
-import { Client } from "@/client/client.ts";
 import { ComunicaSparqlEngine } from "@/client/adapters/comunica/mod.ts";
-import { createLibsqlAdapter } from "./create-libsql-adapter.ts";
+import { createLibsqlClient } from "./create-libsql-adapter.ts";
 import type { LibsqlStore } from "@/client/adapters/libsql/store/mod.ts";
 
 const { quad, namedNode, literal } = DataFactory;
@@ -22,12 +21,12 @@ const expectedHexastoreIndexNames = [
 ] as const;
 
 Deno.test(
-  "createLibsqlAdapter - createSparqlEngine receives LibsqlStore",
+  "createLibsqlClient - createSparqlEngine receives LibsqlStore",
   async () => {
     const databaseClient = createClient({ url: ":memory:" });
     let receivedLibsqlStore: LibsqlStore | undefined;
 
-    await createLibsqlAdapter({
+    await createLibsqlClient({
       client: databaseClient,
       createSparqlEngine: ({ libsqlStore }) => {
         receivedLibsqlStore = libsqlStore;
@@ -42,17 +41,15 @@ Deno.test(
 );
 
 Deno.test(
-  "createLibsqlAdapter - import persists quads readable via SPARQL",
+  "createLibsqlClient - import persists quads readable via SPARQL",
   async () => {
     const databaseClient = createClient({ url: ":memory:" });
 
-    const client = new Client(
-      await createLibsqlAdapter({
-        client: databaseClient,
-        createSparqlEngine: ({ libsqlStore }) =>
-          new ComunicaSparqlEngine({ queryEngine, store: libsqlStore }),
-      }),
-    );
+    const client = await createLibsqlClient({
+      client: databaseClient,
+      createSparqlEngine: ({ libsqlStore }) =>
+        new ComunicaSparqlEngine({ queryEngine, store: libsqlStore }),
+    });
 
     await client.import({
       source: {
@@ -81,11 +78,11 @@ Deno.test(
 );
 
 Deno.test(
-  "createLibsqlAdapter - initializeSchema provisions all hexastore indexes",
+  "createLibsqlClient - initializeSchema provisions all hexastore indexes",
   async () => {
     const databaseClient = createClient({ url: ":memory:" });
 
-    await createLibsqlAdapter({ client: databaseClient });
+    await createLibsqlClient({ client: databaseClient });
 
     const indexResultSet = await databaseClient.execute(
       "SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'quads'",
@@ -99,25 +96,23 @@ Deno.test(
       );
     }
 
-    await createLibsqlAdapter({ client: databaseClient });
+    await createLibsqlClient({ client: databaseClient });
 
     databaseClient.close();
   },
 );
 
 Deno.test(
-  "createLibsqlAdapter - searchIndexOnImport disabled skips chunks and search stays empty",
+  "createLibsqlClient - searchIndexOnImport disabled skips chunks and search stays empty",
   async () => {
     const databaseClient = createClient({ url: ":memory:" });
 
-    const client = new Client(
-      await createLibsqlAdapter({
-        client: databaseClient,
-        searchIndexOnImport: "disabled",
-        createSparqlEngine: ({ libsqlStore }) =>
-          new ComunicaSparqlEngine({ queryEngine, store: libsqlStore }),
-      }),
-    );
+    const client = await createLibsqlClient({
+      client: databaseClient,
+      searchIndexOnImport: "disabled",
+      createSparqlEngine: ({ libsqlStore }) =>
+        new ComunicaSparqlEngine({ queryEngine, store: libsqlStore }),
+    });
 
     await client.import({
       source: {
@@ -155,18 +150,16 @@ Deno.test(
 );
 
 Deno.test(
-  "createLibsqlAdapter - rebuildSearchIndex after searchIndexOnImport disabled enables search",
+  "createLibsqlClient - rebuildSearchIndex after searchIndexOnImport disabled enables search",
   async () => {
     const databaseClient = createClient({ url: ":memory:" });
 
-    const client = new Client(
-      await createLibsqlAdapter({
-        client: databaseClient,
-        searchIndexOnImport: "disabled",
-        createSparqlEngine: ({ libsqlStore }) =>
-          new ComunicaSparqlEngine({ queryEngine, store: libsqlStore }),
-      }),
-    );
+    const client = await createLibsqlClient({
+      client: databaseClient,
+      searchIndexOnImport: "disabled",
+      createSparqlEngine: ({ libsqlStore }) =>
+        new ComunicaSparqlEngine({ queryEngine, store: libsqlStore }),
+    });
 
     await client.import({
       source: {
@@ -205,20 +198,18 @@ Deno.test(
 );
 
 Deno.test(
-  "createLibsqlAdapter - rebuildSearchIndex include/exclude scopes indexed graphs",
+  "createLibsqlClient - rebuildSearchIndex include/exclude scopes indexed graphs",
   async () => {
     const databaseClient = createClient({ url: ":memory:" });
     const graphAlpha = namedNode("urn:graph:alpha");
     const graphBeta = namedNode("urn:graph:beta");
 
-    const client = new Client(
-      await createLibsqlAdapter({
-        client: databaseClient,
-        searchIndexOnImport: "disabled",
-        createSparqlEngine: ({ libsqlStore }) =>
-          new ComunicaSparqlEngine({ queryEngine, store: libsqlStore }),
-      }),
-    );
+    const client = await createLibsqlClient({
+      client: databaseClient,
+      searchIndexOnImport: "disabled",
+      createSparqlEngine: ({ libsqlStore }) =>
+        new ComunicaSparqlEngine({ queryEngine, store: libsqlStore }),
+    });
 
     await client.import({
       source: {
@@ -255,18 +246,16 @@ Deno.test(
 );
 
 Deno.test(
-  "createLibsqlAdapter - rebuildSearchIndex is idempotent on second run",
+  "createLibsqlClient - rebuildSearchIndex is idempotent on second run",
   async () => {
     const databaseClient = createClient({ url: ":memory:" });
 
-    const client = new Client(
-      await createLibsqlAdapter({
-        client: databaseClient,
-        searchIndexOnImport: "disabled",
-        createSparqlEngine: ({ libsqlStore }) =>
-          new ComunicaSparqlEngine({ queryEngine, store: libsqlStore }),
-      }),
-    );
+    const client = await createLibsqlClient({
+      client: databaseClient,
+      searchIndexOnImport: "disabled",
+      createSparqlEngine: ({ libsqlStore }) =>
+        new ComunicaSparqlEngine({ queryEngine, store: libsqlStore }),
+    });
 
     await client.import({
       source: {

--- a/src/client/adapters/libsql/create-libsql-adapter.ts
+++ b/src/client/adapters/libsql/create-libsql-adapter.ts
@@ -1,7 +1,11 @@
 import { RecursiveCharacterTextSplitter } from "@langchain/textsplitters";
 
-import type { Adapter } from "@/client/client.ts";
-import type { SparqlEngineInterface } from "@/client/sparql-engine/mod.ts";
+import { Client } from "@/client/client.ts";
+import type { ExportRequest, ImportRequest } from "@/client/quad-store/mod.ts";
+import type {
+  SparqlEngineInterface,
+  SparqlRequest,
+} from "@/client/sparql-engine/mod.ts";
 import { RdfjsQuadStore } from "@/client/adapters/rdfjs/mod.ts";
 
 import type { LibsqlClientBaseOptions } from "./libsql-client-base-options.ts";
@@ -32,11 +36,11 @@ export interface LibsqlAdapterOptions extends LibsqlClientBaseOptions {
 }
 
 /**
- * createLibsqlAdapter synthesizes a Adapter for direct LibsqlStore + hexastore indexes.
+ * createLibsqlClient synthesizes a Client for direct LibsqlStore + hexastore indexes.
  */
-export async function createLibsqlAdapter(
+export async function createLibsqlClient(
   options: LibsqlAdapterOptions,
-): Promise<Adapter> {
+): Promise<Client> {
   const vectorDimensions = options.vectorDimensions ?? 32;
   const queryBuilder = new LibsqlQueryBuilder(vectorDimensions);
 
@@ -68,26 +72,31 @@ export async function createLibsqlAdapter(
 
   const quadStore = new RdfjsQuadStore(libsqlStore);
 
-  return {
-    quadStore: {
-      export: (request) => quadStore.export(request),
-      import: async (request) => {
-        patchSync.beforeImport();
-        const response = await quadStore.import(request);
+  const wrappedQuadStore = {
+    export: (request: ExportRequest) => quadStore.export(request),
+    import: async (request: ImportRequest) => {
+      patchSync.beforeImport();
+      const response = await quadStore.import(request);
+      await libsqlStore.commit();
+      await patchSync.afterImport();
+      return response;
+    },
+  };
+
+  const wrappedSparqlEngine = configuredSparqlEngine
+    ? {
+      sparql: async (request: SparqlRequest) => {
+        const response = await configuredSparqlEngine.sparql(request);
         await libsqlStore.commit();
-        await patchSync.afterImport();
         return response;
       },
-    },
-    sparqlEngine: configuredSparqlEngine
-      ? {
-        execute: async (request) => {
-          const response = await configuredSparqlEngine.execute(request);
-          await libsqlStore.commit();
-          return response;
-        },
-      }
-      : undefined,
-    searchIndex,
-  };
+    }
+    : undefined;
+
+  return new Client(wrappedQuadStore, searchIndex, wrappedSparqlEngine);
 }
+
+/**
+ * createLibsqlAdapter is deprecated; use createLibsqlClient. Removed in 0.0.17.
+ */
+export const createLibsqlAdapter = createLibsqlClient;

--- a/src/client/adapters/libsql/create-libsql-adapter.ts
+++ b/src/client/adapters/libsql/create-libsql-adapter.ts
@@ -18,28 +18,24 @@ import {
 import { createLibsqlPatchSyncState } from "@/client/adapters/libsql/sync/mod.ts";
 
 /**
- * LibsqlSparqlEngineOptions contains the hexastore-backed LibsqlStore for SPARQL adapters.
- */
-export interface LibsqlSparqlEngineOptions {
-  /** libsqlStore is the durable hexastore-backed RDF/JS store (SQL index seeks, no N3 hydration). */
-  libsqlStore: LibsqlStore;
-}
-
-/**
  * LibsqlAdapterOptions configures LibSQL execution through LibsqlStore and hexastore indexes.
  */
-export interface LibsqlAdapterOptions extends LibsqlClientBaseOptions {
-  /** createSparqlEngine optionally attaches a caller-provided SPARQL engine over LibsqlStore. */
-  createSparqlEngine?: (
-    options: LibsqlSparqlEngineOptions,
-  ) => SparqlEngineInterface;
-}
+export interface LibsqlAdapterOptions extends LibsqlClientBaseOptions {}
 
 /**
- * createLibsqlClient synthesizes a Client for direct LibsqlStore + hexastore indexes.
+ * AttachLibsqlSparqlEngine wires a SPARQL engine after LibsqlStore exists (in-repo preset use only).
  */
-export async function createLibsqlClient(
+export type AttachLibsqlSparqlEngine = (
+  options: { libsqlStore: LibsqlStore },
+) => SparqlEngineInterface;
+
+/**
+ * assembleLibsqlClient builds a Client for LibsqlStore + hexastore indexes.
+ * Prefer createLibsqlClient (search/import) or createLibsqlComunicaClient (Comunica SPARQL).
+ */
+export async function assembleLibsqlClient(
   options: LibsqlAdapterOptions,
+  attachSparqlEngine?: AttachLibsqlSparqlEngine,
 ): Promise<Client> {
   const vectorDimensions = options.vectorDimensions ?? 32;
   const queryBuilder = new LibsqlQueryBuilder(vectorDimensions);
@@ -68,7 +64,7 @@ export async function createLibsqlClient(
     matchPageSize: options.matchPageSize,
   });
 
-  const configuredSparqlEngine = options.createSparqlEngine?.({ libsqlStore });
+  const configuredSparqlEngine = attachSparqlEngine?.({ libsqlStore });
 
   const quadStore = new RdfjsQuadStore(libsqlStore);
 
@@ -94,6 +90,16 @@ export async function createLibsqlClient(
     : undefined;
 
   return new Client(wrappedQuadStore, searchIndex, wrappedSparqlEngine);
+}
+
+/**
+ * createLibsqlClient synthesizes a Client for import, export, and search without SPARQL.
+ * For Comunica SPARQL, use createLibsqlComunicaClient from `@worlds/client/adapters/libsql/comunica`.
+ */
+export async function createLibsqlClient(
+  options: LibsqlAdapterOptions,
+): Promise<Client> {
+  return await assembleLibsqlClient(options);
 }
 
 /**

--- a/src/client/adapters/rdfjs/create-rdfjs-adapter.test.ts
+++ b/src/client/adapters/rdfjs/create-rdfjs-adapter.test.ts
@@ -1,17 +1,16 @@
 import { assertEquals, assertRejects } from "@std/assert";
 import { QueryEngine } from "@comunica/query-sparql-rdfjs-lite";
 import { DataFactory, Store } from "n3";
-import { Client } from "@/client/client.ts";
 import { ComunicaSparqlEngine } from "@/client/adapters/comunica/mod.ts";
-import { createRdfjsAdapter } from "./create-rdfjs-adapter.ts";
+import { createRdfjsClient } from "./create-rdfjs-adapter.ts";
 
 const { quad, namedNode, literal } = DataFactory;
 const queryEngine = new QueryEngine();
 
 Deno.test(
-  "createRdfjsAdapter - import delivers immediate search hits",
+  "createRdfjsClient - import delivers immediate search hits",
   async () => {
-    const client = new Client(createRdfjsAdapter());
+    const client = createRdfjsClient();
     const testQuad = quad(
       namedNode("http://example.com/sub"),
       namedNode("http://example.com/pred"),
@@ -27,7 +26,7 @@ Deno.test(
 );
 
 Deno.test(
-  "createRdfjsAdapter - preloaded store is shared with the client",
+  "createRdfjsClient - preloaded store is shared with the client",
   async () => {
     const store = new Store();
     store.addQuad(
@@ -36,7 +35,7 @@ Deno.test(
       literal("Preloaded fact."),
     );
 
-    const client = new Client(createRdfjsAdapter({ store }));
+    const client = createRdfjsClient({ store });
 
     const response = await client.search({ query: "preloaded" });
     assertEquals(response.results?.length, 1);
@@ -45,14 +44,12 @@ Deno.test(
 );
 
 Deno.test(
-  "createRdfjsAdapter - createSparqlEngine enables SELECT queries",
+  "createRdfjsClient - createSparqlEngine enables SELECT queries",
   async () => {
-    const client = new Client(
-      createRdfjsAdapter({
-        createSparqlEngine: ({ store }) =>
-          new ComunicaSparqlEngine({ queryEngine, store }),
-      }),
-    );
+    const client = createRdfjsClient({
+      createSparqlEngine: ({ store }) =>
+        new ComunicaSparqlEngine({ queryEngine, store }),
+    });
 
     await client.import({
       source: {
@@ -81,9 +78,9 @@ Deno.test(
 );
 
 Deno.test(
-  "createRdfjsAdapter - rebuildSearchIndex rejects on non-LibSQL topology",
+  "createRdfjsClient - rebuildSearchIndex rejects on non-LibSQL topology",
   async () => {
-    const client = new Client(createRdfjsAdapter());
+    const client = createRdfjsClient();
 
     await assertRejects(
       () => client.rebuildSearchIndex(),
@@ -94,9 +91,9 @@ Deno.test(
 );
 
 Deno.test(
-  "createRdfjsAdapter - sparql rejects when createSparqlEngine is omitted",
+  "createRdfjsClient - sparql rejects when createSparqlEngine is omitted",
   async () => {
-    const client = new Client(createRdfjsAdapter());
+    const client = createRdfjsClient();
 
     await assertRejects(
       () => client.sparql({ query: "ASK WHERE { ?s ?p ?o }" }),

--- a/src/client/adapters/rdfjs/create-rdfjs-adapter.ts
+++ b/src/client/adapters/rdfjs/create-rdfjs-adapter.ts
@@ -1,5 +1,5 @@
 import { Store } from "n3";
-import type { Adapter } from "@/client/client.ts";
+import { Client } from "@/client/client.ts";
 import type { SparqlEngineInterface } from "@/client/sparql-engine/mod.ts";
 import { RdfjsQuadStore } from "./rdfjs-quad-store.ts";
 import { RdfjsSearchIndex } from "./rdfjs-search-index.ts";
@@ -26,17 +26,22 @@ export interface RdfjsOptions {
  * local RDFJS primitives. It is the fastest path to a working Client for development, tests,
  * and single-process demos where no external persistence is needed.
  *
- * Unlike createLibsqlAdapter and createDenokvAdapter, there is no synchronization layer — all data exists
+ * Unlike createLibsqlClient and createDenokvClient, there is no synchronization layer — all data exists
  * transiently in the N3 Store and is lost when the process exits.
  */
-export function createRdfjsAdapter(
+export function createRdfjsClient(
   options?: RdfjsOptions,
-): Adapter {
+): Client {
   const store = options?.store ?? new Store();
 
-  return {
-    quadStore: new RdfjsQuadStore(store),
-    searchIndex: new RdfjsSearchIndex(store),
-    sparqlEngine: options?.createSparqlEngine?.({ store }),
-  };
+  return new Client(
+    new RdfjsQuadStore(store),
+    new RdfjsSearchIndex(store),
+    options?.createSparqlEngine?.({ store }),
+  );
 }
+
+/**
+ * createRdfjsAdapter is deprecated; use createRdfjsClient. Removed in 0.0.17.
+ */
+export const createRdfjsAdapter = createRdfjsClient;

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -9,11 +9,11 @@ import { hashQuad } from "./quad-store/mod.ts";
 const queryEngine = new QueryEngine();
 
 function createTestClient(store: Store): Client {
-  return new Client({
-    quadStore: new RdfjsQuadStore(store),
-    sparqlEngine: new ComunicaSparqlEngine({ queryEngine, store }),
-    searchIndex: new RdfjsSearchIndex(store),
-  });
+  return new Client(
+    new RdfjsQuadStore(store),
+    new RdfjsSearchIndex(store),
+    new ComunicaSparqlEngine({ queryEngine, store }),
+  );
 }
 
 Deno.test("Client.import delegates to quadStore.import", async () => {
@@ -47,7 +47,7 @@ Deno.test("Client.export delegates to quadStore.export", async () => {
   assertEquals(response.quads.length, 0);
 });
 
-Deno.test("Client.sparql delegates to sparqlEngine.execute", async () => {
+Deno.test("Client.sparql delegates to sparqlEngine.sparql", async () => {
   const store = new Store();
   const client = createTestClient(store);
 
@@ -61,10 +61,10 @@ Deno.test("Client.sparql delegates to sparqlEngine.execute", async () => {
 
 Deno.test("Client.sparql rejects when sparqlEngine is not configured", async () => {
   const store = new Store();
-  const client = new Client({
-    quadStore: new RdfjsQuadStore(store),
-    searchIndex: new RdfjsSearchIndex(store),
-  });
+  const client = new Client(
+    new RdfjsQuadStore(store),
+    new RdfjsSearchIndex(store),
+  );
 
   await assertRejects(
     () => client.sparql({ query: "ASK WHERE { ?s ?p ?o }" }),

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -19,61 +19,45 @@ import type {
 } from "./search-index/mod.ts";
 
 /**
- * Adapter details the aggregate internal subsystems powering active execution.
- */
-export interface Adapter {
-  /**
-   * quadStore manages the ingestion and extraction of triple/quad data.
-   */
-  quadStore: QuadStoreInterface;
-
-  /**
-   * sparqlEngine evaluates declarative queries and updates against the graph.
-   */
-  sparqlEngine?: SparqlEngineInterface;
-
-  /**
-   * searchIndex enables high-performance keyword search across the graph literals.
-   */
-  searchIndex: SearchIndexInterface;
-}
-
-/**
  * Client is the standard gateway client for the Worlds API.
  * It aggregates the specialized capabilities for data persistence,
  * declarative querying, and fuzzy searching.
  */
 export class Client implements ClientInterface {
-  public constructor(protected readonly adapter: Adapter) {}
+  public constructor(
+    private readonly quadStore: QuadStoreInterface,
+    private readonly searchIndex: SearchIndexInterface,
+    private readonly sparqlEngine?: SparqlEngineInterface,
+  ) {}
 
   public async import(request: ImportRequest): Promise<void> {
-    return await this.adapter.quadStore.import(request);
+    return await this.quadStore.import(request);
   }
 
   public async export(request: ExportRequest): Promise<ExportResponse> {
-    return await this.adapter.quadStore.export(request);
+    return await this.quadStore.export(request);
   }
 
   public async sparql(request: SparqlRequest): Promise<SparqlResponse> {
-    if (!this.adapter.sparqlEngine) {
+    if (!this.sparqlEngine) {
       throw new Error("SPARQL engine is not configured.");
     }
 
-    return await this.adapter.sparqlEngine.execute(request);
+    return await this.sparqlEngine.sparql(request);
   }
 
   public async search(request: SearchRequest): Promise<SearchResponse> {
-    return await this.adapter.searchIndex.search(request);
+    return await this.searchIndex.search(request);
   }
 
   public async rebuildSearchIndex(
     request?: RebuildSearchIndexRequest,
   ): Promise<RebuildSearchIndexResponse> {
-    if (!this.adapter.searchIndex.rebuildSearchIndex) {
+    if (!this.searchIndex.rebuildSearchIndex) {
       throw new Error(
         "search index rebuild is only supported for LibSQL-backed clients",
       );
     }
-    return await this.adapter.searchIndex.rebuildSearchIndex(request);
+    return await this.searchIndex.rebuildSearchIndex(request);
   }
 }

--- a/src/client/sparql-engine/sparql-engine-interface.ts
+++ b/src/client/sparql-engine/sparql-engine-interface.ts
@@ -3,11 +3,11 @@
  */
 export interface SparqlEngineInterface {
   /**
-   * execute fires a SPARQL request and returns a strongly typed response.
+   * sparql fires a SPARQL request and returns a strongly typed response.
    *
    * @param request contains the raw query string and execution settings.
    */
-  execute(request: SparqlRequest): Promise<SparqlResponse>;
+  sparql(request: SparqlRequest): Promise<SparqlResponse>;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Remove exported `Adapter` interface; factories return `Client` directly with positional `new Client(quadStore, searchIndex, sparqlEngine?)` for advanced composition.
- Rename `SparqlEngineInterface.execute` to `sparql` (aligns with `ClientInterface.sparql`).
- Replace `createSparqlEngine` callbacks on LibSQL paths with Comunica preset clients:
  - `createLibsqlComunicaClient` from `@worlds/client/adapters/libsql/comunica` (hexastore)
  - `createLibsqlN3ComunicaClient` from `@worlds/client/adapters/libsql-n3/comunica` (hydrated N3)
- Restore `createXClient` as canonical names; `createXAdapter` deprecated (removed in 0.0.17).
- Bump version to 0.0.16; update CHANGELOG, AGENTS.md, README, examples, and benchmarks.

## Test plan

- [x] `deno task ci` (fmt, lint, check, test)
- [ ] `deno task publish:dry` before merge
- [ ] Spot-check `deno task example:hello-world` (search-only, no Comunica)
- [ ] Spot-check `deno task example:libsql-sparql-scale` (hexastore Comunica preset)
- [ ] Spot-check `deno task example:libsql-n3-warm-container:n3` (N3 Comunica preset)
