### PR TITLE
feat: rename package to @worlds/sdk (repo worlds-sdk-ts)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ all AI Agents writing code in this repository.
 
 ## Workspace boundary
 
-This repository is the lean `@worlds/client` package, not the Wazoo multi-repo
+This repository is the lean `@worlds/sdk` package, not the Wazoo multi-repo
 workspace. Sibling Wazoo repositories MUST live under
 `C:\Users\ethan\Documents\GitHub\wazootech`.
 
@@ -56,8 +56,8 @@ local-dev and test topology in this package. Durable backends
 `*RdfjsStore` implementations and read durable indexes directly with no
 per-query N3 mirror. Historical **libsql-n3** (hydrate durable quads into N3,
 then query) was removed; see [CHANGELOG.md](CHANGELOG.md) and
-[discussion #45](https://github.com/wazootech/worlds-client-ts/discussions/45)
-for crossover methodology only.
+[discussion #45](https://github.com/wazootech/worlds-sdk-ts/discussions/45) for
+crossover methodology only.
 
 ### Synchronization
 
@@ -142,11 +142,11 @@ mathematical brevity.
 
 - **`@/` (in-repo only):** `"@/": "./src/"` under `imports`. Use `@/client/...`
   inside `src/` for cross-domain imports. Never use the published package name
-  (`@worlds/client/...`) in `src/` — real `deno publish` resolves that as an
+  (`@worlds/sdk/...`) in `src/` — real `deno publish` resolves that as an
   external JSR dependency and fails
   ([denoland/deno#25191](https://github.com/denoland/deno/issues/25191),
   [maintainer guidance](https://github.com/denoland/deno/issues/25191#issuecomment-2308790000)).
-- **`@worlds/client/...` (public):** `exports` only. Examples, benchmarks, and
+- **`@worlds/sdk/...` (public):** `exports` only. Examples, benchmarks, and
   external apps use documented export subpaths — not `@/` and not deep file
   paths.
 
@@ -158,10 +158,10 @@ mathematical brevity.
 2. **Same domain folder.** `./file.ts` or `./subfolder/mod.ts` for siblings and
    children.
 3. **Nested folder, parent barrel.** Use `@/client/mod.ts` — not `../` and not
-   `@worlds/client/...`.
+   `@worlds/sdk/...`.
 
 Never use parent-relative `../` to reach another domain. Never import
-`@worlds/client/...` anywhere under `src/`.
+`@worlds/sdk/...` anywhere under `src/`.
 
 ### Examples
 
@@ -173,7 +173,7 @@ Never use parent-relative `../` to reach another domain. Never import
 - ✅ `import { Client } from "@/client/client.ts"` (avoids root barrel cycles)
 - ✅ `./string-to-chars.ts` (from `tokenizer/tokenizer.ts`)
 - ✅ `./client.ts`, `../rdfjs/mod.ts` (from `src/client/client.test.ts`)
-- ❌ `@worlds/client/sparql-engine` inside `src/`
+- ❌ `@worlds/sdk/sparql-engine` inside `src/`
 - ❌ `../../quad-store/mod.ts`
 - ❌ `Promise<import("@/client/sparql-engine/mod.ts").SparqlResponse>` — use a
   top-level `import type` instead
@@ -187,12 +187,12 @@ would cycle — e.g. `chunk-quads.ts` uses `@/client/quad-store/mod.ts`, not
 ### Public surface changes
 
 When adding a new importable subpath, add it to `exports` in `deno.json` for
-`@worlds/client/...` consumers. Mirror the file path under `@/client/...` for
-in-repo imports (no duplicate `@worlds/client/*` entries in `imports`). Shared
+`@worlds/sdk/...` consumers. Mirror the file path under `@/client/...` for
+in-repo imports (no duplicate `@worlds/sdk/*` entries in `imports`). Shared
 topology-agnostic patch buffering lives in `rdfjs-buffer/` (export
-`@worlds/client/quad-store`). Durable adapter `*RdfjsStore` implementations live
-in the external [`@worlds/libsql`](https://github.com/wazootech/worlds-libsql)
-and [`@worlds/denokv`](https://github.com/wazootech/worlds-denokv) repositories.
+`@worlds/sdk/quad-store`). Durable adapter `*RdfjsStore` implementations live in
+the external [`@worlds/libsql`](https://github.com/wazootech/worlds-libsql) and
+[`@worlds/denokv`](https://github.com/wazootech/worlds-denokv) repositories.
 
 ### Packaging and dependency resolution rationale
 
@@ -206,7 +206,7 @@ resolution:
 
 - **On-demand fetching**: Runtimes (like Deno) only resolve, download, and
   compile dependencies actually traversed in the imported path. Importing from
-  `@worlds/client/rdfjs` fetches `n3` and `@rdfjs/types` — but never downloads
+  `@worlds/sdk/rdfjs` fetches `n3` and `@rdfjs/types` — but never downloads
   `@libsql/client` or `@tensorflow/tfjs`.
 
 ### No inline imports
@@ -255,10 +255,10 @@ documentation files:
   - ✅ **Prefer:** `### AI SDK agent`
 - **Suppression of horizontal rules:** Avoid utilizing `---` divider lines to
   segment documents. Let empty lines establish boundaries cleanly.
-- **No pinned JSR versions in docs:** Link and refer to `@worlds/client` (or
-  `jsr:@worlds/client`) without `@x.y.z` suffixes in README, examples,
-  benchmarks, and AGENTS. Version lives only in `deno.json` for publish;
-  consumers pin via `deno add jsr:@worlds/client` or their own lockfile.
+- **No pinned JSR versions in docs:** Link and refer to `@worlds/sdk` (or
+  `jsr:@worlds/sdk`) without `@x.y.z` suffixes in README, examples, benchmarks,
+  and AGENTS. Version lives only in `deno.json` for publish; consumers pin via
+  `deno add jsr:@worlds/sdk` or their own lockfile.
 
 ## Development constraints and CI hygiene
 
@@ -302,27 +302,27 @@ green-passing integration pipeline runs:
 - **Local benchmarks only:** Benchmark suites live in the adapter repos
   ([`@worlds/libsql`](https://github.com/wazootech/worlds-libsql),
   [`@worlds/denokv`](https://github.com/wazootech/worlds-denokv)) and in
-  [discussion #69](https://github.com/wazootech/worlds-client-ts/discussions/69).
+  [discussion #69](https://github.com/wazootech/worlds-sdk-ts/discussions/69).
   There is no CI benchmark regression gate in this repo.
 
 - **GitHub Actions CI:** Pull requests and pushes to `main` run
   [`.github/workflows/ci.yml`](.github/workflows/ci.yml) (`deno task ci`: fmt,
   lint, check, test). Open PRs show the **CI** check before merge.
-- **JSR publish (`deno publish`):** The package is `@worlds/client` on JSR.
-  Pushes to `main` also run
+- **JSR publish (`deno publish`):** The package is `@worlds/sdk` on JSR. Pushes
+  to `main` also run
   [`.github/workflows/publish.yml`](.github/workflows/publish.yml):
   `deno task ci` → `deno task publish:dry` → `deno publish`. Before any release
   or import/`exports` refactor, run the same sequence locally.
   - **Version:** Bump `"version"` in `deno.json` for each JSR release (CI does
     not auto-bump).
   - **In-repo imports:** Only `@/` under `src/` (see import conventions). Do not
-    add `@worlds/client/*` to `imports`; `exports` alone defines the public
-    package surface.
+    add `@worlds/sdk/*` to `imports`; `exports` alone defines the public package
+    surface.
   - **Dry-run smoke:** `deno task publish:dry`
     (`deno publish --dry-run
     --allow-dirty`) is required in CI before merge.
-  - **If publish fails** with `export '…' not found in jsr:@worlds/client` or
-    `unresolvable 'jsr:' dependency`, search `src/` for `@worlds/client` imports
+  - **If publish fails** with `export '…' not found in jsr:@worlds/sdk` or
+    `unresolvable 'jsr:' dependency`, search `src/` for `@worlds/sdk` imports
     and replace them with `@/client/...` per
     [denoland/deno#25191](https://github.com/denoland/deno/issues/25191).
   - **Packaging:** JSR strips `links` and `exclude` from `deno.json`; the

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,25 +1,25 @@
 # Architecture
 
-This document describes the stable architecture of `@worlds/client` and how it
+This document describes the stable architecture of `@worlds/sdk` and how it
 relates to the Worlds ecosystem.
 
 ## Package topology
 
-`@worlds/client` ships the core client abstractions and the in-memory RDF/JS
+`@worlds/sdk` ships the core client abstractions and the in-memory RDF/JS
 backend. Durable backends are published as separate packages.
 
 ### In this package
 
-| Export                                           | Role                                                                            |
-| ------------------------------------------------ | ------------------------------------------------------------------------------- |
-| `@worlds/client`                                 | Root barrel: `Client`, interfaces, patch types, embedding-service, quad-chunker |
-| `@worlds/client/quad-store`                      | Quad import/export API, RDF formats, patch transactions                         |
-| `@worlds/client/search-index`                    | Search index interface and types                                                |
-| `@worlds/client/sparql-engine`                   | SPARQL engine interface                                                         |
-| `@worlds/client/rdfjs`                           | In-memory `RdfjsQuadStore` and `RdfjsSearchIndex` over `N3.Store`               |
-| `@worlds/client/comunica`                        | `ComunicaSparqlEngine` adapter                                                  |
-| `@worlds/client/ai-sdk`                          | Vercel AI SDK embedding service                                                 |
-| `@worlds/client/tfjs-universal-sentence-encoder` | Offline TF.js USE embedding service                                             |
+| Export                                        | Role                                                                            |
+| --------------------------------------------- | ------------------------------------------------------------------------------- |
+| `@worlds/sdk`                                 | Root barrel: `Client`, interfaces, patch types, embedding-service, quad-chunker |
+| `@worlds/sdk/quad-store`                      | Quad import/export API, RDF formats, patch transactions                         |
+| `@worlds/sdk/search-index`                    | Search index interface and types                                                |
+| `@worlds/sdk/sparql-engine`                   | SPARQL engine interface                                                         |
+| `@worlds/sdk/rdfjs`                           | In-memory `RdfjsQuadStore` and `RdfjsSearchIndex` over `N3.Store`               |
+| `@worlds/sdk/comunica`                        | `ComunicaSparqlEngine` adapter                                                  |
+| `@worlds/sdk/ai-sdk`                          | Vercel AI SDK embedding service                                                 |
+| `@worlds/sdk/tfjs-universal-sentence-encoder` | Offline TF.js USE embedding service                                             |
 
 ### External durable backends
 
@@ -60,9 +60,9 @@ interface ClientOptions {
 ### In-memory topology (dev, tests, demos)
 
 ```typescript
-import { Client } from "@worlds/client";
+import { Client } from "@worlds/sdk";
 import { WazooSparqlEngine } from "@wazoo/sparql-engine";
-import { RdfjsQuadStore, RdfjsSearchIndex } from "@worlds/client/rdfjs";
+import { RdfjsQuadStore, RdfjsSearchIndex } from "@worlds/sdk/rdfjs";
 import { Store } from "n3";
 
 const store = new Store();
@@ -125,7 +125,7 @@ const sparqlResponse = await client.sparql({
 
 ## SPARQL engine choice
 
-`@worlds/client` is engine-agnostic: the `SparqlEngineInterface` abstraction
+`@worlds/sdk` is engine-agnostic: the `SparqlEngineInterface` abstraction
 (`execute(request)`) makes any engine swappable without changing client code.
 Two engines implement it today:
 
@@ -138,11 +138,11 @@ Two engines implement it today:
   durable backends). It covers SELECT / ASK / CONSTRUCT / DESCRIBE plus UPDATE
   and is differentially tested against Comunica.
 - **Comunica (compatible alternative)** — `@comunica/query-sparql-rdfjs-lite`,
-  wrapped by `ComunicaSparqlEngine` (`@worlds/client/comunica`). The lite
-  variant was chosen over the full `@comunica/query-sparql` because Worlds only
-  queries in-process RDF/JS Store sources (LibSQL, Deno KV, N3). The full
-  engine's HTTP federation, file source, and serialization actors are
-  unnecessary. Lite is smaller, faster to instantiate, and edge-safe.
+  wrapped by `ComunicaSparqlEngine` (`@worlds/sdk/comunica`). The lite variant
+  was chosen over the full `@comunica/query-sparql` because Worlds only queries
+  in-process RDF/JS Store sources (LibSQL, Deno KV, N3). The full engine's HTTP
+  federation, file source, and serialization actors are unnecessary. Lite is
+  smaller, faster to instantiate, and edge-safe.
 
 The `ComunicaQueryEngine` interface is a structural type requiring only
 `query(query, { sources, baseIRI })`. A custom engine remains feasible through
@@ -160,7 +160,7 @@ for the original Comunica rationale.
 
 ## Non-goals
 
-- `@worlds/client` does not include a hosted Wazoo API client.
+- `@worlds/sdk` does not include a hosted Wazoo API client.
 - Durable/immediate persistent backends (LibSQL, Deno KV) are not implemented
   inside this package. They ship in separate JSR packages with different
   lifecycle and dependency profiles.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,23 @@
 # Changelog
 
+## 0.1.0
+
+### Breaking
+
+- Renamed the package from `@worlds/client` to `@worlds/sdk`, and the repository
+  from `wazootech/worlds-client-ts` to `wazootech/worlds-sdk-ts`. The
+  `worlds-client-ts` name now refers to the generated data-plane HTTP client
+  (mirroring `wazoo-client-ts`). Update imports: `@worlds/client` →
+  `@worlds/sdk`; all export subpaths are unchanged (e.g. `@worlds/client/rdfjs`
+  becomes `@worlds/sdk/rdfjs`).
+
 ## 0.0.19
 
 ### Changed
 
 - Default the in-memory SPARQL engine to `@wazoo/sparql-engine`
   (`WazooSparqlEngine`), keeping Comunica as the compatible alternative via
-  `@worlds/client/comunica`.
+  `@worlds/sdk/comunica`.
 - Reconcile `SparqlEngineInterface` with `@wazoo/sparql-engine` under the
   identical-spec policy: add the `construct` result variant and RDF 1.2
   `its:dir` literal direction, and collapse `SparqlRequest.query`/`update` into
@@ -28,7 +39,7 @@
   `createLibsqlStores`, `createDenokvClientFromStores`, and
   `createDenokvStores`. Custom assembly uses explicit
   `new Client({ quadStore, searchIndex, sparqlEngine? })`.
-- Narrowed `@worlds/client/adapters/libsql` and `@worlds/client/adapters/denokv`
+- Narrowed `@worlds/sdk/adapters/libsql` and `@worlds/sdk/adapters/denokv`
   exports to factory entry points, suffixed stores, and search helpers; SQL/KV
   internals are in-repo only under durable adapter seam folders such as
   `libsql/rdfjs-store/sql/` and `denokv/rdfjs-store/kv/`.
@@ -56,37 +67,34 @@
   **`deduplicateBuffers`**; **`CommittingRdfjsStore`** →
   **`ImportCommitTarget`**; **`createRdfjsCommittingStore`** →
   **`createImportCommitTarget`**.
-- Renamed `@worlds/client/rdfjs-store` → **`@worlds/client/quad-store`** (shared
-  patch buffering and import orchestration). Adapter `*RdfjsStore`
-  implementations remain under `@worlds/client/adapters/*/rdfjs-store/`.
+- Renamed `@worlds/sdk/rdfjs-store` → **`@worlds/sdk/quad-store`** (shared patch
+  buffering and import orchestration). Adapter `*RdfjsStore` implementations
+  remain under `@worlds/sdk/adapters/*/rdfjs-store/`.
 - Removed dead `wire-durable-client.ts` stub (logic lives in durable factories).
 
 ### Migration
 
 ```typescript
 // Before
-import { Client } from "@worlds/client";
-import { createLibsqlAdapter } from "@worlds/client/adapters/libsql";
+import { Client } from "@worlds/sdk";
+import { createLibsqlAdapter } from "@worlds/sdk/adapters/libsql";
 const client = new Client(
   await createLibsqlAdapter({ client: db, queryEngine }),
 );
 await client.rebuildSearchIndex();
 
 // After
-import { createLibsqlClient } from "@worlds/client/adapters/libsql";
+import { createLibsqlClient } from "@worlds/sdk/adapters/libsql";
 const client = await createLibsqlClient({ client: db, queryEngine });
 await client.reindex();
 
-// Shared buffering (was @worlds/client/rdfjs-store)
-import { importViaBufferedRdfjsStore } from "@worlds/client/quad-store";
+// Shared buffering (was @worlds/sdk/rdfjs-store)
+import { importViaBufferedRdfjsStore } from "@worlds/sdk/quad-store";
 
 // In-memory (replaces createRdfjsClient)
-import { Client } from "@worlds/client";
-import {
-  RdfjsQuadStore,
-  RdfjsSearchIndex,
-} from "@worlds/client/adapters/rdfjs";
-import { ComunicaSparqlEngine } from "@worlds/client/adapters/comunica";
+import { Client } from "@worlds/sdk";
+import { RdfjsQuadStore, RdfjsSearchIndex } from "@worlds/sdk/adapters/rdfjs";
+import { ComunicaSparqlEngine } from "@worlds/sdk/adapters/comunica";
 import { Store } from "n3";
 
 const store = new Store();
@@ -101,12 +109,12 @@ const memoryClient = new Client({
 
 - Removed misnamed LibSQL query helpers `buildHydrateQuery` and
   `buildHydrateQuadsPageQuery` from `LibsqlQueryBuilder` (not exported from
-  `@worlds/client/adapters/libsql`; breaking only for deep imports of
+  `@worlds/sdk/adapters/libsql`; breaking only for deep imports of
   `libsql-query-builder.ts`). `rebuildLibsqlSearchIndexFromQuads` now
   keyset-pages via `buildMatchQuadsQuery` with `filterQuads` in TypeScript for
   include/exclude.
 - Durable `LibsqlQuadStore` and `DenokvQuadStore` extend shared
-  `BufferedRdfjsQuadStore` (`@worlds/client/quad-store`), delegating import and
+  `BufferedRdfjsQuadStore` (`@worlds/sdk/quad-store`), delegating import and
   export to `importViaBufferedRdfjsStore` / `exportFromRdfjsStore`.
 - LibSQL SPARQL is configured by passing a Comunica `queryEngine` directly into
   adapter options (no `createSparqlEngine` callback or factory helper).
@@ -126,8 +134,8 @@ const memoryClient = new Client({
 
 ### Breaking
 
-- Removed `@worlds/client/adapters/libsql-n3` (`createLibsqlN3Adapter`) and
-  `@worlds/client/quad-store/n3` (`createProxiedN3Store`).
+- Removed `@worlds/sdk/adapters/libsql-n3` (`createLibsqlN3Adapter`) and
+  `@worlds/sdk/quad-store/n3` (`createProxiedN3Store`).
 - Removed `createComunicaSparqlEngineFactory` and `createSparqlEngine` adapter
   callbacks; pass `queryEngine` into adapter options instead.
 - Renamed `LibsqlStore` / `LibsqlStoreOptions` to `LibsqlRdfjsStore` /
@@ -143,7 +151,7 @@ const memoryClient = new Client({
 
 ```typescript
 // Before
-import { ComunicaSparqlEngine } from "@worlds/client/adapters/comunica";
+import { ComunicaSparqlEngine } from "@worlds/sdk/adapters/comunica";
 
 createSparqlEngine: ({ store }) =>
   new ComunicaSparqlEngine({ queryEngine, store }),
@@ -154,19 +162,16 @@ queryEngine,
 
 ```typescript
 // Before
-import { LibsqlStore } from "@worlds/client/adapters/libsql";
+import { LibsqlStore } from "@worlds/sdk/adapters/libsql";
 
 // After
-import {
-  LibsqlQuadStore,
-  LibsqlRdfjsStore,
-} from "@worlds/client/adapters/libsql";
+import { LibsqlQuadStore, LibsqlRdfjsStore } from "@worlds/sdk/adapters/libsql";
 ```
 
 Most apps keep using `createLibsqlClient` unchanged:
 
 ```typescript
-import { createLibsqlClient } from "@worlds/client/adapters/libsql";
+import { createLibsqlClient } from "@worlds/sdk/adapters/libsql";
 
 const adapter = await createLibsqlClient({ client, queryEngine });
 ```
@@ -175,14 +180,14 @@ Custom LibSQL assembly (removed `createLibsqlClientFromStores` and
 `createLibsqlClientInfrastructure`; prefer `createLibsqlClient` when possible):
 
 ```typescript
-import { Client } from "@worlds/client";
-import { ComunicaSparqlEngine } from "@worlds/client/adapters/comunica";
+import { Client } from "@worlds/sdk";
+import { ComunicaSparqlEngine } from "@worlds/sdk/adapters/comunica";
 import {
   createLibsqlClient,
   LibsqlQuadStore,
   LibsqlRdfjsStore,
   LibsqlSearchIndex,
-} from "@worlds/client/adapters/libsql";
+} from "@worlds/sdk/adapters/libsql";
 
 // Default path (recommended):
 const adapter = await createLibsqlClient({ client, queryEngine });
@@ -212,13 +217,13 @@ Deno KV custom assembly (removed `createDenokvClientFromStores`; prefer
 `createDenokvClient` when possible):
 
 ```typescript
-import { Client } from "@worlds/client";
+import { Client } from "@worlds/sdk";
 import {
   createDenokvClient,
   DenokvQuadStore,
   DenokvRdfjsStore,
   DenokvSearchIndex,
-} from "@worlds/client/adapters/denokv";
+} from "@worlds/sdk/adapters/denokv";
 
 const adapter = createDenokvClient({ kv, keyPrefix, queryEngine });
 
@@ -231,17 +236,17 @@ const customAdapter = new Client({
 ```
 
 Shared import helpers (`getFormat`, `parseQuads`, `materializeImportQuads`) are
-exported from `@worlds/client/quad-store` (no new export subpath).
+exported from `@worlds/sdk/quad-store` (no new export subpath).
 
 ## 0.0.15
 
 ### Breaking
 
-- Removed `@worlds/client/adapters/libsql/n3`. Use
-  `@worlds/client/adapters/libsql-n3` (`createLibsqlN3Adapter`).
-- Removed `@worlds/client/adapters/rdfjs/n3`. N3 patch capture moved to
-  `@worlds/client/quad-store/n3` as `createProxiedN3Store` (formerly
-  `proxyStore` on the old path).
+- Removed `@worlds/sdk/adapters/libsql/n3`. Use `@worlds/sdk/adapters/libsql-n3`
+  (`createLibsqlN3Adapter`).
+- Removed `@worlds/sdk/adapters/rdfjs/n3`. N3 patch capture moved to
+  `@worlds/sdk/quad-store/n3` as `createProxiedN3Store` (formerly `proxyStore`
+  on the old path).
 - Removed libsql SPARQL query-pattern helper exports; use inline SPARQL strings
   in application code.
 - Renamed `ClientOptions` to `Adapter`. The interface describes the composed
@@ -257,18 +262,18 @@ exported from `@worlds/client/quad-store` (no new export subpath).
 
 ### Added
 
-- `mergePatches` on `@worlds/client/quad-store` for concatenating drained N3
-  patch batches before persistence.
-- `@worlds/client/quad-store/n3` (`createProxiedN3Store`).
+- `mergePatches` on `@worlds/sdk/quad-store` for concatenating drained N3 patch
+  batches before persistence.
+- `@worlds/sdk/quad-store/n3` (`createProxiedN3Store`).
 
 ### Migration
 
 ```typescript
 // Before
-import { createLibsqlN3Adapter } from "@worlds/client/adapters/libsql/n3";
+import { createLibsqlN3Adapter } from "@worlds/sdk/adapters/libsql/n3";
 
 // After
-import { createLibsqlN3Adapter } from "@worlds/client/adapters/libsql-n3";
+import { createLibsqlN3Adapter } from "@worlds/sdk/adapters/libsql-n3";
 ```
 
 ```typescript
@@ -281,11 +286,11 @@ const client = new Client(await createLibsqlClient({ client: db }));
 
 ```typescript
 // Before
-import { proxyStore } from "@worlds/client/adapters/rdfjs/n3";
+import { proxyStore } from "@worlds/sdk/adapters/rdfjs/n3";
 
 // After
-import { createProxiedN3Store } from "@worlds/client/quad-store/n3";
-import { mergePatches } from "@worlds/client/quad-store";
+import { createProxiedN3Store } from "@worlds/sdk/quad-store/n3";
+import { mergePatches } from "@worlds/sdk/quad-store";
 
 const { store, drainPatches } = createProxiedN3Store(baseStore);
 const patch = mergePatches(drainPatches());
@@ -296,9 +301,9 @@ const patch = mergePatches(drainPatches());
 ### Added
 
 - `createComunicaSparqlEngineFactory` and
-  `createComunicaLibsqlSparqlEngineFactory` on
-  `@worlds/client/adapters/comunica` — preset helpers that return typed
-  `createSparqlEngine` callbacks for standard Comunica wiring.
+  `createComunicaLibsqlSparqlEngineFactory` on `@worlds/sdk/adapters/comunica` —
+  preset helpers that return typed `createSparqlEngine` callbacks for standard
+  Comunica wiring.
 
 ## 0.0.13
 
@@ -315,7 +320,7 @@ const patch = mergePatches(drainPatches());
 const client = await createLibsqlClient({ client: db });
 
 // After
-import { Client } from "@worlds/client";
+import { Client } from "@worlds/sdk";
 const client = new Client(await createLibsqlClientOptions({ client: db }));
 ```
 

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@
   <br /><br />
   <em>Persistent, edge-native knowledge graph storage for agents.</em>
   <br /><br />
-  <a href="https://jsr.io/@worlds/client"><img src="https://jsr.io/badges/@worlds/client" alt="JSR" /></a>
-  <a href="https://jsr.io/@worlds/client/score"><img src="https://jsr.io/badges/@worlds/client/score" alt="JSR Score" /></a>
-  <a href="https://github.com/wazootech/worlds-client-ts"><img src="https://img.shields.io/badge/GitHub-black?logo=github" alt="GitHub" /></a>
-  <a href="https://deepwiki.com/wazootech/worlds-client-ts"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki" /></a>
+  <a href="https://jsr.io/@worlds/sdk"><img src="https://jsr.io/badges/@worlds/sdk" alt="JSR" /></a>
+  <a href="https://jsr.io/@worlds/sdk/score"><img src="https://jsr.io/badges/@worlds/sdk/score" alt="JSR Score" /></a>
+  <a href="https://github.com/wazootech/worlds-sdk-ts"><img src="https://img.shields.io/badge/GitHub-black?logo=github" alt="GitHub" /></a>
+  <a href="https://deepwiki.com/wazootech/worlds-sdk-ts"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki" /></a>
 </p>
 
 - **Portable facade** — Unified `Client` API that works across in-memory,
@@ -22,15 +22,15 @@
 ## Install
 
 ```bash
-deno add jsr:@worlds/client
+deno add jsr:@worlds/sdk
 ```
 
 ## Quickstart
 
 ```typescript
-import { Client } from "@worlds/client";
+import { Client } from "@worlds/sdk";
 import { WazooSparqlEngine } from "@wazoo/sparql-engine";
-import { RdfjsQuadStore, RdfjsSearchIndex } from "@worlds/client/rdfjs";
+import { RdfjsQuadStore, RdfjsSearchIndex } from "@worlds/sdk/rdfjs";
 import { Store } from "n3";
 
 const store = new Store();
@@ -64,7 +64,7 @@ console.log(sparqlResponse);
 > Deno KV (`@worlds/denokv`) backends.
 >
 > Prefer Comunica? Swap `WazooSparqlEngine` for `ComunicaSparqlEngine` from
-> `@worlds/client/comunica` — both implement the same `SparqlEngineInterface`.
+> `@worlds/sdk/comunica` — both implement the same `SparqlEngineInterface`.
 
 ## Core concepts
 
@@ -77,27 +77,26 @@ with vector similarity via an embedding service and quad chunker.
 **SPARQL engine**: Evaluates declarative queries and updates against the graph
 for structured traversal and reasoning. The zero-dependency
 [`@wazoo/sparql-engine`](https://jsr.io/@wazoo/sparql-engine) is the default;
-Comunica remains available via `@worlds/client/comunica`.
+Comunica remains available via `@worlds/sdk/comunica`.
 
 ## Module layout
 
 `Client` is the portable facade. Shared modules sit under `src/client/`:
 
-| Export                         | Role                                                 |
-| ------------------------------ | ---------------------------------------------------- |
-| `@worlds/client`               | Root barrel: `Client`, interfaces, patch types       |
-| `@worlds/client/quad-store`    | Quad import/export API, RDF formats, patch buffering |
-| `@worlds/client/search-index`  | Search index interface and types                     |
-| `@worlds/client/sparql-engine` | SPARQL engine interface                              |
-| `@worlds/client/rdfjs`         | In-memory N3 `RdfjsQuadStore` and `RdfjsSearchIndex` |
-| `@worlds/client/comunica`      | `ComunicaSparqlEngine` adapter                       |
-| `@worlds/client/ai-sdk`        | Vercel AI SDK tool bindings                          |
+| Export                      | Role                                                 |
+| --------------------------- | ---------------------------------------------------- |
+| `@worlds/sdk`               | Root barrel: `Client`, interfaces, patch types       |
+| `@worlds/sdk/quad-store`    | Quad import/export API, RDF formats, patch buffering |
+| `@worlds/sdk/search-index`  | Search index interface and types                     |
+| `@worlds/sdk/sparql-engine` | SPARQL engine interface                              |
+| `@worlds/sdk/rdfjs`         | In-memory N3 `RdfjsQuadStore` and `RdfjsSearchIndex` |
+| `@worlds/sdk/comunica`      | `ComunicaSparqlEngine` adapter                       |
+| `@worlds/sdk/ai-sdk`        | Vercel AI SDK tool bindings                          |
 
 The recommended default engine is the external
 [`@wazoo/sparql-engine`](https://jsr.io/@wazoo/sparql-engine) package, which
 implements the same `SparqlEngineInterface` as `ComunicaSparqlEngine`.
-`@worlds/client/comunica` remains available when the Comunica engine is
-preferred.
+`@worlds/sdk/comunica` remains available when the Comunica engine is preferred.
 
 Regenerate merged API doc JSON with `deno task doc:json` (writes gitignored
 `docs/api.json`). For architecture documentation (package topology, runtime
@@ -111,22 +110,22 @@ in separate packages:
 
 | Package                                                        | Persistence          | Search               | SPARQL                        |
 | -------------------------------------------------------------- | -------------------- | -------------------- | ----------------------------- |
-| `@worlds/client` (this package)                                | In-memory (N3 Store) | RDF/JS keyword       | Wazoo (default) or Comunica   |
+| `@worlds/sdk` (this package)                                   | In-memory (N3 Store) | RDF/JS keyword       | Wazoo (default) or Comunica   |
 | [`@worlds/libsql`](https://github.com/wazootech/worlds-libsql) | SQLite / Turso Cloud | Hybrid FTS5 + vector | LibsqlRdfjsStore quad indexes |
 | [`@worlds/denokv`](https://github.com/wazootech/worlds-denokv) | Deno KV              | Keyword FTS          | DenokvRdfjsStore quad indexes |
 
 **Choosing LibSQL vs Deno KV:** LibSQL is the default for hybrid FTS/vector
 search and faster cold quad index preload at scale. Deno KV can be faster on
 selective SPARQL execute after preload in long-lived or cached processes. See
-[discussion #69](https://github.com/wazootech/worlds-client-ts/discussions/69)
-for benchmark methodology.
+[discussion #69](https://github.com/wazootech/worlds-sdk-ts/discussions/69) for
+benchmark methodology.
 
 ### In-memory (dev, tests, demos)
 
 ```typescript
-import { Client } from "@worlds/client";
+import { Client } from "@worlds/sdk";
 import { WazooSparqlEngine } from "@wazoo/sparql-engine";
-import { RdfjsQuadStore, RdfjsSearchIndex } from "@worlds/client/rdfjs";
+import { RdfjsQuadStore, RdfjsSearchIndex } from "@worlds/sdk/rdfjs";
 import { Store } from "n3";
 
 const store = new Store();
@@ -144,9 +143,9 @@ const client = new Client({
 client code changes:
 
 ```typescript
-import { Client } from "@worlds/client";
-import { ComunicaSparqlEngine } from "@worlds/client/comunica";
-import { RdfjsQuadStore, RdfjsSearchIndex } from "@worlds/client/rdfjs";
+import { Client } from "@worlds/sdk";
+import { ComunicaSparqlEngine } from "@worlds/sdk/comunica";
+import { RdfjsQuadStore, RdfjsSearchIndex } from "@worlds/sdk/rdfjs";
 import { QueryEngine } from "@comunica/query-sparql-rdfjs-lite";
 import { Store } from "n3";
 
@@ -202,6 +201,6 @@ All CI checks must pass before merging updates.
 
 - [Documentation](https://docs.wazoo.dev)
 - [Wazoo Technologies](https://wazoo.dev)
-- [Support](https://github.com/wazootech/worlds-client-ts/issues)
+- [Support](https://github.com/wazootech/worlds-sdk-ts/issues)
 
 Developed with [**@wazootech**](https://github.com/wazootech)

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
-  "name": "@worlds/client",
-  "version": "0.0.19",
+  "name": "@worlds/sdk",
+  "version": "0.1.0",
   "nodeModulesDir": "auto",
   "exports": {
     ".": "./src/mod.ts",

--- a/examples/ai-sdk-hello-world/main.ts
+++ b/examples/ai-sdk-hello-world/main.ts
@@ -1,6 +1,6 @@
-import { Client } from "@worlds/client";
-import { ComunicaSparqlEngine } from "@worlds/client/comunica";
-import { RdfjsQuadStore, RdfjsSearchIndex } from "@worlds/client/rdfjs";
+import { Client } from "@worlds/sdk";
+import { ComunicaSparqlEngine } from "@worlds/sdk/comunica";
+import { RdfjsQuadStore, RdfjsSearchIndex } from "@worlds/sdk/rdfjs";
 import { QueryEngine } from "@comunica/query-sparql-rdfjs-lite";
 import { Store } from "n3";
 import { GRAPH_GROUNDED_AGENT_SYSTEM_PROMPT } from "./agent-prompts.ts";

--- a/examples/ai-sdk-hello-world/tools.ts
+++ b/examples/ai-sdk-hello-world/tools.ts
@@ -1,4 +1,4 @@
-import type { ClientInterface } from "@worlds/client";
+import type { ClientInterface } from "@worlds/sdk";
 import {
   createExecuteSparqlTool,
   createExportRdfTool,

--- a/examples/ai-sdk-hello-world/tools/export.ts
+++ b/examples/ai-sdk-hello-world/tools/export.ts
@@ -1,6 +1,6 @@
 import { tool } from "ai";
-import type { ClientInterface } from "@worlds/client";
-import type { ExportRequest } from "@worlds/client/quad-store";
+import type { ClientInterface } from "@worlds/sdk";
+import type { ExportRequest } from "@worlds/sdk/quad-store";
 import { z } from "zod";
 
 /**

--- a/examples/ai-sdk-hello-world/tools/import.ts
+++ b/examples/ai-sdk-hello-world/tools/import.ts
@@ -1,6 +1,6 @@
 import { tool } from "ai";
-import type { ClientInterface } from "@worlds/client";
-import type { ImportRequest } from "@worlds/client/quad-store";
+import type { ClientInterface } from "@worlds/sdk";
+import type { ImportRequest } from "@worlds/sdk/quad-store";
 import { z } from "zod";
 
 /**

--- a/examples/ai-sdk-hello-world/tools/search.ts
+++ b/examples/ai-sdk-hello-world/tools/search.ts
@@ -1,9 +1,6 @@
 import { tool } from "ai";
-import type { ClientInterface } from "@worlds/client";
-import type {
-  SearchRequest,
-  SearchResponse,
-} from "@worlds/client/search-index";
+import type { ClientInterface } from "@worlds/sdk";
+import type { SearchRequest, SearchResponse } from "@worlds/sdk/search-index";
 import { z } from "zod";
 import { SEARCH_WORLD_TOOL_DESCRIPTION } from "./agent-tool-descriptions.ts";
 

--- a/examples/ai-sdk-hello-world/tools/sparql.ts
+++ b/examples/ai-sdk-hello-world/tools/sparql.ts
@@ -1,6 +1,6 @@
 import { tool } from "ai";
-import type { ClientInterface } from "@worlds/client";
-import type { SparqlRequest } from "@worlds/client/sparql-engine";
+import type { ClientInterface } from "@worlds/sdk";
+import type { SparqlRequest } from "@worlds/sdk/sparql-engine";
 import { z } from "zod";
 import { EXECUTE_SPARQL_TOOL_DESCRIPTION } from "./agent-tool-descriptions.ts";
 

--- a/examples/hello-world/main.ts
+++ b/examples/hello-world/main.ts
@@ -1,6 +1,6 @@
-import { Client } from "@worlds/client";
+import { Client } from "@worlds/sdk";
 import { WazooSparqlEngine } from "@wazoo/sparql-engine";
-import { RdfjsQuadStore, RdfjsSearchIndex } from "@worlds/client/rdfjs";
+import { RdfjsQuadStore, RdfjsSearchIndex } from "@worlds/sdk/rdfjs";
 import { Store } from "n3";
 
 if (import.meta.main) {

--- a/scripts/generate-doc-json.ts
+++ b/scripts/generate-doc-json.ts
@@ -5,7 +5,7 @@ import denoJson from "../deno.json" with { type: "json" };
 
 /** DocJsonEntryPoint records one deno.json export and its source file. */
 interface DocJsonEntryPoint {
-  /** subpath is the @worlds/client export key (e.g. "./adapters/libsql"). */
+  /** subpath is the @worlds/sdk export key (e.g. "./adapters/libsql"). */
   subpath: string;
   /** file is the repository-relative entry file path. */
   file: string;

--- a/scripts/interface-parity.ts
+++ b/scripts/interface-parity.ts
@@ -9,7 +9,7 @@
  * single-sided edit fails CI here instead of silently forking the contract.
  *
  * This is the mirror of `sparql-engine`'s own `test/interface-parity.ts`, which
- * guards the reverse direction (sparql-engine diffs against @worlds/client).
+ * guards the reverse direction (sparql-engine diffs against @worlds/sdk).
  */
 
 const SPARQL_INTERFACE_URL =

--- a/skills/worlds-sdk-ts-onboarding/README.md
+++ b/skills/worlds-sdk-ts-onboarding/README.md
@@ -1,6 +1,6 @@
 # Worlds client onboarding
 
-Welcome to the onboarding flow for `@worlds/client`. This skill is designed to
+Welcome to the onboarding flow for `@worlds/sdk`. This skill is designed to
 guide you through setting up your environment, running examples, executing
 tests, and understanding the core architecture.
 
@@ -13,8 +13,8 @@ Follow these steps to run the onboarding skill with your AI coding assistant:
 First, clone or fork the repository to your local system:
 
 ```bash
-git clone https://github.com/wazootech/worlds-client-ts.git
-cd worlds-client-ts
+git clone https://github.com/wazootech/worlds-sdk-ts.git
+cd worlds-sdk-ts
 ```
 
 ### Open in your AI-assisted editor
@@ -29,8 +29,8 @@ onboarding skill or guide you using the instructions in the [SKILL.md](SKILL.md)
 file. For example, you can tell the assistant:
 
 > "Please load the onboarding skill from
-> `skills/worlds-client-ts-onboarding/SKILL.md` and guide me through the
-> onboarding workflow."
+> `skills/worlds-sdk-ts-onboarding/SKILL.md` and guide me through the onboarding
+> workflow."
 
 The AI agent will adopt the persona of Ethan (the lead developer) and walk you
 step-by-step through environment verification, example execution, and key

--- a/skills/worlds-sdk-ts-onboarding/REFERENCE.md
+++ b/skills/worlds-sdk-ts-onboarding/REFERENCE.md
@@ -1,6 +1,6 @@
 # Codebase reference and introduction
 
-This document provides a high-level walkthrough of the `@worlds/client`
+This document provides a high-level walkthrough of the `@worlds/sdk`
 architecture, listing the key entry points, testing procedures, and the
 front-to-back integration plan.
 
@@ -82,16 +82,16 @@ pull JSR packages directly into Node.js, Bun, or Yarn environments:
 
 ```bash
 # Node.js projects
-npx jsr add @worlds/client
+npx jsr add @worlds/sdk
 
 # Bun projects
-bunx jsr add @worlds/client
+bunx jsr add @worlds/sdk
 
 # Yarn projects
-yarn dlx jsr add @worlds/client
+yarn dlx jsr add @worlds/sdk
 
 # Pnpm projects
-pnpm dlx jsr add @worlds/client
+pnpm dlx jsr add @worlds/sdk
 ```
 
 This automates compiler bindings and resolves dependencies cleanly for modern

--- a/skills/worlds-sdk-ts-onboarding/SKILL.md
+++ b/skills/worlds-sdk-ts-onboarding/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: worlds-client-ts-onboarding
+name: worlds-sdk-ts-onboarding
 description: Onboard new contributors to the wazoo-worlds codebase by guiding them through installation, running examples, understanding the client architecture, and troubleshooting common environment and runtime errors. Use when a contributor needs to set up their development environment, run demo scripts or tests, understand client or store concepts, or debug runtime gotchas in the wazoo-worlds repository.
 ---
 
@@ -62,9 +62,9 @@ they are ready to proceed.
 - Explain that the goal is to build new full-stack projects and peripherals on
   top of the worlds ecosystem using this client library.
 - Explain how to install the JSR package in new JavaScript/TypeScript projects:
-  - Node: `npx jsr add @worlds/client`
-  - Bun: `bunx jsr add @worlds/client`
-  - Yarn: `yarn dlx jsr add @worlds/client`
+  - Node: `npx jsr add @worlds/sdk`
+  - Bun: `bunx jsr add @worlds/sdk`
+  - Yarn: `yarn dlx jsr add @worlds/sdk`
 - Tell them: "Let's do it! Now that we know the client fundamentals, let's build
   the "Worlds" ecosystem!"
 
@@ -72,9 +72,8 @@ they are ready to proceed.
 
 - **Certified**: Upon completing the final stage, congratulate them!
 - **Open issue hunter**: If the user has the `gh` cli installed, then use it to
-  list the open issues on `wazootech/worlds-client-ts` (specifically
-  prioritizing those labeled `good first issue`) to find conducive, proactive
-  next steps.
+  list the open issues on `wazootech/worlds-sdk-ts` (specifically prioritizing
+  those labeled `good first issue`) to find conducive, proactive next steps.
 
 ### [Celebratory ASCII art](https://patorjk.com/software/taag/#p=display&f=ANSI+Shadow&t=Worlds)
 

--- a/skills/worlds-sdk-ts-onboarding/TROUBLESHOOTING.md
+++ b/skills/worlds-sdk-ts-onboarding/TROUBLESHOOTING.md
@@ -74,7 +74,7 @@ Are your changes rejected by the CI formatting pipeline?
 
 ```
 Are you getting import resolution errors during local test execution or when doing a dry-run publish?
-  ├── [Yes] ──> Search modified files under 'src/' in the workspace for imports starting with '@worlds/client'
+  ├── [Yes] ──> Search modified files under 'src/' in the workspace for imports starting with '@worlds/sdk'
   │               ├── [Found] ──> Replace them with relative imports or '@/' (e.g. '@/client/quad-store/mod.ts').
   │               └── [None]  ──> Run: deno task publish:dry to check export maps in workspace deno.json.
   └── [No]  ──> Continue setup.
@@ -82,7 +82,7 @@ Are you getting import resolution errors during local test execution or when doi
 
 ### Symptoms
 
-- Errors such as: `export '...' not found in jsr:@worlds/client` or
+- Errors such as: `export '...' not found in jsr:@worlds/sdk` or
   `unresolvable 'jsr:' dependency`.
 - JSR publish dry-run fails with diagnostic errors.
 
@@ -92,8 +92,8 @@ Are you getting import resolution errors during local test execution or when doi
 Integrating this client into a new project or checking out console prior art?
   ├── [Step 1] ──> Initialize your Node/Bun project or checkout the prior art repository.
   ├── [Step 2] ──> In the project directory, run:
-  │                  ├── [Using Node/npm] ──> npx jsr add @worlds/client
-  │                  ├── [Using Bun]      ──> bunx jsr add @worlds/client
-  │                  └── [Using Yarn]     ──> yarn dlx jsr add @worlds/client
+  │                  ├── [Using Node/npm] ──> npx jsr add @worlds/sdk
+  │                  ├── [Using Bun]      ──> bunx jsr add @worlds/sdk
+  │                  └── [Using Yarn]     ──> yarn dlx jsr add @worlds/sdk
   └── [Step 3] ──> Import and configure the Client to start building your application.
 ```


### PR DESCRIPTION
Renames the embeddable client package to `@worlds/sdk` (repo `worlds-sdk-ts`), freeing the `worlds-client-ts` / `@worlds/client` name for the generated data-plane HTTP client (mirroring `wazoo-api`/`wazoo-client-ts`).

- `deno.json`: name `@worlds/client` → `@worlds/sdk`, version `0.0.19` → `0.1.0` (breaking rename; export subpaths unchanged).
- README, ARCHITECTURE, AGENTS, CHANGELOG, examples, and the onboarding skill updated to the new package/repo names.
- **Merging this PR triggers `publish.yml` → publishes `@worlds/sdk@0.1.0` to JSR.**

Verified locally: `deno task ci` green (72 passed, 0 failed, 1 ignored), `deno task publish:dry` passes.