### PR TITLE
docs: update backend factory name to createLibsqlSdk

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -388,7 +388,7 @@ Built-in label predicates (`rdfs:label`, `skos:prefLabel`, `schema:name`) are
 always indexed. Extend with `labelPredicates` on adapter options:
 
 ```typescript
-await createLibsqlClient({
+await createLibsqlSdk({
   client: db,
   labelPredicates: ["http://example.org/customLabel"],
 });

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -31,7 +31,7 @@ The Deno KV backend (`@worlds/denokv`) is
 supported durable backend.
 
 Durable backends implement the same quad store, search index, and SPARQL
-interfaces. The LibSQL backend ships its own factory (`createLibsqlClient`) that
+interfaces. The LibSQL backend ships its own factory (`createLibsqlSdk`) that
 assembles a `Sdk` internally.
 
 ## Runtime model
@@ -80,7 +80,7 @@ Durable backends wrap their own `*QuadStore`, `*SearchIndex`, and `*RdfjsStore`
 implementations inside the factory:
 
 ```typescript
-import { createLibsqlClient } from "@worlds/libsql";
+import { createLibsqlSdk } from "@worlds/libsql";
 ```
 
 The factory returns the same `SdkInterface` contract. Application code never


### PR DESCRIPTION
Updates the @worlds/sdk durable backend factory name from createLibsqlClient to createLibsqlSdk following the @worlds/libsql 0.3.0 rename. Drop-in doc-only change.