### PR TITLE
ci: mirror the SparqlEngineInterface parity guard from @wazoo/sparql-engine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,3 +21,18 @@ jobs:
         run: deno ci
       - name: Run CI checks
         run: deno task ci
+  # Identical-spec parity gate: src/client/sparql-engine/sparql-engine-interface.ts
+  # must match @wazoo/sparql-engine's copy (line endings normalized). A
+  # single-sided edit fails this job instead of silently forking the shared
+  # SparqlEngineInterface. Standalone job (not a ci dependency) so a drift
+  # cannot abort the rest of the suite.
+  interface-parity:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: denoland/setup-deno@v2
+        with:
+          cache: true
+          deno-version-file: .tool-versions
+      - name: Check SparqlEngineInterface parity
+        run: deno task interface-parity

--- a/deno.json
+++ b/deno.json
@@ -52,6 +52,7 @@
     "test": "deno test --allow-all",
     "publish:dry": "deno publish --dry-run --allow-dirty",
     "doc:json": "deno -A ./scripts/generate-doc-json.ts",
+    "interface-parity": "deno run --allow-read --allow-net scripts/interface-parity.ts",
     "ci": {
       "description": "Formats, lints, checks, and tests the code",
       "dependencies": [

--- a/scripts/interface-parity.ts
+++ b/scripts/interface-parity.ts
@@ -1,0 +1,48 @@
+/**
+ * interface-parity asserts that `src/client/sparql-engine/sparql-engine-interface.ts`
+ * stays identical to `@wazoo/sparql-engine`'s copy under the identical-spec policy.
+ *
+ * The engine's public envelopes (`SparqlEngineInterface`, `SparqlRequest`,
+ * `SparqlResponse`, and the result shapes) are duplicated in both packages and
+ * must not drift. This fetches the canonical copy from `sparql-engine` `main`
+ * and diffs it against the local file (line endings normalized), so a
+ * single-sided edit fails CI here instead of silently forking the contract.
+ *
+ * This is the mirror of `sparql-engine`'s own `test/interface-parity.ts`, which
+ * guards the reverse direction (sparql-engine diffs against @worlds/client).
+ */
+
+const SPARQL_INTERFACE_URL =
+  "https://raw.githubusercontent.com/wazootech/sparql-engine/main/src/sparql-engine-interface.ts";
+
+const LOCAL_INTERFACE = new URL(
+  "../src/client/sparql-engine/sparql-engine-interface.ts",
+  import.meta.url,
+);
+
+/** normalize collapses CRLF and trailing whitespace so only real drift fails. */
+function normalize(text: string): string {
+  return text.replace(/\r\n/g, "\n").replace(/[ \t]+$/gm, "").trimEnd();
+}
+
+const local = normalize(await Deno.readTextFile(LOCAL_INTERFACE));
+
+const response = await fetch(SPARQL_INTERFACE_URL);
+if (!response.ok) {
+  console.error(
+    `interface-parity: failed to fetch @wazoo/sparql-engine interface (HTTP ${response.status})`,
+  );
+  Deno.exit(1);
+}
+const remote = normalize(await response.text());
+
+if (local !== remote) {
+  console.error(
+    "interface-parity: src/client/sparql-engine/sparql-engine-interface.ts differs from " +
+      "@wazoo/sparql-engine's copy. Update both packages together under the " +
+      "identical-spec policy.",
+  );
+  Deno.exit(1);
+}
+
+console.log("interface-parity: SparqlEngineInterface copies match.");


### PR DESCRIPTION
Mirrors the identical-spec parity guard that sparql-engine#116 added, so a single-sided `SparqlEngineInterface` edit fails CI from **either** repo's PRs (sparql-engine currently only guards its own direction).

- **`scripts/interface-parity.ts`** — fetches the canonical copy from `wazootech/sparql-engine` `main` and diffs against `src/client/sparql-engine/sparql-engine-interface.ts` (CRLF/trailing-whitespace normalized). Same logic as the sparql-engine guard, direction reversed.
- **`deno task interface-parity`** — `deno run --allow-read --allow-net scripts/interface-parity.ts`.
- **`.github/workflows/ci.yml`** — standalone `interface-parity` job (not a `ci` dependency, so a drift can't abort the rest of the suite — the lesson from the first sparql-engine wiring).

Verified locally:
- `deno task interface-parity` → "copies match" (both sides byte-identical on main)
- drift probe (appended a comment to the local interface) → exits 1 with the identical-spec message, reverted after
- `deno fmt` / `deno check` / `deno lint` clean

Closes #154.