### PR TITLE
feat: implement Vercel AI SDK embedding service

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -13,7 +13,8 @@
     "./tfjs-universal-sentence-encoder": "./src/tfjs-universal-sentence-encoder/mod.ts",
     "./comunica": "./src/comunica/mod.ts",
     "./rdfjs": "./src/rdfjs/mod.ts",
-    "./denokv": "./src/denokv/mod.ts"
+    "./denokv": "./src/denokv/mod.ts",
+    "./ai-sdk": "./src/ai-sdk/mod.ts"
   },
   "imports": {
     "@/": "./src/",

--- a/src/ai-sdk/ai-sdk-embedding-service.test.ts
+++ b/src/ai-sdk/ai-sdk-embedding-service.test.ts
@@ -22,16 +22,7 @@ Deno.test("AiSdkEmbeddingService.embed - generates mock embeddings correctly", a
 });
 
 Deno.test("AiSdkEmbeddingService.embed - returns empty array on empty input", async () => {
-  const mockModel = new MockEmbeddingModelV3({
-    doEmbed: () =>
-      Promise.resolve({
-        embeddings: [],
-        usage: { tokens: 0 },
-        warnings: [],
-      }),
-  });
-
-  const service = new AiSdkEmbeddingService({ model: mockModel });
+  const service = new AiSdkEmbeddingService({ model: null! });
   const result = await service.embed([]);
 
   assertEquals(result, []);

--- a/src/ai-sdk/ai-sdk-embedding-service.test.ts
+++ b/src/ai-sdk/ai-sdk-embedding-service.test.ts
@@ -1,0 +1,38 @@
+import { assertEquals } from "@std/assert";
+import { MockEmbeddingModelV3 } from "ai/test";
+import { AiSdkEmbeddingService } from "./ai-sdk-embedding-service.ts";
+
+Deno.test("AiSdkEmbeddingService.embed - generates mock embeddings correctly", async () => {
+  const mockModel = new MockEmbeddingModelV3({
+    doEmbed: ({ values }) =>
+      Promise.resolve({
+        embeddings: values.map((value) => value === "first" ? [0, 1] : [1, 2]),
+        usage: { tokens: 10 },
+        warnings: [],
+      }),
+  });
+
+  const service = new AiSdkEmbeddingService({ model: mockModel });
+  const result = await service.embed(["first", "second"]);
+
+  assertEquals(result, [
+    [0, 1],
+    [1, 2],
+  ]);
+});
+
+Deno.test("AiSdkEmbeddingService.embed - returns empty array on empty input", async () => {
+  const mockModel = new MockEmbeddingModelV3({
+    doEmbed: () =>
+      Promise.resolve({
+        embeddings: [],
+        usage: { tokens: 0 },
+        warnings: [],
+      }),
+  });
+
+  const service = new AiSdkEmbeddingService({ model: mockModel });
+  const result = await service.embed([]);
+
+  assertEquals(result, []);
+});

--- a/src/ai-sdk/ai-sdk-embedding-service.ts
+++ b/src/ai-sdk/ai-sdk-embedding-service.ts
@@ -1,0 +1,47 @@
+import { embedMany } from "ai";
+import type { EmbeddingModel } from "ai";
+import type { EmbeddingService } from "@/client/search-index/embedding-service/mod.ts";
+
+/**
+ * AiSdkEmbeddingServiceOptions provides configurations for the AI SDK embedding service.
+ */
+export interface AiSdkEmbeddingServiceOptions {
+  /** model is the Vercel AI SDK embedding model instance. */
+  model: EmbeddingModel;
+
+  /** maxRetries is the optional maximum number of retries for embedding requests. */
+  maxRetries?: number;
+
+  /** abortSignal is the optional signal to cancel request execution. */
+  abortSignal?: AbortSignal;
+}
+
+/**
+ * AiSdkEmbeddingService provides text embedding generation leveraging Vercel AI SDK's embedMany.
+ */
+export class AiSdkEmbeddingService implements EmbeddingService {
+  public constructor(
+    private readonly options: AiSdkEmbeddingServiceOptions,
+  ) {}
+
+  /**
+   * embed converts text sequences into high-dimensional vector arrays using Vercel AI SDK.
+   *
+   * @param texts Array of clean input sequences targeted for vectorizing.
+   * @returns Vector space projection arrays matching the input array index positioning.
+   */
+  public async embed(texts: string[]): Promise<Array<Float32Array | number[]>> {
+    if (texts.length === 0) {
+      return [];
+    }
+
+    const { embeddings } = await embedMany({
+      model: this.options.model,
+      values: texts,
+      maxRetries: this.options.maxRetries,
+      abortSignal: this.options.abortSignal,
+    });
+
+    return embeddings;
+  }
+}

--- a/src/ai-sdk/mod.ts
+++ b/src/ai-sdk/mod.ts
@@ -1,0 +1,1 @@
+export * from "./ai-sdk-embedding-service.ts";


### PR DESCRIPTION
Introduced the new subpath export @worlds/client/ai-sdk containing AiSdkEmbeddingService, which delegates text vectorizing calls to Vercel AI SDK's embedMany. Created unit tests with MockEmbeddingModelV3.