### PR TITLE
chore: release @worlds/client 0.0.18

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@worlds/client",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "nodeModulesDir": "auto",
   "exports": {
     ".": "./src/mod.ts",


### PR DESCRIPTION
## Release: @worlds/client 0.0.18

Bumps deno.json version 0.0.17 ? 0.0.18. CI publishes to JSR on merge (publish.yml).

This release carries the fix for worlds-api#10: **#148** ? error boundaries around SPARQL stream evaluation so 	oSparqlValue() failures surface as handled errors instead of unhandled exceptions (the root cause of Cloudflare Worker 1101 crashes on POST /worlds/:id/sparql).

Local checks: deno task fmt ?, deno task fmt:check ?, deno task publish:dry ? (simulated @worlds/client@0.0.18).
