### PR TITLE
docs: add durable-backend maturity ladder to README and ARCHITECTURE

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -22,13 +22,20 @@ backend. Durable backends are published as separate packages.
 
 ### External durable backends
 
-| Package                                                                                                | Persistence          | Search               |
-| ------------------------------------------------------------------------------------------------------ | -------------------- | -------------------- |
-| [`@worlds/libsql`](https://jsr.io/@worlds/libsql) ([repo](https://github.com/wazootech/worlds-libsql)) | SQLite / Turso Cloud | Hybrid FTS5 + vector |
+| Package                                                                                                      | Persistence                | Search                       | Status                                            |
+| ------------------------------------------------------------------------------------------------------------ | -------------------------- | ---------------------------- | ------------------------------------------------- |
+| [`@worlds/libsql`](https://jsr.io/@worlds/libsql) ([repo](https://github.com/wazootech/worlds-libsql))       | SQLite / Turso Cloud       | Hybrid FTS5 + vector         | **Beta — full SDK factory** (`createLibsqlSdk`)   |
+| [`@worlds/sqlite`](https://jsr.io/@worlds/sqlite) ([repo](https://github.com/wazootech/worlds-sqlite))       | Local file (`node:sqlite`) | — (Layer 2 parked)           | Parked post-beta — `SqliteStore` only, no factory |
+| [`@worlds/postgres`](https://jsr.io/@worlds/postgres) ([repo](https://github.com/wazootech/worlds-postgres)) | PostgreSQL + pgvector      | Hybrid FTS5 + vector (store) | Parked post-beta — raw stores only, no factory    |
+| [`worlds-cloudflare`](https://github.com/wazootech/worlds-cloudflare) (no package yet)                       | — (D1 planned)             | — (Vectorize planned)        | Scaffold only — nothing shipped                   |
 
 The Deno KV backend (`@worlds/denokv`) is
 [archived](https://github.com/wazootech/worlds-denokv); `@worlds/libsql` is the
-supported durable backend.
+supported durable backend. Backend maturity: of the durable backend packages,
+only `@worlds/libsql` ships a full SDK factory today; `@worlds/sqlite`,
+`@worlds/postgres`, and `@worlds/cloudflare` are parked post-beta (see the
+[de-escalated durable-backend seam decision](#durable-backend-seam-removed-from-worldssdk-de-escalated)
+below).
 
 Durable backends implement the same quad store, search index, and SPARQL
 interfaces. The LibSQL backend ships its own factory (`createLibsqlSdk`) that

--- a/README.md
+++ b/README.md
@@ -103,14 +103,19 @@ conventions, see [AGENTS.md](AGENTS.md).
 This package provides the core in-memory RDF/JS backend. Durable backends live
 in separate packages:
 
-| Package                                                                                                | Persistence               | Search               | SPARQL                        |
-| ------------------------------------------------------------------------------------------------------ | ------------------------- | -------------------- | ----------------------------- |
-| `@worlds/sdk` (this package)                                                                           | In-memory (`MemoryStore`) | RDF/JS keyword       | Wazoo                         |
-| [`@worlds/libsql`](https://jsr.io/@worlds/libsql) ([repo](https://github.com/wazootech/worlds-libsql)) | SQLite / Turso Cloud      | Hybrid FTS5 + vector | LibsqlRdfjsStore quad indexes |
+| Package                                                                                                      | Persistence                | Search                       | Status                                            |
+| ------------------------------------------------------------------------------------------------------------ | -------------------------- | ---------------------------- | ------------------------------------------------- |
+| `@worlds/sdk` (this package)                                                                                 | In-memory (`MemoryStore`)  | RDF/JS keyword               | Core client + in-memory backend                   |
+| [`@worlds/libsql`](https://jsr.io/@worlds/libsql) ([repo](https://github.com/wazootech/worlds-libsql))       | SQLite / Turso Cloud       | Hybrid FTS5 + vector         | **Beta — full SDK factory** (`createLibsqlSdk`)   |
+| [`@worlds/sqlite`](https://jsr.io/@worlds/sqlite) ([repo](https://github.com/wazootech/worlds-sqlite))       | Local file (`node:sqlite`) | — (Layer 2 parked)           | Parked post-beta — `SqliteStore` only, no factory |
+| [`@worlds/postgres`](https://jsr.io/@worlds/postgres) ([repo](https://github.com/wazootech/worlds-postgres)) | PostgreSQL + pgvector      | Hybrid FTS5 + vector (store) | Parked post-beta — raw stores only, no factory    |
+| [`worlds-cloudflare`](https://github.com/wazootech/worlds-cloudflare) (no package yet)                       | — (D1 planned)             | — (Vectorize planned)        | Scaffold only — nothing shipped                   |
 
-The Deno KV backend (`@worlds/denokv`) is
-[archived](https://github.com/wazootech/worlds-denokv); LibSQL is the supported
-durable backend.
+**Backend maturity:** Of the durable backend packages, only `@worlds/libsql`
+ships a full SDK factory today; `@worlds/sqlite`, `@worlds/postgres`, and
+`@worlds/cloudflare` are parked post-beta. The Deno KV backend
+(`@worlds/denokv`) is [archived](https://github.com/wazootech/worlds-denokv);
+use `@worlds/libsql`.
 
 **Choosing persistence:** LibSQL is the default for hybrid FTS/vector search and
 faster cold quad index preload at scale. See


### PR DESCRIPTION
Carries the same one-line status ladder as docs.wazoo.dev (self-host page): only `@worlds/libsql` ships a full SDK factory today; `@worlds/sqlite`, `@worlds/postgres`, and `@worlds/cloudflare` are parked post-beta.

- **README.md** — Adapters table gains a Status column and lists all durable backends (libsql beta baseline; sqlite store-only; postgres raw stores only; cloudflare scaffold), plus the maturity one-liner.
- **ARCHITECTURE.md** — External durable backends table mirrors the same ladder, with a pointer to the de-escalated seam decision record.

Docs-only; no source changes.