### PR TITLE
chore: bump @worlds/client to 0.0.19 for the reconciled SparqlEngineInterface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.0.19
+
+### Changed
+
+- Default the in-memory SPARQL engine to `@wazoo/sparql-engine`
+  (`WazooSparqlEngine`), keeping Comunica as the compatible alternative via
+  `@worlds/client/comunica`.
+- Reconcile `SparqlEngineInterface` with `@wazoo/sparql-engine` under the
+  identical-spec policy: add the `construct` result variant and RDF 1.2
+  `its:dir` literal direction, and collapse `SparqlRequest.query`/`update` into
+  a single required `query` field.
+
 ## Unreleased
 
 ### Breaking

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@worlds/client",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "nodeModulesDir": "auto",
   "exports": {
     ".": "./src/mod.ts",


### PR DESCRIPTION
Bumps `@worlds/client` from `0.0.18` → `0.0.19` so the publish workflow actually ships the reconciled `SparqlEngineInterface` from #153.

## Why

The #153 merge ran the publish workflow but it skipped — `Publishing @worlds/client@0.0.18 ... Warning: Skipping, already published`. The version was never bumped, so the `construct` result variant (which makes `WazooSparqlEngine` a type-safe drop-in) is on `main` but **not on JSR**. This blocks:

- worlds-libsql#12 — default `createLibsqlClient` to `WazooSparqlEngine`
- worlds-denokv#5 — default `createDenokvClient` to `WazooSparqlEngine`

## Change

- `deno.json`: `0.0.18` → `0.0.19`
- `CHANGELOG.md`: add a `0.0.19` section for the Wazoo default + interface reconciliation

## Release decision

Suggested **patch** (`0.0.19`) because the only commit since `0.0.18` is #153: additive `construct` + `its:dir`, and the `query`/`update` collapse (which fixes a duplicated `query` declaration and drops the non-functional `update` field). Flagging for review in case you'd prefer a minor (`0.1.0`) given the `update` field removal is technically breaking.

Merging to `main` auto-publishes via the existing `publish.yml` (no manual JSR step). After it lands, worlds-libsql#12 and worlds-denokv#5 become mechanical.

Closes #156.