### PR TITLE
docs: point sibling repo path at workspace harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,8 +13,8 @@ docs/api.json
 docs.json
 transcript.md
 
-# Local multi-repo workspace spillover belongs under
-# C:\Users\ethan\Documents\GitHub\wazootech, not inside this package repo.
+# Local multi-repo workspace spillover belongs under the workspace repos/ dir
+# (wazootech/workspace harness checkout), not inside this package repo.
 _console-worktrees/
 _wazoo-*/
 _worlds-*/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,19 +9,18 @@ all AI Agents writing code in this repository.
 ## Workspace boundary
 
 This repository is the lean `@worlds/sdk` package, not the Wazoo multi-repo
-workspace. Sibling Wazoo repositories MUST live under
-`C:\Users\ethan\Documents\GitHub\wazootech`.
+workspace. Sibling Wazoo repositories MUST live under `<workspace>/repos/` (the
+`wazootech/workspace` harness checkout; run `deno task workspace:check` from the
+workspace root).
 
 Before working across Wazoo repositories:
 
 1. Identify the exact repository in scope.
-2. Use the existing clone under
-   `C:\Users\ethan\Documents\GitHub\wazootech\<repo-name>`.
-3. If the clone is missing, create or restore it under the `wazootech` workspace
-   root, never inside this package repo.
-4. Run the parent workspace baseline checker from
-   `C:\Users\ethan\Documents\GitHub\wazootech`:
-   `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\check-repo-baselines.ps1`.
+2. Use the existing clone under `<workspace>/repos/<repo-name>`.
+3. If the clone is missing, create or restore it under `<workspace>/repos/`,
+   never inside this package repo.
+4. Run the parent workspace baseline checker from the workspace root:
+   `deno task workspace:check`.
 
 Do not clone, copy, scaffold, or create worktrees for sibling projects inside
 this repository. Local spillover folders such as `_wazoo-*`, `_worlds-*`,


### PR DESCRIPTION
Fixes the workspace-boundary section and .gitignore comment that referenced the stale \C:\Users\ethan\Documents\GitHub\wazootech\ path. The canonical sibling checkout is now \<workspace>/repos/\ with \deno task workspace:check\ as the baseline checker.