### PR TITLE
docs: mark the @worlds/denokv backend as archived across SDK docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,17 +41,17 @@ the client-side edge semantic environments:
 ### Graph store
 
 The in-memory RDF surface used by adapters and the SPARQL engine (the Wazoo
-engine). Durable backends (LibSQL/Turso, Deno KV) query **persistent hexastore**
-stores (`LibsqlRdfjsStore`, `DenokvRdfjsStore`) in their respective packages.
-This package provides the engine's zero-dependency `MemoryStore` for local
-development and tests.
+engine). Durable backends (LibSQL/Turso) query **persistent hexastore** stores
+(`LibsqlRdfjsStore`) in their respective packages. The Deno KV backend
+(`@worlds/denokv`, `DenokvRdfjsStore`) is
+[archived](https://github.com/wazootech/worlds-denokv). This package provides
+the engine's zero-dependency `MemoryStore` for local development and tests.
 
 ### Durable reads vs in-memory MemoryStore
 
 **In-memory RDF/JS** (`RdfjsQuadStore` over the engine's `MemoryStore`) is the
 intentional local-dev and test topology in this package. Durable backends
-([`@worlds/libsql`](https://github.com/wazootech/worlds-libsql),
-[`@worlds/denokv`](https://github.com/wazootech/worlds-denokv)) wire hexastore
+([`@worlds/libsql`](https://github.com/wazootech/worlds-libsql)) wire hexastore
 `*RdfjsStore` implementations and read durable indexes directly with no
 per-query in-memory mirror. Historical **libsql-n3** (hydrate durable quads into
 an N3 store, then query) was removed; see [CHANGELOG.md](CHANGELOG.md) and
@@ -189,15 +189,16 @@ When adding a new importable subpath, add it to `exports` in `deno.json` for
 in-repo imports (no duplicate `@worlds/sdk/*` entries in `imports`). Shared
 topology-agnostic patch buffering lives in `rdfjs-buffer/` (export
 `@worlds/sdk/quad-store`). Durable adapter `*RdfjsStore` implementations live in
-the external [`@worlds/libsql`](https://github.com/wazootech/worlds-libsql) and
-[`@worlds/denokv`](https://github.com/wazootech/worlds-denokv) repositories.
+the external [`@worlds/libsql`](https://github.com/wazootech/worlds-libsql)
+repository.
 
 ### Packaging and dependency resolution rationale
 
 This package ships only the core client abstractions and the in-memory RDF/JS
-backend. Durable backends (LibSQL/Turso, Deno KV) are published as separate JSR
-packages: [`@worlds/libsql`](https://github.com/wazootech/worlds-libsql) and
-[`@worlds/denokv`](https://github.com/wazootech/worlds-denokv).
+backend. Durable backends (LibSQL/Turso) are published as separate JSR packages:
+[`@worlds/libsql`](https://github.com/wazootech/worlds-libsql). The Deno KV
+backend (`@worlds/denokv`) is
+[archived](https://github.com/wazootech/worlds-denokv).
 
 This package relies on Deno/JSR's source-based publishing and dynamic runtime
 resolution:
@@ -289,9 +290,8 @@ green-passing integration pipeline runs:
   formats, and passes operational invariants without errors prior to opening
   pull requests.
 
-- **Local benchmarks only:** Benchmark suites live in the adapter repos
-  ([`@worlds/libsql`](https://github.com/wazootech/worlds-libsql),
-  [`@worlds/denokv`](https://github.com/wazootech/worlds-denokv)) and in
+- **Local benchmarks only:** Benchmark suites live in the adapter repo
+  ([`@worlds/libsql`](https://github.com/wazootech/worlds-libsql)) and in
   [discussion #69](https://github.com/wazootech/worlds-sdk-ts/discussions/69).
   There is no CI benchmark regression gate in this repo.
 
@@ -320,22 +320,18 @@ green-passing integration pipeline runs:
 
 Public graph persistence facades must use explicit suffixes:
 
-- **`*RdfjsStore`** — implements `rdfjs.Store` (e.g. `LibsqlRdfjsStore`,
-  `DenokvRdfjsStore`). File name: `rdfjs-store/libsql-rdfjs-store.ts`.
+- **`*RdfjsStore`** — implements `rdfjs.Store` (e.g. `LibsqlRdfjsStore`). File
+  name: `rdfjs-store/libsql-rdfjs-store.ts`.
 - **`*QuadStore`** — implements `QuadStoreInterface` (e.g. `LibsqlQuadStore`,
-  `DenokvQuadStore`, in-memory `RdfjsQuadStore`). File name:
-  `quad-store/libsql-quad-store.ts`.
-- **No bare `*Store`** names on public graph classes (`LibsqlStore`,
-  `DenokvStore`).
+  in-memory `RdfjsQuadStore`). File name: `quad-store/libsql-quad-store.ts`.
+- **No bare `*Store`** names on public graph classes (`LibsqlStore`).
 
-LibSQL: `client.import` → `LibsqlQuadStore` → `LibsqlRdfjsStore.commit()`. Deno
-KV: `client.import` → `DenokvQuadStore` (native KV bulk path). Both use
-`*RdfjsStore` for the SPARQL engine (Wazoo). Advanced assembly uses explicit
+LibSQL: `client.import` → `LibsqlQuadStore` → `LibsqlRdfjsStore.commit()`.
+Advanced assembly uses explicit
 `new Sdk({ quadStore, searchIndex, sparqlEngine? })` with the suffixed stores.
 
-> These conventions apply to the durable adapter repos
-> ([`@worlds/libsql`](https://github.com/wazootech/worlds-libsql),
-> [`@worlds/denokv`](https://github.com/wazootech/worlds-denokv)). This package
+> These conventions apply to the durable adapter repo
+> ([`@worlds/libsql`](https://github.com/wazootech/worlds-libsql)). This package
 > only ships the in-memory `RdfjsQuadStore` and `RdfjsSearchIndex`.
 
 ## Architecture

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -25,11 +25,14 @@ backend. Durable backends are published as separate packages.
 | Package                                                                                                | Persistence          | Search               |
 | ------------------------------------------------------------------------------------------------------ | -------------------- | -------------------- |
 | [`@worlds/libsql`](https://jsr.io/@worlds/libsql) ([repo](https://github.com/wazootech/worlds-libsql)) | SQLite / Turso Cloud | Hybrid FTS5 + vector |
-| [`@worlds/denokv`](https://jsr.io/@worlds/denokv) ([repo](https://github.com/wazootech/worlds-denokv)) | Deno KV              | Keyword FTS          |
+
+The Deno KV backend (`@worlds/denokv`) is
+[archived](https://github.com/wazootech/worlds-denokv); `@worlds/libsql` is the
+supported durable backend.
 
 Durable backends implement the same quad store, search index, and SPARQL
-interfaces. Each backend ships its own factory (`createLibsqlClient`,
-`createDenokvClient`) that assembles a `Sdk` internally.
+interfaces. The LibSQL backend ships its own factory (`createLibsqlClient`) that
+assembles a `Sdk` internally.
 
 ## Runtime model
 
@@ -78,8 +81,6 @@ implementations inside the factory:
 
 ```typescript
 import { createLibsqlClient } from "@worlds/libsql";
-// or
-import { createDenokvClient } from "@worlds/denokv";
 ```
 
 The factory returns the same `SdkInterface` contract. Application code never
@@ -132,9 +133,9 @@ The single engine shipped today is:
   the opinionated minimal default. It is a zero-runtime-dependency SPARQL 1.1 &
   1.2 engine that implements `SparqlEngineInterface`, drops into a `Sdk`
   unchanged, and runs over any `rdfjs.Store` (the engine's `MemoryStore` here;
-  `LibsqlRdfjsStore` / `DenokvRdfjsStore` in the durable backends). It covers
-  SELECT / ASK / CONSTRUCT / DESCRIBE plus UPDATE, enforces `timeoutMs`, and
-  accepts a request-level `baseIri`.
+  `LibsqlRdfjsStore` in the LibSQL backend). It covers SELECT / ASK / CONSTRUCT
+  / DESCRIBE plus UPDATE, enforces `timeoutMs`, and accepts a request-level
+  `baseIri`.
 
 A custom engine remains feasible through `SparqlEngineInterface`.
 
@@ -162,12 +163,12 @@ review live here, indexed by the wayfinder map
 shape of a durable backend**, types-only. Review (2026-08-18) concluded the seam
 is premature public abstraction (YAGNI):
 
-- **Zero published consumers.** The only JSR dependents of `@worlds/sdk` are
-  `@worlds/denokv` and `@worlds/libsql`, and neither imports the subpath. The
-  seam's only planned consumer was the in-flight worlds-libsql#17.
+- **Zero published consumers.** The only JSR dependent of `@worlds/sdk` is
+  `@worlds/libsql`, and it does not import the subpath. The seam's only planned
+  consumer was the in-flight worlds-libsql#17.
 - **No evidence-backed future adoption.** The parked backends (`@worlds/sqlite`,
-  `@worlds/postgres`, `@worlds/denokv`) are built and shipping on raw provider
-  clients; conforming later would be a rewrite.
+  `@worlds/postgres`) are built and shipping on raw provider clients; conforming
+  later would be a rewrite. `@worlds/denokv` is archived.
 - **The sdk ships zero SQL.** A published vocabulary contract with one consumer
   is premature public abstraction.
 
@@ -183,9 +184,9 @@ subpath to `@worlds/sdk` in review. Supersedes the seam decisions recorded in
 ## Non-goals
 
 - `@worlds/sdk` does not include a hosted Wazoo API client.
-- Durable/immediate persistent backends (LibSQL, Deno KV) are not implemented
-  inside this package. They ship in separate JSR packages with different
-  lifecycle and dependency profiles.
+- Durable/immediate persistent backends (LibSQL) are not implemented inside this
+  package. They ship in separate JSR packages with different lifecycle and
+  dependency profiles.
 - Provider-specific embedding implementations (e.g. OpenAI, Anthropic,
   Gemini-specific embedding code) should not be added to the core package unless
   they are intentionally exported abstractions.

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
   <a href="https://deepwiki.com/wazootech/worlds-sdk-ts"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki" /></a>
 </p>
 
-- **Portable facade** — Unified `Sdk` API that works across in-memory,
-  LibSQL/Turso, and Deno KV backends.
+- **Portable facade** — Unified `Sdk` API that works across in-memory and
+  LibSQL/Turso backends.
 - **Search** — Hybrid retrieval combining keyword FTS5 and vector embeddings.
 - **Query** — The zero-dependency Wazoo SPARQL engine as the opinionated minimal
   default.
@@ -59,8 +59,10 @@ console.log(sparqlResponse);
 ```
 
 > [!TIP]
-> For production search and scale, use the durable LibSQL (`@worlds/libsql`) or
-> Deno KV (`@worlds/denokv`) backends.
+> For production search and scale, use the durable LibSQL backend
+> (`@worlds/libsql`). The Deno KV backend (`@worlds/denokv`) is
+> [archived](https://github.com/wazootech/worlds-denokv); use `@worlds/libsql`
+> instead.
 
 ## Core concepts
 
@@ -105,11 +107,13 @@ in separate packages:
 | ------------------------------------------------------------------------------------------------------ | ------------------------- | -------------------- | ----------------------------- |
 | `@worlds/sdk` (this package)                                                                           | In-memory (`MemoryStore`) | RDF/JS keyword       | Wazoo                         |
 | [`@worlds/libsql`](https://jsr.io/@worlds/libsql) ([repo](https://github.com/wazootech/worlds-libsql)) | SQLite / Turso Cloud      | Hybrid FTS5 + vector | LibsqlRdfjsStore quad indexes |
-| [`@worlds/denokv`](https://jsr.io/@worlds/denokv) ([repo](https://github.com/wazootech/worlds-denokv)) | Deno KV                   | Keyword FTS          | DenokvRdfjsStore quad indexes |
 
-**Choosing LibSQL vs Deno KV:** LibSQL is the default for hybrid FTS/vector
-search and faster cold quad index preload at scale. Deno KV can be faster on
-selective SPARQL execute after preload in long-lived or cached processes. See
+The Deno KV backend (`@worlds/denokv`) is
+[archived](https://github.com/wazootech/worlds-denokv); LibSQL is the supported
+durable backend.
+
+**Choosing persistence:** LibSQL is the default for hybrid FTS/vector search and
+faster cold quad index preload at scale. See
 [discussion #69](https://github.com/wazootech/worlds-sdk-ts/discussions/69) for
 benchmark methodology.
 
@@ -135,9 +139,8 @@ const client = new Sdk({
 | Hello world | In-memory graph with search     | `deno task example:hello-world`        |
 | AI SDK      | Vercel AI SDK tools with Gemini | `deno task example:ai-sdk-hello-world` |
 
-For LibSQL or Deno KV examples, see the
-[`@worlds/libsql`](https://github.com/wazootech/worlds-libsql) and
-[`@worlds/denokv`](https://github.com/wazootech/worlds-denokv) repositories.
+For LibSQL examples, see the
+[`@worlds/libsql`](https://github.com/wazootech/worlds-libsql) repository.
 
 Agent evaluation and memory benchmarking lives in the separate
 [wazoo-memorybench](https://github.com/wazootech/wazoo-memorybench) repository,
@@ -149,10 +152,9 @@ successor to the archived worlds-client-evals eval harness.
 hybrid retrieval. See [AGENTS.md](AGENTS.md) and
 [ARCHITECTURE.md](ARCHITECTURE.md).
 
-**LibSQL/Deno KV benchmarks**: Quad index performance methodology, regression
-policy, and comparison tables live in the adapter repos
-([`@worlds/libsql`](https://github.com/wazootech/worlds-libsql),
-[`@worlds/denokv`](https://github.com/wazootech/worlds-denokv)).
+**LibSQL benchmarks**: Quad index performance methodology, regression policy,
+and comparison tables live in the
+[`@worlds/libsql`](https://github.com/wazootech/worlds-libsql) adapter repo.
 
 ## Development workflow
 

--- a/skills/worlds-sdk-ts-onboarding/SKILL.md
+++ b/skills/worlds-sdk-ts-onboarding/SKILL.md
@@ -46,9 +46,10 @@ they are ready to proceed.
 
 ### Durable edge persistence
 
-- Explain that durable backends (LibSQL, Deno KV) live in separate packages:
-  [`@worlds/libsql`](https://github.com/wazootech/worlds-libsql) and
-  [`@worlds/denokv`](https://github.com/wazootech/worlds-denokv).
+- Explain that the durable LibSQL backend lives in a separate package:
+  [`@worlds/libsql`](https://github.com/wazootech/worlds-libsql). The Deno KV
+  backend (`@worlds/denokv`) is
+  [archived](https://github.com/wazootech/worlds-denokv).
 - Explain selective/grounded SPARQL query shapes vs full-scan queries.
 
 ### Environment verification


### PR DESCRIPTION
Reflects the archival of wazootech/worlds-denokv. Updates README, ARCHITECTURE, AGENTS, and the onboarding skill so the supported durable backend is LibSQL only, with archived pointers for Deno KV. CHANGELOG is left untouched (historical record).