### PR TITLE
chore: release @worlds/sdk 0.3.0 (breaking; removes durable-backend subpath)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.3.0
 
 ### Breaking
 
@@ -14,6 +14,18 @@
   The concrete classes live on as private worlds-libsql vocabulary
   (`LibsqlConnectionDriver` / `LibsqlSchemaBuilder` /
   `LibsqlSearchQueryBuilder`).
+
+## 0.2.1
+
+### Added
+
+- Added the `@worlds/sdk/durable-backend` subpath (types-only provider-seam
+  strategy interfaces). Shipped briefly, then de-escalated and removed in 0.3.0.
+
+## 0.2.0
+
+### Breaking
+
 - Renamed the public facade symbols to match the `@worlds/sdk` package (resolves
   [worlds-sdk-ts#169](https://github.com/wazootech/worlds-sdk-ts/issues/169)):
   `Client` → `Sdk`, `ClientInterface` → `SdkInterface`, `ClientOptions` →

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@worlds/sdk",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "nodeModulesDir": "auto",
   "exports": {
     ".": "./src/mod.ts",


### PR DESCRIPTION
Release @worlds/sdk@0.3.0 (breaking) per worlds-sdk-ts#170. The @worlds/sdk/durable-backend subpath shipped in 0.2.1 is removed from the published package; the concrete seam classes live on as private worlds-libsql vocabulary (\LibsqlConnectionDriver\ / \LibsqlSchemaBuilder\ / \LibsqlSearchQueryBuilder\).

- Bump version \