### PR TITLE
test: SqliteStore-backed client cases + pin @wazoo/sparql-engine 0.3.0

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -20,7 +20,7 @@
     "@ai-sdk/google": "npm:@ai-sdk/google@^3.0.80",
     "@comunica/query-sparql-rdfjs-lite": "npm:@comunica/query-sparql-rdfjs-lite@^5.2.3",
     "@rdfjs/types": "npm:@rdfjs/types@^2.0.1",
-    "@wazoo/sparql-engine": "jsr:@wazoo/sparql-engine@^0.2.0",
+    "@wazoo/sparql-engine": "jsr:@wazoo/sparql-engine@^0.3.0",
     "@std/assert": "jsr:@std/assert@^1.0.19",
     "@std/async": "jsr:@std/async@^1.4.0",
     "@std/encoding": "jsr:@std/encoding@^1.0.10",

--- a/deno.lock
+++ b/deno.lock
@@ -9,7 +9,7 @@
     "jsr:@std/internal@^1.0.12": "1.0.14",
     "jsr:@std/internal@^1.0.14": "1.0.14",
     "jsr:@std/path@^1.1.5": "1.1.5",
-    "jsr:@wazoo/sparql-engine@0.2": "0.2.0",
+    "jsr:@wazoo/sparql-engine@0.3": "0.3.0",
     "npm:@ai-sdk/google@^3.0.80": "3.0.80_zod@4.4.3",
     "npm:@comunica/query-sparql-rdfjs-lite@^5.2.3": "5.2.3",
     "npm:@langchain/core@^1.1.48": "1.1.48",
@@ -61,8 +61,8 @@
         "jsr:@std/internal@^1.0.14"
       ]
     },
-    "@wazoo/sparql-engine@0.2.0": {
-      "integrity": "bbac089d055a784482e9e6667c7e63e0b6c0693219106016ef14234548c4742b",
+    "@wazoo/sparql-engine@0.3.0": {
+      "integrity": "fc0c11ea0569c318baf5ded1f43a7a02b27d2f43466d29feb67294877bb7430a",
       "dependencies": [
         "npm:@rdfjs/types"
       ]
@@ -3917,7 +3917,7 @@
       "jsr:@std/encoding@^1.0.10",
       "jsr:@std/fs@^1.0.24",
       "jsr:@std/path@^1.1.5",
-      "jsr:@wazoo/sparql-engine@0.2",
+      "jsr:@wazoo/sparql-engine@0.3",
       "npm:@ai-sdk/google@^3.0.80",
       "npm:@comunica/query-sparql-rdfjs-lite@^5.2.3",
       "npm:@langchain/core@^1.1.48",

--- a/src/client/memory-store-client.test.ts
+++ b/src/client/memory-store-client.test.ts
@@ -9,13 +9,11 @@
  * WazooSparqlEngine or Comunica's adapter — and returns identical results
  * on identical data (differential parity).
  */
+import type * as rdfjs from "@rdfjs/types";
 import { assertEquals } from "@std/assert";
 import { DataFactory as N3, Store as N3Store } from "n3";
 import { MemoryStore, WazooSparqlEngine } from "@wazoo/sparql-engine";
-// Note: SqliteStore ships behind the ./sqlite subpath, which the published
-// @wazoo/sparql-engine@0.2.0 does not export yet (source has it). It is
-// exercised by the engine repo's own sqlite-store + parity suites; once the
-// subpath is published, add a SqliteStore({ path: ":memory:" }) case here.
+import { SqliteStore } from "@wazoo/sparql-engine/sqlite";
 import { Client } from "./client.ts";
 import type { SparqlBinding, SparqlResponse } from "./sparql-engine/mod.ts";
 import { RdfjsQuadStore, RdfjsSearchIndex } from "../rdfjs/mod.ts";
@@ -56,7 +54,7 @@ function normalizeBindings(bindings: SparqlBinding[]): unknown {
 }
 
 /** Wires the full Client facade over one shared RDF/JS store + WazooSparqlEngine. */
-function createWazooClient(store: MemoryStore): Client {
+function createWazooClient(store: rdfjs.Store & { size: number }): Client {
   return new Client({
     quadStore: new RdfjsQuadStore({ store }),
     sparqlEngine: new WazooSparqlEngine({ store }),
@@ -197,4 +195,122 @@ Deno.test("MemoryStore-backed client — shared store instance across quad + spa
 
   const search = await client.search({ query: "preloaded" });
   assertEquals(search.results?.length, 1);
+});
+
+Deno.test("SqliteStore-backed client — import → search → SELECT → ASK → reindex end to end", async () => {
+  const store = new SqliteStore({ path: ":memory:" });
+  try {
+    const client = createWazooClient(store);
+
+    await client.import({
+      source: {
+        kind: "serialized",
+        data: SEED_TURTLE,
+        contentType: "text/turtle",
+      },
+    });
+
+    // Imports landed in the same durable store the engine reads.
+    assertEquals(store.size, 8);
+
+    // Search over the durable store.
+    const search = await client.search({ query: "acme" });
+    assertEquals(search.results?.length, 1);
+    assertEquals(search.results?.[0].text, "Acme Corp");
+
+    // Multi-hop SELECT through WazooSparqlEngine.
+    const multiHop = assertSelect(
+      await client.sparql({ query: MULTI_HOP_QUERY }),
+    );
+    assertEquals(multiHop.length, 1);
+    assertEquals(multiHop[0].name?.value, "Bob");
+    assertEquals(multiHop[0].org?.value, "Acme Corp");
+
+    // ASK.
+    const ask = await client.sparql({ query: ASK_QUERY });
+    if (ask.kind !== "ask") throw new Error(`Expected ask, got ${ask.kind}`);
+    assertEquals(ask.data.boolean, true);
+
+    // Reindex reports the store size through the durable store.
+    const reindex = await client.reindex();
+    assertEquals(reindex.processedQuadCount, 8);
+  } finally {
+    store.close();
+  }
+});
+
+Deno.test("Differential parity — Wazoo(SqliteStore) vs Wazoo(MemoryStore) on identical data", async () => {
+  const sqliteStore = new SqliteStore({ path: ":memory:" });
+  const memoryStore = new MemoryStore();
+  try {
+    const sqliteClient = createWazooClient(sqliteStore);
+    const memoryClient = createWazooClient(memoryStore);
+
+    const seed = {
+      source: {
+        kind: "serialized",
+        data: SEED_TURTLE,
+        contentType: "text/turtle",
+      },
+    } as const;
+    await sqliteClient.import(seed);
+    await memoryClient.import(seed);
+
+    // Multi-hop join: identical bindings (name + org).
+    const sqliteMulti = normalizeBindings(
+      assertSelect(await sqliteClient.sparql({ query: MULTI_HOP_QUERY })),
+    );
+    const memoryMulti = normalizeBindings(
+      assertSelect(await memoryClient.sparql({ query: MULTI_HOP_QUERY })),
+    );
+    assertEquals(sqliteMulti, memoryMulti);
+
+    // OPTIONAL + FILTER + ORDER BY: identical ordered bindings.
+    const sqliteOptional = normalizeBindings(
+      assertSelect(await sqliteClient.sparql({ query: OPTIONAL_FILTER_QUERY })),
+    );
+    const memoryOptional = normalizeBindings(
+      assertSelect(await memoryClient.sparql({ query: OPTIONAL_FILTER_QUERY })),
+    );
+    assertEquals(sqliteOptional, memoryOptional);
+
+    // ASK: identical boolean.
+    const sqliteAsk = await sqliteClient.sparql({ query: ASK_QUERY });
+    const memoryAsk = await memoryClient.sparql({ query: ASK_QUERY });
+    if (sqliteAsk.kind !== "ask" || memoryAsk.kind !== "ask") {
+      throw new Error("Expected ask responses from both stores");
+    }
+    assertEquals(sqliteAsk.data.boolean, memoryAsk.data.boolean);
+  } finally {
+    sqliteStore.close();
+  }
+});
+
+Deno.test("SqliteStore-backed client — preloaded store shared across quad + sparql + search facades", async () => {
+  const store = new SqliteStore({ path: ":memory:" });
+  try {
+    // Preload directly on the durable store (simulating a hydrated backend),
+    // then verify the engine + search see it without a separate import step.
+    store.addQuad(
+      quad(
+        namedNode("urn:pre"),
+        namedNode("urn:pred"),
+        literal("Preloaded fact."),
+      ),
+    );
+
+    const client = createWazooClient(store);
+    const bindings = assertSelect(
+      await client.sparql({
+        query: "SELECT ?o WHERE { <urn:pre> <urn:pred> ?o }",
+      }),
+    );
+    assertEquals(bindings.length, 1);
+    assertEquals(bindings[0].o?.value, "Preloaded fact.");
+
+    const search = await client.search({ query: "preloaded" });
+    assertEquals(search.results?.length, 1);
+  } finally {
+    store.close();
+  }
 });


### PR DESCRIPTION
Follows PR #158 (any-RDF/JS-store RdfjsSearchIndex). Adds the SqliteStore-backed client cases that `memory-store-client.test.ts` explicitly deferred until `@wazoo/sparql-engine` published the `./sqlite` subpath.

- `@wazoo/sparql-engine` pinned to `^0.3.0` (first published release with `./sqlite`; lockfile updated so CI resolves SqliteStore without the minimum-dependency-age gate).
- New cases: end-to-end import → search → SELECT → ASK → reindex over `SqliteStore({ path: ":memory:" })`, differential parity Wazoo(SqliteStore) vs Wazoo(MemoryStore), and the preloaded/hydrated read path.

Verified locally: `deno task ci` green (78 passed, 0 failed, 1 ignored).