### PR TITLE
docs: drop archived commitPatchToDenokv from comment

### DIFF
--- a/src/client/quad-store/rdf-formats.ts
+++ b/src/client/quad-store/rdf-formats.ts
@@ -120,7 +120,7 @@ export function exportQuadsResponse(
 /**
  * awaitDrainRemoveMatches waits for removeMatches(null, null, null, null) to finish.
  * Used by createRdfjsStoreCommitHandler for replace import commits; durable backends
- * honor isReplaceImportCommit in commitPatchToLibsql and commitPatchToDenokv.
+ * honor isReplaceImportCommit in their commit patch handlers.
  */
 export function awaitDrainRemoveMatches(
   store: rdfjs.Store,


### PR DESCRIPTION
The `commitPatchToDenokv` handler lives in the archived `@worlds/denokv` package, not this repo. Softens the `awaitDrainRemoveMatches` doc comment to reference durable backends' commit patch handlers generally. Comment-only change; `deno fmt --check` passes.