### PR TITLE
feat: add signal to SparqlRequest and honor it in the Comunica engine (sparql-engine#122)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@worlds/sdk",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "nodeModulesDir": "auto",
   "exports": {
     ".": "./src/mod.ts",

--- a/src/client/sparql-engine/sparql-engine-interface.ts
+++ b/src/client/sparql-engine/sparql-engine-interface.ts
@@ -24,6 +24,14 @@ export interface SparqlRequest {
 
   /** Query timeout in milliseconds (defaults to 30 seconds). */
   timeoutMs?: number;
+
+  /**
+   * signal aborts the request: the execute promise rejects (with the
+   * signal's reason when it is an Error, else a generic abort error) and
+   * the evaluation is cancelled at the next pattern/join boundary. The
+   * engine composes it with the timeout — whichever fires first wins.
+   */
+  signal?: AbortSignal;
 }
 
 /**

--- a/src/comunica/comunica-sparql-engine.test.ts
+++ b/src/comunica/comunica-sparql-engine.test.ts
@@ -247,6 +247,38 @@ Deno.test("executeSparql - rejects when the query times out", async () => {
   );
 });
 
+Deno.test("executeSparql - caller signal aborts an in-flight query", async () => {
+  const store = new Store();
+  const controller = new AbortController();
+  setTimeout(() => controller.abort(new Error("caller cancelled")), 10);
+
+  await assertRejects(
+    () =>
+      executeSparql(createTimeoutEngine(), store, {
+        query: "SELECT ?s WHERE { ?s ?p ?o }",
+        signal: controller.signal,
+      }),
+    Error,
+    "caller cancelled",
+  );
+});
+
+Deno.test("executeSparql - pre-aborted signal rejects immediately", async () => {
+  const store = new Store();
+  const controller = new AbortController();
+  controller.abort(new Error("aborted before start"));
+
+  await assertRejects(
+    () =>
+      executeSparql(createTimeoutEngine(), store, {
+        query: "SELECT ?s WHERE { ?s ?p ?o }",
+        signal: controller.signal,
+      }),
+    Error,
+    "aborted before start",
+  );
+});
+
 Deno.test(
   "executeSparql - rejects unsupported Comunica result types",
   async () => {

--- a/src/comunica/comunica-sparql-engine.ts
+++ b/src/comunica/comunica-sparql-engine.ts
@@ -153,7 +153,26 @@ export async function executeSparql(
         clearTimeout(timer);
         timer = undefined;
       }
+      // The caller's signal is only listened for while the request is in
+      // flight; once it settles, the listener is detached.
+      request.signal?.removeEventListener("abort", onAbort);
     };
+    // The caller's signal races the timeout (issue #122): abort rejects
+    // with the signal's reason when it is an Error, else a clear error.
+    const onAbort = () => {
+      clearTimer();
+      const reason = request.signal?.reason;
+      reject(
+        reason instanceof Error ? reason : new Error("SPARQL query aborted"),
+      );
+    };
+    if (request.signal !== undefined) {
+      if (request.signal.aborted) {
+        onAbort();
+        return;
+      }
+      request.signal.addEventListener("abort", onAbort, { once: true });
+    }
 
     timer = setTimeout(() => {
       clearTimer();


### PR DESCRIPTION
Lockstep half of [wazootech/sparql-engine#122](https://github.com/wazootech/sparql-engine/issues/122), coordinated with [the engine PR](https://github.com/wazootech/sparql-engine/pull/149) under the identical-spec policy.

## What

- **Interface mirror** — `SparqlRequest` gains `signal?: AbortSignal` on `src/client/sparql-engine/sparql-engine-interface.ts`, byte-identical to the engine's copy (verified: `diff` clean after line-ending normalization). Keeps `timeoutMs` (Fork B superset, non-breaking).
- **Comunica engine honors it** — `executeSparql`'s end-of-request race now listens for the caller's signal alongside the existing timeout: abort rejects with the signal's `Error` reason (or `"SPARQL query aborted"`), pre-aborted signals reject immediately, and the listener is detached when the request settles. This keeps the drop-in engine-swap story honest in both directions — callers passing `signal` get the same behavior from Comunica and the wazoo engine.

## Verification

- 3 new tests in `comunica-sparql-engine.test.ts` (in-flight abort, pre-aborted, timeout race unchanged); full suite 77 passed.
- `deno fmt`, `deno lint`, `deno check` clean.
- `interface-parity` (this repo's `scripts/interface-parity.ts` diffs against `sparql-engine` `main`) intentionally red until the engine PR merges — same lockstep as the engine's own gate.

## Merge order

Merge with [sparql-engine#149](https://github.com/wazootech/sparql-engine/pull/149) — either order; the second merge reconciles both parity gates.