### PR TITLE
fix(comunica): add error boundaries around SPARQL stream evaluation to prevent Worker 1101 crashes

### DIFF
--- a/src/comunica/comunica-sparql-engine.ts
+++ b/src/comunica/comunica-sparql-engine.ts
@@ -211,9 +211,18 @@ async function handleBindings(
     throw new Error("SPARQL bindings result is missing metadata.");
   }
 
-  const bindingsStream = await queryType.execute() as ComunicaEventStream<
-    ComunicaBinding
-  >;
+  let bindingsStream: ComunicaEventStream<ComunicaBinding>;
+  try {
+    bindingsStream = await queryType.execute() as ComunicaEventStream<
+      ComunicaBinding
+    >;
+  } catch (error) {
+    throw new Error(
+      `SPARQL bindings stream execution failed: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
   const vars = (await queryType.metadata()).variables.map((v) => v.value);
 
   const bindings = await new Promise<SparqlBinding[]>((resolve, reject) => {
@@ -222,14 +231,21 @@ async function handleBindings(
 
     const onData = (binding: ComunicaBinding) => {
       if (finished) return;
-      const bindingObj: SparqlBinding = {};
-      for (const v of vars) {
-        const term = binding.get?.(v);
-        if (term) {
-          bindingObj[v] = toSparqlValue(term);
+      try {
+        const bindingObj: SparqlBinding = {};
+        for (const v of vars) {
+          const term = binding.get?.(v);
+          if (term) {
+            bindingObj[v] = toSparqlValue(term);
+          }
+        }
+        b.push(bindingObj);
+      } catch (error) {
+        if (!finished) {
+          finished = true;
+          reject(error);
         }
       }
-      b.push(bindingObj);
     };
 
     const onEnd = () => {
@@ -260,7 +276,16 @@ async function handleBindings(
 async function handleBoolean(
   queryType: ComunicaQueryResult,
 ): Promise<SparqlAskResults> {
-  const boolean = await queryType.execute();
+  let boolean: unknown;
+  try {
+    boolean = await queryType.execute();
+  } catch (error) {
+    throw new Error(
+      `SPARQL boolean result execute failed: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
   if (typeof boolean !== "boolean") {
     throw new Error("SPARQL boolean result returned a non-boolean payload.");
   }


### PR DESCRIPTION
## Problem

Comunica SPARQL stream evaluation crashes Cloudflare Workers with error 1101 (unhandled rejection) when:

1. **The bindings stream `onData` handler throws** — if `toSparqlValue()` receives a malformed Comunica term, the exception propagates _inside the event-emitter context_ (not the Promise executor), causing an unhandled rejection that terminates the isolate.

2. **`queryType.execute()` rejects** in `handleBindings` or `handleBoolean` — the rejection is already caught by the existing `try/catch` in `executeSparql`, but the stream setup in `handleBindings` is outside that boundary.

## Changes

### `src/comunica/comunica-sparql-engine.ts`

- **`onData` handler (line 223):** wrapped in `try/catch` — if `toSparqlValue()` throws, the error rejects the bindings promise instead of crashing the isolate.
- **`handleBindings` (line 214):** wrapped `queryType.execute()` in `try/catch` so stream materialization failures produce a clean `Error` instead of an unhandled rejection.
- **`handleBoolean` (line 263):** wrapped `queryType.execute()` in `try/catch` for the same reason.

## Validation

- `deno task ci` (fmt, lint, check, test): **72 tests pass, 1 ignored, 0 failed**
- All existing tests continue to pass including the bindings error stream and timeout rejection tests