### PR TITLE
feat: extract shared backend abstractions (hexastore, FTS value, row-to-quad) into @worlds/client

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -127,19 +127,17 @@ const sparqlResponse = await client.sparql({
 - Combining them delivers both discovery and precision without depending on a
   single unreliable retrieval mode.
 
-## Scale considerations
+## SPARQL engine choice
 
-- In-memory RDF/JS is suitable for development, tests, and single-process demos
-  with small graphs.
-- For millions of quads and production workloads, use
-  [`@worlds/libsql`](https://github.com/wazootech/worlds-libsql) (default) or
-  [`@worlds/denokv`](https://github.com/wazootech/worlds-denokv).
-- LibSQL is preferred for hybrid FTS/vector search and fast cold hexastore
-  preload.
-- Deno KV can be faster on selective SPARQL execute after preload in long-lived
-  processes.
-- Benchmark methodology and comparison tables live in the adapter repos and
-  [discussion #69](https://github.com/wazootech/worlds-client-ts/discussions/69).
+The SDK uses `@comunica/query-sparql-rdfjs-lite` as its SPARQL query engine, wrapped by `ComunicaSparqlEngine`. The lite variant was chosen over the full `@comunica/query-sparql` because Worlds only queries in-process RDF/JS Store sources (LibSQL, Deno KV, N3). The full engine's HTTP federation, file source, and serialization actors are unnecessary. Lite is smaller, faster to instantiate, and edge-safe.
+
+The `ComunicaQueryEngine` interface is a structural type requiring only `query(query, { sources, baseIRI })`. The `SparqlEngineInterface` abstraction (`execute(request)`) makes any engine — a different Comunica variant or a custom implementation — swappable without changing client code.
+
+A custom engine is feasible through `SparqlEngineInterface` but would require reimplementing SPARQL 1.1 parsing, algebra compilation, join optimization, and result serialization. Comunica provides a mature, spec-compliant baseline.
+
+See [Wazoopedia decision record](https://github.com/wazootech/wazoopedia/blob/main/wiki/Decision_Sparql_Engine_Rdfjs_Lite.md) for full rationale.
+
+## Scale considerations
 
 ## Non-goals
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -129,13 +129,25 @@ const sparqlResponse = await client.sparql({
 
 ## SPARQL engine choice
 
-The SDK uses `@comunica/query-sparql-rdfjs-lite` as its SPARQL query engine, wrapped by `ComunicaSparqlEngine`. The lite variant was chosen over the full `@comunica/query-sparql` because Worlds only queries in-process RDF/JS Store sources (LibSQL, Deno KV, N3). The full engine's HTTP federation, file source, and serialization actors are unnecessary. Lite is smaller, faster to instantiate, and edge-safe.
+The SDK uses `@comunica/query-sparql-rdfjs-lite` as its SPARQL query engine,
+wrapped by `ComunicaSparqlEngine`. The lite variant was chosen over the full
+`@comunica/query-sparql` because Worlds only queries in-process RDF/JS Store
+sources (LibSQL, Deno KV, N3). The full engine's HTTP federation, file source,
+and serialization actors are unnecessary. Lite is smaller, faster to
+instantiate, and edge-safe.
 
-The `ComunicaQueryEngine` interface is a structural type requiring only `query(query, { sources, baseIRI })`. The `SparqlEngineInterface` abstraction (`execute(request)`) makes any engine — a different Comunica variant or a custom implementation — swappable without changing client code.
+The `ComunicaQueryEngine` interface is a structural type requiring only
+`query(query, { sources, baseIRI })`. The `SparqlEngineInterface` abstraction
+(`execute(request)`) makes any engine — a different Comunica variant or a custom
+implementation — swappable without changing client code.
 
-A custom engine is feasible through `SparqlEngineInterface` but would require reimplementing SPARQL 1.1 parsing, algebra compilation, join optimization, and result serialization. Comunica provides a mature, spec-compliant baseline.
+A custom engine is feasible through `SparqlEngineInterface` but would require
+reimplementing SPARQL 1.1 parsing, algebra compilation, join optimization, and
+result serialization. Comunica provides a mature, spec-compliant baseline.
 
-See [Wazoopedia decision record](https://github.com/wazootech/wazoopedia/blob/main/wiki/Decision_Sparql_Engine_Rdfjs_Lite.md) for full rationale.
+See
+[Wazoopedia decision record](https://github.com/wazootech/wazoopedia/blob/main/wiki/Decision_Sparql_Engine_Rdfjs_Lite.md)
+for full rationale.
 
 ## Scale considerations
 

--- a/src/client/quad-store/hexastore-indexes.ts
+++ b/src/client/quad-store/hexastore-indexes.ts
@@ -6,12 +6,14 @@ export interface HexastoreIndexDescriptor {
   name: string;
 
   /** columns lists the ordered column group for the index. */
-  columns: readonly [string, string, string] | readonly [
-    string,
-    string,
-    string,
-    string,
-  ];
+  columns:
+    | readonly [string, string, string]
+    | readonly [
+      string,
+      string,
+      string,
+      string,
+    ];
 }
 
 /**

--- a/src/client/quad-store/hexastore-indexes.ts
+++ b/src/client/quad-store/hexastore-indexes.ts
@@ -1,0 +1,29 @@
+/**
+ * HexastoreIndexDescriptor names a single covering index on the quads table.
+ */
+export interface HexastoreIndexDescriptor {
+  /** name is the index identifier (e.g. idx_quads_spog). */
+  name: string;
+
+  /** columns lists the ordered column group for the index. */
+  columns: readonly [string, string, string] | readonly [
+    string,
+    string,
+    string,
+    string,
+  ];
+}
+
+/**
+ * HEXASTORE_INDEXES defines the 7 covering composite indexes on the quads table
+ * enabling any quad pattern to be resolved via a single index seek.
+ */
+export const HEXASTORE_INDEXES: readonly HexastoreIndexDescriptor[] = [
+  { name: "idx_quads_spog", columns: ["s", "p", "o", "g"] },
+  { name: "idx_quads_sopg", columns: ["s", "o", "p", "g"] },
+  { name: "idx_quads_pso", columns: ["p", "s", "o"] },
+  { name: "idx_quads_pos", columns: ["p", "o", "s"] },
+  { name: "idx_quads_ospg", columns: ["o", "s", "p", "g"] },
+  { name: "idx_quads_opsg", columns: ["o", "p", "s", "g"] },
+  { name: "idx_quads_gpso", columns: ["g", "p", "s", "o"] },
+] as const;

--- a/src/client/quad-store/mod.ts
+++ b/src/client/quad-store/mod.ts
@@ -4,6 +4,7 @@ export * from "./transaction-context.ts";
 export * from "./quad-filter.ts";
 export * from "./is-textual-literal.ts";
 export * from "./hash-quad.ts";
+export * from "./hexastore-indexes.ts";
 export * from "./term.ts";
 export * from "./quad.ts";
 export * from "./rdf-formats.ts";

--- a/src/client/quad-store/mod.ts
+++ b/src/client/quad-store/mod.ts
@@ -5,6 +5,7 @@ export * from "./quad-filter.ts";
 export * from "./is-textual-literal.ts";
 export * from "./hash-quad.ts";
 export * from "./hexastore-indexes.ts";
+export * from "./quad-row-reader.ts";
 export * from "./term.ts";
 export * from "./quad.ts";
 export * from "./rdf-formats.ts";

--- a/src/client/quad-store/quad-row-reader.ts
+++ b/src/client/quad-store/quad-row-reader.ts
@@ -1,0 +1,63 @@
+import type * as rdfjs from "@rdfjs/types";
+import { DataFactory } from "n3";
+import { toRdfjsTerm } from "@/client/quad-store/term.ts";
+
+const { quad } = DataFactory;
+
+/**
+ * QuadRowReader provides typed accessors for quads table column values from any backend driver row.
+ */
+export interface QuadRowReader {
+  /** s is the subject IRI or blank node label. */
+  s: string;
+
+  /** sType is the subject term type ("NamedNode" or "BlankNode"). */
+  sType: string;
+
+  /** p is the predicate IRI. */
+  p: string;
+
+  /** o is the object lexical value. */
+  o: string;
+
+  /** oType is the object term type ("NamedNode", "BlankNode", or "Literal"). */
+  oType: string;
+
+  /** oDatatype is the object datatype IRI for typed literals, or null. */
+  oDatatype: string | null;
+
+  /** oLang is the object language tag for language-tagged strings, or null. */
+  oLang: string | null;
+
+  /** g is the graph IRI or term value. */
+  g: string;
+
+  /** gType is the graph term type ("NamedNode" or "DefaultGraph"). */
+  gType: string;
+}
+
+/**
+ * quadFromRow reconstructs an RDF/JS quad from a QuadRowReader impl, eliminating per-backend row mapping duplication.
+ */
+export function quadFromRow(row: QuadRowReader): rdfjs.Quad {
+  const subject = toRdfjsTerm({
+    termType: row.sType,
+    value: row.s,
+  }) as rdfjs.Quad_Subject;
+  const predicate = toRdfjsTerm({
+    termType: "NamedNode",
+    value: row.p,
+  }) as rdfjs.Quad_Predicate;
+  const object = toRdfjsTerm({
+    termType: row.oType,
+    value: row.o,
+    language: row.oLang ?? undefined,
+    datatype: row.oDatatype ?? undefined,
+  }) as rdfjs.Quad_Object;
+  const graph = toRdfjsTerm({
+    termType: row.gType,
+    value: row.g,
+  }) as rdfjs.Quad_Graph;
+
+  return quad(subject, predicate, object, graph);
+}

--- a/src/client/search-index/mod.ts
+++ b/src/client/search-index/mod.ts
@@ -1,1 +1,3 @@
 export * from "./search-index-interface.ts";
+export * from "./build-search-result-id.ts";
+export * from "./search-chunk-fts.ts";

--- a/src/client/search-index/search-chunk-fts.ts
+++ b/src/client/search-index/search-chunk-fts.ts
@@ -1,0 +1,102 @@
+import type { ChunkRowPayload } from "@/client/search-index/quad-chunker/mod.ts";
+
+/**
+ * BuildChunkFtsValueOptions supplies subject label literals looked up from durable quads.
+ */
+export interface BuildChunkFtsValueOptions {
+  /** labelLiteralsForSubject lists configured label predicate object values for the chunk subject. */
+  labelLiteralsForSubject: string[];
+}
+
+/**
+ * buildChunkFtsValue composes space-separated discovery tokens for FTS and semantic indexing.
+ */
+export function buildChunkFtsValue(
+  chunk: ChunkRowPayload,
+  options: BuildChunkFtsValueOptions,
+): string {
+  const tokens: string[] = [
+    extractRdfLocalLabel(chunk.subject),
+    formatPredicatePhrase(chunk.predicate),
+    chunk.value,
+    ...options.labelLiteralsForSubject,
+  ];
+  return tokens.filter((token) => token.length > 0).join(" ");
+}
+
+/**
+ * extractRdfLocalLabel returns a short human-readable label from an IRI or term value.
+ */
+export function extractRdfLocalLabel(iri: string): string {
+  const trimmed = iri.trim();
+  if (trimmed.length === 0) {
+    return "unknown entity";
+  }
+
+  const hashIndex = trimmed.lastIndexOf("#");
+  if (hashIndex >= 0 && hashIndex < trimmed.length - 1) {
+    return humanizeToken(trimmed.slice(hashIndex + 1));
+  }
+
+  const slashIndex = trimmed.lastIndexOf("/");
+  if (slashIndex >= 0 && slashIndex < trimmed.length - 1) {
+    return humanizeToken(trimmed.slice(slashIndex + 1));
+  }
+
+  return humanizeToken(trimmed);
+}
+
+/**
+ * formatPredicatePhrase converts a predicate IRI into a short verb phrase.
+ */
+export function formatPredicatePhrase(predicateIri: string): string {
+  const localName = extractRdfLocalLabel(predicateIri);
+  return localName.toLowerCase();
+}
+
+/**
+ * humanizeToken decodes common IRI local-name separators into spaced words.
+ */
+function humanizeToken(token: string): string {
+  const withSpaces = token
+    .replace(/([a-z])([A-Z])/g, "$1 $2")
+    .replace(/[_-]+/g, " ")
+    .trim();
+
+  if (withSpaces.length === 0) {
+    return token;
+  }
+
+  return withSpaces;
+}
+
+/**
+ * DEFAULT_LABEL_PREDICATES lists built-in predicate IRIs used for subject alias discovery at index time.
+ */
+export const DEFAULT_LABEL_PREDICATES: readonly string[] = [
+  "http://www.w3.org/2000/01/rdf-schema#label",
+  "http://www.w3.org/2004/02/skos/core#prefLabel",
+  "http://schema.org/name",
+] as const;
+
+/**
+ * resolveLabelPredicates merges caller extensions with built-in label IRIs (union, deduped, stable order).
+ */
+export function resolveLabelPredicates(
+  labelPredicates?: string[],
+): string[] {
+  const seen = new Set<string>();
+  const resolved: string[] = [];
+  for (
+    const predicate of [
+      ...DEFAULT_LABEL_PREDICATES,
+      ...(labelPredicates ?? []),
+    ]
+  ) {
+    if (!seen.has(predicate)) {
+      seen.add(predicate);
+      resolved.push(predicate);
+    }
+  }
+  return resolved;
+}


### PR DESCRIPTION
## Summary

Extracts three shared backend abstractions into `@worlds/client` to eliminate duplication across durable backend packages (`@worlds/libsql`, `@worlds/polygres`, `@worlds/denokv`). See #139 for full analysis.

## Changes

### Phase A1: `HEXASTORE_INDEXES` shared constant
- **New:** `src/client/quad-store/hexastore-indexes.ts`
- Exports `HEXASTORE_INDEXES` — the 7 hexastore covering index definitions as typed descriptors
- `HexastoreIndexDescriptor` interface with `name` and `columns`
- Backend `*SchemaBuilder` classes can consume this instead of hardcoding index DDL

### Phase A2: `search-chunk-fts.ts` → `@worlds/client`
- **New:** `src/client/search-index/search-chunk-fts.ts`
- Moved from `@worlds/libsql` (verbatim — zero changes needed, pure string ops)
- Exports: `buildChunkFtsValue`, `extractRdfLocalLabel`, `formatPredicatePhrase`, `DEFAULT_LABEL_PREDICATES`, `resolveLabelPredicates`, `BuildChunkFtsValueOptions`
- `@worlds/polygres` will import these instead of carrying a copy

### Bonus: Export `build-search-result-id.ts` from search-index barrel
- `build-search-result-id.ts` existed in `src/client/search-index/` but was NOT exported from the barrel — it was dead/unreachable from the public API
- Added to `search-index/mod.ts` so backends can import from `@worlds/client/search-index` instead of duplicating the file

### Phase B: `QuadRowReader` + `quadFromRow()`
- **New:** `src/client/quad-store/quad-row-reader.ts`
- `QuadRowReader` interface — typed accessors for all `quads` table columns
- `quadFromRow(reader)` — single `rdfjs.Quad` reconstruction from any backend row mapper
- Polygres quad-row.ts will be ~5 lines instead of ~30

## How backends share these abstractions

All backends import shared logic from `@worlds/client` via JSR — they implement thin adapters, not duplicate logic:

```
@worlds/client (this package)
  ├── HEXASTORE_INDEXES           → shared constant
  ├── search-chunk-fts.ts         → FTS value, label predicates, IRI humanization
  ├── build-search-result-id.ts   → now exported from barrel
  └── quad-row-reader.ts          → QuadRowReader interface + quadFromRow()
       ↑ JSR import           ↑ JSR import           ↑ JSR import
  @worlds/libsql          @worlds/denokv          @worlds/polygres
  (existing, needs        (keyword-only,           (planned, will use
   import update)          limited overlap)          all from day one)
```

| Abstraction | libsql | denokv | polygres |
|---|---|---|---|
| `HEXASTORE_INDEXES` | Consume in `LibsqlSchemaBuilder.buildIndexes()` | N/A (KV store) | Consume in `PolygresSchemaBuilder.buildIndexes()` |
| `buildChunkFtsValue` / `extractRdfLocalLabel` / `resolveLabelPredicates` | **Currently has own copy** → update import | N/A (keyword-only) | Import directly, no local copy |
| `buildSearchResultId` | **Currently has own copy** → update import | N/A | Import directly |
| `QuadRowReader` + `quadFromRow()` | Implement adapter for `@libsql/client` Row | Implement adapter for KV entry | Implement adapter for `pg.Row` |

### The pattern in practice

Before, each backend duplicated ~160 lines of identical logic. After this PR, backends write a thin adapter (~15 lines) mapping their driver row shape to `QuadRowReader`, then call the shared `quadFromRow()`:

```typescript
// worlds-libsql/src/libsql/libsql-quad-row.ts (after update)
import { quadFromRow } from "@worlds/client/quad-store";

export function quadFromLibsqlRow(row: Row): rdfjs.Quad {
  return quadFromRow({
    s: String(row.s), sType: String(row.s_type),
    p: String(row.p),
    o: String(row.o), oType: String(row.o_type),
    oDatatype: row.o_datatype ? String(row.o_datatype) : null,
    oLang: row.o_lang ? String(row.o_lang) : null,
    g: String(row.g), gType: String(row.g_type),
  });
}
```

```typescript
// worlds-polygres/src/polygres/polygres-quad-row.ts (planned)
import { quadFromRow } from "@worlds/client/quad-store";

export function quadFromPolygresRow(row: pg.Row): rdfjs.Quad {
  return quadFromRow({
    s: row.s, sType: row.s_type,
    p: row.p,
    o: row.o, oType: row.o_type,
    oDatatype: row.o_datatype ?? null,
    oLang: row.o_lang ?? null,
    g: row.g, gType: row.g_type,
  });
}
```

Same pattern for search chunks — instead of copying `search-chunk-fts.ts`:

```typescript
// Any backend
import {
  buildChunkFtsValue,
  resolveLabelPredicates,
  extractRdfLocalLabel,
} from "@worlds/client/search-index";

import { buildSearchResultId } from "@worlds/client/search-index";
```

### Net reduction

| Backend | Before | After |
|---|---|---|
| `@worlds/libsql` | Own copy of search-chunk-fts (102 lines), build-search-result-id (35 lines), own quad-row (32 lines) | Import from client, ~12-line quad-row function |
| `@worlds/polygres` (planned) | Was going to copy all three (~170 lines) | Import from client from day one, ~12-line quad-row function |

## CI

```
deno fmt --check  ✓
deno lint         ✓
deno check        ✓
deno test         72 passed, 0 failed
deno publish --dry-run  ✓
```

## Related

- Closes #139 (extraction analysis)
- Unblocks #138 (`@worlds/polygres`)
