### PR TITLE
feat: @worlds/sdk/testing parity harness + @worlds/sdk/memory reference

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@worlds/sdk",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "nodeModulesDir": "auto",
   "exports": {
     ".": "./src/mod.ts",
@@ -11,7 +11,9 @@
     "./sparql-engine": "./src/client/sparql-engine/mod.ts",
     "./tfjs-universal-sentence-encoder": "./src/tfjs-universal-sentence-encoder/mod.ts",
     "./rdfjs": "./src/rdfjs/mod.ts",
-    "./ai-sdk": "./src/ai-sdk/mod.ts"
+    "./memory": "./src/memory/mod.ts",
+    "./ai-sdk": "./src/ai-sdk/mod.ts",
+    "./testing": "./src/testing/mod.ts"
   },
   "imports": {
     "@/": "./src/",

--- a/src/memory/create-memory-sdk.test.ts
+++ b/src/memory/create-memory-sdk.test.ts
@@ -1,0 +1,60 @@
+import { assertEquals } from "@std/assert";
+import { createMemorySdk } from "./create-memory-sdk.ts";
+
+const SEED = [
+  '<urn:alice> <urn:likes> "sailing"@en .',
+  '<urn:alice> <urn:age> "42"^^<http://www.w3.org/2001/XMLSchema#integer> .',
+  '<urn:alice> <urn:posts> "a public note" <urn:graph:public> .',
+].join("\n");
+
+Deno.test("createMemorySdk — import → search → SELECT → ASK → reindex end to end", async () => {
+  const sdk = createMemorySdk();
+
+  await sdk.import({
+    source: {
+      kind: "serialized",
+      data: SEED,
+      contentType: "application/n-quads",
+    },
+  });
+
+  const search = await sdk.search({ query: "public" });
+  assertEquals(search.results?.length, 1);
+  assertEquals(search.results?.[0].text, "a public note");
+
+  const select = await sdk.sparql({
+    query: "SELECT ?o WHERE { <urn:alice> <urn:age> ?o }",
+  });
+  if (select.kind !== "select") throw new Error("Expected select");
+  assertEquals(select.data.results.bindings.length, 1);
+  assertEquals(
+    select.data.results.bindings[0].o?.value,
+    "42",
+  );
+
+  const ask = await sdk.sparql({
+    query: "ASK WHERE { GRAPH <urn:graph:public> { ?s ?p ?o } }",
+  });
+  if (ask.kind !== "ask") throw new Error("Expected ask");
+  assertEquals(ask.data.boolean, true);
+
+  const reindex = await sdk.reindex();
+  assertEquals(reindex.processedQuadCount, 3);
+});
+
+Deno.test("createMemorySdk — each call returns an independent fresh topology", async () => {
+  const first = createMemorySdk();
+  const second = createMemorySdk();
+
+  await first.import({
+    source: {
+      kind: "serialized",
+      data: SEED,
+      contentType: "application/n-quads",
+    },
+  });
+
+  const secondExport = await second.export({ format: { kind: "quads" } });
+  if (secondExport.kind !== "quads") throw new Error("Expected quads");
+  assertEquals(secondExport.quads.length, 0, "second Sdk must start empty");
+});

--- a/src/memory/create-memory-sdk.ts
+++ b/src/memory/create-memory-sdk.ts
@@ -1,0 +1,28 @@
+import { Sdk } from "@/client/client.ts";
+import { RdfjsQuadStore, RdfjsSearchIndex } from "@/rdfjs/mod.ts";
+import { MemoryStore, WazooSparqlEngine } from "@wazoo/sparql-engine";
+
+/**
+ * createMemorySdk builds a portable in-memory Worlds Sdk backed by the Wazoo
+ * engine's MemoryStore (the in-memory baseline, per the durable-backend map's
+ * consolidation decision, wazootech/workspace#74).
+ *
+ * It is the shared parity reference and proving ground for the family: the
+ * @worlds/sdk/testing harness (runParitySuite) and every backend's phase-4
+ * parity suite can use it as a zero-dependency, in-memory reference — no
+ * libsql checkout or private test double required. It wires the same Sdk
+ * facade the durable backends expose (quad store + SPARQL + search over one
+ * shared RDF/JS store), so a backend that matches it matches the family.
+ *
+ * The store is owned by the Sdk: each call returns an independent, fresh
+ * topology. Use a factory (`() => createMemorySdk()`) where each case needs
+ * an isolated world.
+ */
+export function createMemorySdk(): Sdk {
+  const store = new MemoryStore();
+  return new Sdk({
+    quadStore: new RdfjsQuadStore({ store }),
+    sparqlEngine: new WazooSparqlEngine({ store }),
+    searchIndex: new RdfjsSearchIndex(store),
+  });
+}

--- a/src/memory/mod.ts
+++ b/src/memory/mod.ts
@@ -1,0 +1,9 @@
+/**
+ * The @worlds/sdk/memory subpath exports the portable in-memory Sdk — the
+ * durable-backend family's shared parity reference (wazootech/workspace#74).
+ * createMemorySdk wires the engine's MemoryStore into the standard Sdk facade
+ * (RdfjsQuadStore + RdfjsSearchIndex + WazooSparqlEngine over one shared
+ * store), so the @worlds/sdk/testing harness and every backend's phase-4
+ * parity suite can run against a zero-dependency in-memory reference.
+ */
+export * from "./create-memory-sdk.ts";

--- a/src/testing/mod.ts
+++ b/src/testing/mod.ts
@@ -1,0 +1,15 @@
+/**
+ * The @worlds/sdk/testing subpath is the shared parity harness for the
+ * durable-backend family (per the shared parity/benchmark suite definition,
+ * wazootech/workspace#72). It is a thin driver over the existing Sdk seam —
+ * no new interfaces, no new runtime surface — consumed by backend repos as a
+ * devDependency in their phase-4 parity suites.
+ *
+ * - `parity-fixtures.ts` — the shared fixture corpus (multi-graph worlds,
+ *   typed literals, RDF-star [declared], chunk-boundary texts, empty world,
+ *   replace-mode) as plain N-Quads data.
+ * - `run-parity-suite.ts` — `runParitySuite`, comparing a candidate backend
+ *   against a reference Sdk (libsql) on the corpus.
+ */
+export * from "./parity-fixtures.ts";
+export * from "./run-parity-suite.ts";

--- a/src/testing/parity-fixtures.ts
+++ b/src/testing/parity-fixtures.ts
@@ -1,0 +1,337 @@
+import type { SearchRequest } from "@/client/search-index/mod.ts";
+import type { SparqlValue } from "@/client/sparql-engine/mod.ts";
+
+/**
+ * Parity fixtures are the shared corpus every durable backend runs in its
+ * phase-4 parity suite (per the shared parity/benchmark suite definition,
+ * wazootech/workspace#72). Fixtures are plain data — N-Quads serialized
+ * strings parsed by the engine's TriG-superset grammar — so the corpus is
+ * backend-agnostic and versionable with the seam package.
+ */
+
+/**
+ * SparqlExpectation is a hand-authored SPARQL result for a fixture query.
+ * SPARQL semantics are engine-independent, so these are the reliable
+ * deterministic expectations; search ranking is not (bm25 vs ts_rank_cd vs
+ * vector distance), so search cases are compared candidate-vs-reference
+ * instead of against authored snapshots.
+ */
+export type SparqlExpectation =
+  | { kind: "select"; bindings: Array<Record<string, SparqlValue>> }
+  | { kind: "ask"; boolean: boolean };
+
+/** A search case: the same request runs against both Sdks; results must match. */
+export interface ParitySearchCase {
+  /** name identifies the case in the parity report. */
+  name: string;
+  /** request is the search executed against both Sdks. */
+  request: SearchRequest;
+}
+
+/** A SPARQL case: the query runs against both Sdks and must match the authored expectation. */
+export interface ParitySparqlCase {
+  /** name identifies the case in the parity report. */
+  name: string;
+  /** query is the SPARQL query executed against both Sdks. */
+  query: string;
+  /** expected is the hand-authored result both Sdks must satisfy. */
+  expected: SparqlExpectation;
+}
+
+/**
+ * gate controls corpus strictness:
+ * - "reference" (default): the case must pass on the reference Sdk (libsql)
+ *   and on the candidate. New fixtures default here.
+ * - "declared": the corpus category is declared but the durable reference does
+ *   not support it yet (e.g. RDF-star storage — the backend-neutral Term
+ *   layer still throws "Unsupported term type: Quad"). The case runs and is
+ *   reported, but never fails the suite until the reference lands support.
+ */
+export type ParityGate = "reference" | "declared";
+
+/** ParityFixture is one world in the corpus plus its cases. */
+export interface ParityFixture {
+  /** name identifies the fixture in the parity report. */
+  name: string;
+  /** nquads is the world serialized as N-Quads (engine TriG-superset grammar). */
+  nquads: string;
+  /** totalQuads is the exact quad count after a merge import. */
+  totalQuads: number;
+  /** graphSizes maps graph term values ("" = default graph) to exact quad counts. */
+  graphSizes?: Record<string, number>;
+  /** search compares the candidate's results to the reference's (order-sensitive by default). */
+  search?: ParitySearchCase[];
+  /** sparql runs against both Sdks and must match the authored expectation. */
+  sparql?: ParitySparqlCase[];
+  /** gate controls strictness; defaults to "reference". */
+  gate?: ParityGate;
+}
+
+/** ParityReplaceCase exercises replace-mode imports: `second` must fully replace `first`. */
+export interface ParityReplaceCase {
+  /** name identifies the case in the parity report. */
+  name: string;
+  /** first is imported with replace mode first. */
+  first: string;
+  /** second is imported with replace mode second. */
+  second: string;
+  /** resultCount is the exact quad count after the second replace import. */
+  resultCount: number;
+}
+
+/** ParityCorpus is the full fixture registry consumed by runParitySuite. */
+export interface ParityCorpus {
+  fixtures: ParityFixture[];
+  replaceCases: ParityReplaceCase[];
+}
+
+const XSD = "http://www.w3.org/2001/XMLSchema#";
+
+/**
+ * multiGraphWorld exercises the one-world-many-graphs guarantee
+ * (wazootech/workspace#71): default-graph quads plus named public and private
+ * graphs with overlapping subjects, searchable and queryable per graph.
+ */
+export const multiGraphWorld: ParityFixture = {
+  name: "multiGraphWorld",
+  nquads: [
+    '<urn:alice> <urn:likes> "sailing"@en .',
+    '<urn:alice> <urn:age> "42"^^<' + XSD + "integer> .",
+    '<urn:alice> <urn:posted> "alice wrote a public note" <urn:graph:public> .',
+    '<urn:bob> <urn:posted> "bob is public too" <urn:graph:public> .',
+    '<urn:alice> <urn:stores> "confidential key material for alice" <urn:graph:private> .',
+  ].join("\n"),
+  totalQuads: 5,
+  graphSizes: {
+    "": 2,
+    "urn:graph:public": 2,
+    "urn:graph:private": 1,
+  },
+  search: [
+    {
+      name: "alice across graphs",
+      request: { query: "alice", topK: 10 },
+    },
+    {
+      name: "confidential hits the private graph only",
+      request: { query: "confidential", topK: 10 },
+    },
+    {
+      name: "public scoped to the public graph via QuadFilter",
+      request: {
+        query: "public",
+        topK: 10,
+        include: { graphs: ["urn:graph:public"] },
+      },
+    },
+  ],
+  sparql: [
+    {
+      name: "private-graph subjects",
+      query: "SELECT ?s WHERE { GRAPH <urn:graph:private> { ?s ?p ?o } }",
+      expected: {
+        kind: "select",
+        bindings: [{ s: { type: "uri", value: "urn:alice" } }],
+      },
+    },
+    {
+      name: "ask a public-graph fact",
+      query: "ASK WHERE { GRAPH <urn:graph:public> { <urn:bob> ?p ?o } }",
+      expected: { kind: "ask", boolean: true },
+    },
+    {
+      name: "cross-graph join narrows to alice",
+      query:
+        "SELECT ?s WHERE { GRAPH <urn:graph:public> { ?s <urn:posted> ?o } . GRAPH <urn:graph:private> { ?s <urn:stores> ?x } }",
+      expected: {
+        kind: "select",
+        bindings: [{ s: { type: "uri", value: "urn:alice" } }],
+      },
+    },
+    {
+      name: "total quad count across all graphs",
+      query:
+        "SELECT (COUNT(*) AS ?c) WHERE { { ?s ?p ?o } UNION { GRAPH ?g { ?s ?p ?o } } }",
+      expected: {
+        kind: "select",
+        bindings: [{
+          c: { type: "literal", value: "5", datatype: XSD + "integer" },
+        }],
+      },
+    },
+  ],
+};
+
+/**
+ * typedLiteralsWorld covers the literal type surface: plain (xsd:string),
+ * language-tagged (en/es/ar incl. RTL unicode), and typed literals
+ * (integer, double, date, boolean).
+ */
+export const typedLiteralsWorld: ParityFixture = {
+  name: "typedLiteralsWorld",
+  nquads: [
+    '<urn:item1> <urn:label> "Widget" .',
+    '<urn:item1> <urn:greeting> "Hello"@en .',
+    '<urn:item1> <urn:greeting> "Hola"@es .',
+    '<urn:item1> <urn:greeting> "\u0645\u0631\u062d\u0628\u0627"@ar .',
+    '<urn:item1> <urn:count> "42"^^<' + XSD + "integer> .",
+    '<urn:item1> <urn:ratio> "3.14"^^<' + XSD + "double> .",
+    '<urn:item1> <urn:born> "2000-01-01"^^<' + XSD + "date> .",
+    '<urn:item1> <urn:active> "true"^^<' + XSD + "boolean> .",
+  ].join("\n"),
+  totalQuads: 8,
+  graphSizes: { "": 8 },
+  search: [
+    { name: "widget label", request: { query: "Widget", topK: 10 } },
+    {
+      name: "arabic greeting (unicode)",
+      request: { query: "\u0645\u0631\u062d\u0628\u0627", topK: 10 },
+    },
+    { name: "english greeting", request: { query: "Hello", topK: 10 } },
+  ],
+  sparql: [
+    {
+      name: "lang-filtered greeting returns the arabic literal",
+      query:
+        'SELECT ?o WHERE { <urn:item1> <urn:greeting> ?o FILTER (LANG(?o) = "ar") }',
+      expected: {
+        kind: "select",
+        bindings: [
+          {
+            o: {
+              type: "literal",
+              value: "\u0645\u0631\u062d\u0628\u0627",
+              "xml:lang": "ar",
+            },
+          },
+        ],
+      },
+    },
+    {
+      name: "typed integer literal round-trips its datatype",
+      query: "SELECT ?o WHERE { <urn:item1> <urn:count> ?o }",
+      expected: {
+        kind: "select",
+        bindings: [
+          { o: { type: "literal", value: "42", datatype: XSD + "integer" } },
+        ],
+      },
+    },
+    {
+      name: "boolean literal matches SPARQL true",
+      query: "ASK WHERE { <urn:item1> <urn:active> true }",
+      expected: { kind: "ask", boolean: true },
+    },
+  ],
+};
+
+/**
+ * rdfStarWorld declares the RDF-star corpus category (RDF 1.2 quoted-triple
+ * syntax). Under RDF 1.2 occurrence semantics, the quoted-triple subject
+ * statement expands to a reification quad (an anonymous reifier with
+ * rdf:reifies) plus the claim, so the world holds 3 quads. The SPARQL engine
+ * models quoted triples, but the durable reference cannot store them yet
+ * (the backend-neutral Term layer throws on Quad terms), so this fixture is
+ * gated "declared": it runs and is reported, but does not fail the suite
+ * until the reference lands RDF-star storage.
+ */
+export const rdfStarWorld: ParityFixture = {
+  name: "rdfStarWorld",
+  nquads: [
+    '<< <urn:alice> <urn:likes> <urn:sailing> >> <urn:claims> "yes" .',
+    '<urn:alice> <urn:notes> "alice keeps a journal" .',
+  ].join("\n"),
+  totalQuads: 3,
+  graphSizes: { "": 3 },
+  gate: "declared",
+  sparql: [
+    {
+      name: "quoted-triple pattern matches the RDF-star fact",
+      query:
+        "SELECT ?o WHERE { << <urn:alice> <urn:likes> <urn:sailing> >> <urn:claims> ?o }",
+      expected: {
+        kind: "select",
+        bindings: [{ o: { type: "literal", value: "yes" } }],
+      },
+    },
+  ],
+};
+
+/**
+ * chunkBoundaryWorld exercises the search chunker with a literal far longer
+ * than the reference's default 1000-char chunk size, plus a short needle
+ * literal. Both Sdks must produce identical chunk-derived search result ids.
+ */
+export const chunkBoundaryWorld: ParityFixture = {
+  name: "chunkBoundaryWorld",
+  nquads: [
+    '<urn:long> <urn:body> "' +
+    longParagraph() +
+    '" .',
+    '<urn:long> <urn:tag> "needle" .',
+  ].join("\n"),
+  totalQuads: 2,
+  graphSizes: { "": 2 },
+  search: [
+    {
+      name: "turquoise hits the long chunk",
+      request: { query: "turquoise", topK: 10 },
+    },
+    { name: "needle short literal", request: { query: "needle", topK: 5 } },
+  ],
+};
+
+/** emptyWorld verifies zero-quad behavior end to end. */
+export const emptyWorld: ParityFixture = {
+  name: "emptyWorld",
+  nquads: "",
+  totalQuads: 0,
+  graphSizes: { "": 0 },
+  search: [{ name: "empty search", request: { query: "anything", topK: 10 } }],
+  sparql: [
+    {
+      name: "ask is false on the empty world",
+      query: "ASK WHERE { ?s ?p ?o }",
+      expected: { kind: "ask", boolean: false },
+    },
+  ],
+};
+
+/**
+ * replaceModeCase exercises replace-mode import: the second import must fully
+ * wipe the first (the reference's commit-patch replace-mode contract).
+ */
+export const replaceModeCase: ParityReplaceCase = {
+  name: "replaceModeCase",
+  first: [
+    '<urn:a> <urn:p> "one" .',
+    '<urn:b> <urn:p> "two" .',
+  ].join("\n"),
+  second: '<urn:c> <urn:p> "three" .',
+  resultCount: 1,
+};
+
+/** parityCorpus is the full registry run by runParitySuite by default. */
+export const parityCorpus: ParityCorpus = {
+  fixtures: [
+    multiGraphWorld,
+    typedLiteralsWorld,
+    rdfStarWorld,
+    chunkBoundaryWorld,
+    emptyWorld,
+  ],
+  replaceCases: [replaceModeCase],
+};
+
+/**
+ * longParagraph returns a deterministic English paragraph of roughly 1,400
+ * characters (well past the reference's default 1000-char chunk size) with
+ * repeated "turquoise" tokens so the long chunk is searchable.
+ */
+function longParagraph(): string {
+  const sentence =
+    "The turquoise ribbon drifted over the harbor while a lone gull circled " +
+    "the mast and the evening tide carried the fishing boats home one by one. ";
+  const paragraph = sentence.repeat(14);
+  return paragraph.slice(0, 1400);
+}

--- a/src/testing/run-parity-suite.n3.test.ts
+++ b/src/testing/run-parity-suite.n3.test.ts
@@ -1,0 +1,86 @@
+import { assertEquals } from "@std/assert";
+import { Store } from "n3";
+import { Sdk } from "@/client/client.ts";
+import { type Patch, Transaction } from "@/client/quad-store/mod.ts";
+import { RdfjsQuadStore, RdfjsSearchIndex } from "@/rdfjs/mod.ts";
+import { createMemorySdk } from "@/memory/mod.ts";
+import { WazooSparqlEngine } from "@wazoo/sparql-engine";
+import { parityCorpus } from "./parity-fixtures.ts";
+import { runParitySuite } from "./run-parity-suite.ts";
+
+/**
+ * Cross-store differential parity: the n3.Store topology (the original
+ * self-test double, kept because two genuinely independent in-memory RDF/JS
+ * implementations agreeing on the whole corpus is a strong signal the
+ * harness discriminates backend behavior, not store implementation).
+ *
+ * Search ordering is compared set-wise (strictSearchOrder: false): for
+ * scan-based keyword search the result order is scan order, which is a store
+ * implementation detail — the parity contract that matters is that the same
+ * worlds yield the same result sets on both stores.
+ */
+function createN3Sdk(): Sdk {
+  const store = new Store();
+  return new Sdk({
+    quadStore: new RdfjsQuadStore({ store }),
+    sparqlEngine: new WazooSparqlEngine({
+      store,
+      createTransaction: () => {
+        return new Transaction({
+          commit: (patch: Patch) => {
+            for (const quad of patch.insertions) store.addQuad(quad);
+            for (const quad of patch.deletions) store.removeQuad(quad);
+            return Promise.resolve();
+          },
+        });
+      },
+    }),
+    searchIndex: new RdfjsSearchIndex(store),
+  });
+}
+
+Deno.test(
+  "runParitySuite - engine MemoryStore and n3.Store agree on the full corpus",
+  async () => {
+    const report = await runParitySuite({
+      reference: () => createMemorySdk(),
+      candidate: () => createN3Sdk(),
+      strictSearchOrder: false,
+    });
+
+    assertEquals(
+      report.results.length,
+      parityCorpus.fixtures.length + parityCorpus.replaceCases.length,
+      "every corpus fixture and replace case runs on both stores",
+    );
+    assertEquals(
+      report.ok,
+      true,
+      report.results
+        .map(
+          (r) =>
+            `${r.name}: ${r.failures.join("; ")}` +
+            `${r.notes ? ` [notes: ${r.notes.join("; ")}]` : ""}`,
+        )
+        .join("\n"),
+    );
+
+    // The reference-gate fixtures must be clean on both stores — any
+    // divergence there is a real parity break, not a declared-category note.
+    const referenceGated = report.results.filter((r) =>
+      r.name !== "rdfStarWorld"
+    );
+    for (const result of referenceGated) {
+      assertEquals(
+        result.ok,
+        true,
+        `${result.name}: ${result.failures.join("; ")}`,
+      );
+      assertEquals(
+        result.notes,
+        undefined,
+        `${result.name} must have no notes`,
+      );
+    }
+  },
+);

--- a/src/testing/run-parity-suite.sqlite.test.ts
+++ b/src/testing/run-parity-suite.sqlite.test.ts
@@ -1,0 +1,76 @@
+import { assertEquals } from "@std/assert";
+import { Sdk } from "@/client/client.ts";
+import { RdfjsQuadStore, RdfjsSearchIndex } from "@/rdfjs/mod.ts";
+import { createMemorySdk } from "@/memory/mod.ts";
+import { SqliteStore } from "@worlds/sqlite";
+import { WazooSparqlEngine } from "@wazoo/sparql-engine";
+import { parityCorpus } from "./parity-fixtures.ts";
+import { runParitySuite } from "./run-parity-suite.ts";
+
+/**
+ * Zero-dependency parity proof (wazootech/workspace#74): the harness runs the
+ * full corpus with the in-memory reference (createMemorySdk) against a real
+ * backend store — @worlds/sqlite's durable SqliteStore, the store the future
+ * createSqliteSdk is built on — with no libsql anywhere in the run.
+ *
+ * This is the pre-publish shape of worlds-sqlite's phase-4 parity suite
+ * (workspace#64): once @worlds/sdk 0.4.0 with ./testing + ./memory publishes,
+ * worlds-sqlite consumes `@worlds/sdk/testing` and `@worlds/sdk/memory` as
+ * devDependencies and copies this exact file. Search ordering is compared
+ * set-wise (strictSearchOrder: false): scan-based keyword search order is a
+ * store implementation detail, not a parity contract.
+ */
+function createSqliteSdk(): Sdk {
+  const store = new SqliteStore({ path: ":memory:" });
+  return new Sdk({
+    quadStore: new RdfjsQuadStore({ store }),
+    sparqlEngine: new WazooSparqlEngine({ store }),
+    searchIndex: new RdfjsSearchIndex(store),
+  });
+}
+
+Deno.test(
+  "runParitySuite - SqliteStore agrees with the in-memory reference on the full corpus",
+  async () => {
+    const report = await runParitySuite({
+      reference: () => createMemorySdk(),
+      candidate: () => createSqliteSdk(),
+      strictSearchOrder: false,
+    });
+
+    assertEquals(
+      report.results.length,
+      parityCorpus.fixtures.length + parityCorpus.replaceCases.length,
+      "every corpus fixture and replace case runs on both stores",
+    );
+    assertEquals(
+      report.ok,
+      true,
+      report.results
+        .map(
+          (r) =>
+            `${r.name}: ${r.failures.join("; ")}` +
+            `${r.notes ? ` [notes: ${r.notes.join("; ")}]` : ""}`,
+        )
+        .join("\n"),
+    );
+
+    // The reference-gated fixtures must be clean on both stores — any
+    // divergence there is a real parity break, not a declared-category note.
+    const referenceGated = report.results.filter(
+      (r) => r.name !== "rdfStarWorld",
+    );
+    for (const result of referenceGated) {
+      assertEquals(
+        result.ok,
+        true,
+        `${result.name}: ${result.failures.join("; ")}`,
+      );
+      assertEquals(
+        result.notes,
+        undefined,
+        `${result.name} must have no notes`,
+      );
+    }
+  },
+);

--- a/src/testing/run-parity-suite.test.ts
+++ b/src/testing/run-parity-suite.test.ts
@@ -1,0 +1,144 @@
+import { assertEquals, assertFalse } from "@std/assert";
+import { DataFactory } from "n3";
+import type * as rdfjs from "@rdfjs/types";
+import { createMemorySdk } from "@/memory/mod.ts";
+import { multiGraphWorld, parityCorpus } from "./parity-fixtures.ts";
+import { runParitySuite, type SdkFactory } from "./run-parity-suite.ts";
+
+const { quad, namedNode, literal } = DataFactory;
+
+/**
+ * The harness proves itself against the engine's MemoryStore via
+ * createMemorySdk (@worlds/sdk/memory) — the family's portable in-memory
+ * reference (wazootech/workspace#74). The n3.Store topology lives in
+ * run-parity-suite.n3.test.ts as a cross-store differential check.
+ */
+const memoryFactory: SdkFactory = () => createMemorySdk();
+
+Deno.test("runParitySuite - passes the full corpus on identical in-memory Sdks", async () => {
+  const report = await runParitySuite({
+    reference: memoryFactory,
+    candidate: memoryFactory,
+  });
+
+  assertEquals(
+    report.results.length,
+    parityCorpus.fixtures.length + parityCorpus.replaceCases.length,
+    "every corpus fixture and replace case runs",
+  );
+  assertEquals(
+    report.ok,
+    true,
+    report.results
+      .map(
+        (r) =>
+          `${r.name}: ${r.failures.join("; ")}` +
+          `${r.notes ? ` [notes: ${r.notes.join("; ")}]` : ""}`,
+      )
+      .join("\n"),
+  );
+
+  // The declared-gate RDF-star fixture must run clean through the in-memory
+  // path (the SPARQL engine models quoted triples) and be reported, not skipped.
+  const rdfStar = report.results.find((r) => r.name === "rdfStarWorld");
+  assertEquals(rdfStar?.ok, true);
+  assertEquals(rdfStar?.notes, undefined, JSON.stringify(rdfStar?.notes));
+});
+
+Deno.test("runParitySuite - fails when the candidate reorders search results", async () => {
+  const brokenCandidate: SdkFactory = () => {
+    const sdk = createMemorySdk();
+    const originalSearch = sdk.search.bind(sdk);
+    // Deliberately invert top-K ordering to violate the parity contract.
+    sdk.search = async (request) => {
+      const response = await originalSearch(request);
+      return { results: [...(response.results ?? [])].reverse() };
+    };
+    return sdk;
+  };
+
+  const report = await runParitySuite({
+    reference: memoryFactory,
+    candidate: brokenCandidate,
+    fixtures: [multiGraphWorld],
+    replaceCases: [],
+  });
+
+  assertFalse(report.ok);
+  const searchFailures = report.results.flatMap((r) => r.failures);
+  assertEquals(
+    searchFailures.some((failure) => failure.includes("search case")),
+    true,
+    searchFailures.join("\n"),
+  );
+});
+
+Deno.test("runParitySuite - fails when the candidate's quad counts differ", async () => {
+  const extraQuad: rdfjs.Quad = quad(
+    namedNode("urn:stray"),
+    namedNode("urn:p"),
+    literal("stray"),
+  );
+  const bloatedCandidate: SdkFactory = () => {
+    const sdk = createMemorySdk();
+    const originalImport = sdk.import.bind(sdk);
+    // Deliberately add a stray quad after every import to break the count contract.
+    sdk.import = async (request) => {
+      await originalImport(request);
+      await originalImport({
+        mode: "merge",
+        source: { kind: "quads", quads: [extraQuad] },
+      });
+    };
+    return sdk;
+  };
+
+  const report = await runParitySuite({
+    reference: memoryFactory,
+    candidate: bloatedCandidate,
+    fixtures: [multiGraphWorld],
+    replaceCases: [],
+  });
+
+  assertFalse(report.ok);
+  const countFailures = report.results.flatMap((r) => r.failures);
+  assertEquals(
+    countFailures.some((failure) => failure.includes("quad count")),
+    true,
+    countFailures.join("\n"),
+  );
+});
+
+Deno.test("runParitySuite - reports declared-gate notes without failing the suite", async () => {
+  const throwingReference: SdkFactory = () => {
+    const sdk = createMemorySdk();
+    const originalImport = sdk.import.bind(sdk);
+    // Simulate a durable reference that cannot store RDF-star (throws on import).
+    sdk.import = async (request) => {
+      if (
+        request.source.kind === "serialized" &&
+        request.source.data.includes("<<")
+      ) {
+        throw new Error("Unsupported term type: Quad");
+      }
+      await originalImport(request);
+    };
+    return sdk;
+  };
+
+  const report = await runParitySuite({
+    reference: throwingReference,
+    candidate: memoryFactory,
+    fixtures: [parityCorpus.fixtures.find((f) => f.name === "rdfStarWorld")!],
+    replaceCases: [],
+  });
+
+  assertEquals(report.ok, true, "declared-gate cases never fail the suite");
+  const rdfStar = report.results[0];
+  assertEquals(rdfStar?.ok, true);
+  assertEquals(
+    rdfStar?.notes?.some((note) => note.includes("Unsupported term type")),
+    true,
+    JSON.stringify(rdfStar?.notes),
+  );
+});

--- a/src/testing/run-parity-suite.ts
+++ b/src/testing/run-parity-suite.ts
@@ -1,0 +1,521 @@
+import type * as rdfjs from "@rdfjs/types";
+import type { SdkInterface } from "@/client/client.ts";
+import {
+  type ImportRequest,
+  materializeImportQuads,
+} from "@/client/quad-store/mod.ts";
+import type { SearchResult } from "@/client/search-index/mod.ts";
+import type {
+  SparqlBinding,
+  SparqlResponse,
+  SparqlValue,
+} from "@/client/sparql-engine/mod.ts";
+import {
+  parityCorpus,
+  type ParityFixture,
+  type ParityReplaceCase,
+  type ParitySearchCase,
+  type ParitySparqlCase,
+} from "./parity-fixtures.ts";
+
+const NQUADS = "application/n-quads";
+const XSD_STRING = "http://www.w3.org/2001/XMLSchema#string";
+
+/** SdkFactory constructs a fresh Sdk (quad store + search + SPARQL wired) for one case. */
+export type SdkFactory = () => Promise<SdkInterface> | SdkInterface;
+
+/** ParitySuiteOptions configures a parity run: the reference, the candidate, and the corpus. */
+export interface ParitySuiteOptions {
+  /**
+   * reference is the known-good Sdk (libsql-backed) that candidates must
+   * match — the "parity vs libsql" baseline per the shared suite definition.
+   */
+  reference: SdkFactory;
+
+  /** candidate is the backend under test. */
+  candidate: SdkFactory;
+
+  /** fixtures overrides the corpus fixtures (defaults to parityCorpus.fixtures). */
+  fixtures?: ParityFixture[];
+
+  /** replaceCases overrides the corpus replace cases (defaults to parityCorpus.replaceCases). */
+  replaceCases?: ParityReplaceCase[];
+
+  /**
+   * strictSearchOrder enforces top-K result ordering equality between the
+   * reference and the candidate (default true — top-K ordering is part of the
+   * parity contract). Set false to compare result sets order-insensitively.
+   */
+  strictSearchOrder?: boolean;
+}
+
+/** ParityCaseResult is one fixture or replace case's verdict. */
+export interface ParityCaseResult {
+  /** name is the fixture or replace-case name. */
+  name: string;
+  /** ok is true when the case passed (declared-gate cases never fail the suite). */
+  ok: boolean;
+  /** failures lists concrete mismatches. */
+  failures: string[];
+  /** notes records informational observations (e.g. declared-gate skips). */
+  notes?: string[];
+}
+
+/** ParityReport aggregates every case in the run. */
+export interface ParityReport {
+  /** ok is true when every case passed. */
+  ok: boolean;
+  /** results is one entry per fixture and replace case. */
+  results: ParityCaseResult[];
+}
+
+/**
+ * runParitySuite verifies a candidate durable backend against a reference
+ * Sdk on the shared fixture corpus. Every fixture is imported into a fresh
+ * pair of Sdks, then checked for: exact quad counts, per-graph counts,
+ * idempotent serialized export round-trips, SPARQL results against
+ * hand-authored expectations (both Sdks), and search results compared to the
+ * reference (order-sensitive by default). See the shared parity/benchmark
+ * suite definition (wazootech/workspace#72).
+ */
+export async function runParitySuite(
+  options: ParitySuiteOptions,
+): Promise<ParityReport> {
+  const fixtures = options.fixtures ?? parityCorpus.fixtures;
+  const replaceCases = options.replaceCases ?? parityCorpus.replaceCases;
+  const results: ParityCaseResult[] = [];
+
+  for (const fixture of fixtures) {
+    results.push(await runFixtureCase(options, fixture));
+  }
+  for (const replaceCase of replaceCases) {
+    results.push(await runReplaceCase(options, replaceCase));
+  }
+
+  return { ok: results.every((result) => result.ok), results };
+}
+
+async function runFixtureCase(
+  options: ParitySuiteOptions,
+  fixture: ParityFixture,
+): Promise<ParityCaseResult> {
+  const failures: string[] = [];
+  const notes: string[] = [];
+
+  try {
+    const ref = await options.reference();
+    const cand = await options.candidate();
+    await importNquads(ref, fixture.nquads);
+    await importNquads(cand, fixture.nquads);
+
+    await checkQuadCounts(
+      fixture.name,
+      ref,
+      cand,
+      fixture.totalQuads,
+      failures,
+    );
+    await checkGraphSizes(fixture.name, cand, fixture.graphSizes, failures);
+    await checkRoundTrip(
+      fixture.name,
+      options.candidate,
+      fixture.nquads,
+      failures,
+    );
+
+    for (const searchCase of fixture.search ?? []) {
+      await checkSearchCase(
+        fixture.name,
+        options,
+        fixture.nquads,
+        searchCase,
+        options.strictSearchOrder ?? true,
+        failures,
+      );
+    }
+
+    for (const sparqlCase of fixture.sparql ?? []) {
+      await checkSparqlCase(
+        fixture.name,
+        options,
+        fixture.nquads,
+        sparqlCase,
+        failures,
+      );
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    failures.push(`threw: ${message}`);
+  }
+
+  if (fixture.gate === "declared") {
+    // Declared corpus categories are reported but never fail the suite until
+    // the reference (libsql) supports them (e.g. RDF-star storage).
+    if (failures.length > 0) {
+      notes.push(...failures);
+      failures.length = 0;
+    }
+  }
+
+  return {
+    name: fixture.name,
+    ok: failures.length === 0,
+    failures,
+    notes: notes.length > 0 ? notes : undefined,
+  };
+}
+
+async function runReplaceCase(
+  options: ParitySuiteOptions,
+  replaceCase: ParityReplaceCase,
+): Promise<ParityCaseResult> {
+  const failures: string[] = [];
+  try {
+    const firstCount = await countNquads(replaceCase.first);
+    for (
+      const [label, factory] of [
+        ["reference", options.reference],
+        ["candidate", options.candidate],
+      ] as const
+    ) {
+      const sdk = await factory();
+      await importNquads(sdk, replaceCase.first, "replace");
+      const afterFirst = await exportQuads(sdk);
+      if (afterFirst.length !== firstCount) {
+        failures.push(
+          `[${replaceCase.name}] ${label} after first replace: ` +
+            `${afterFirst.length} quads != expected ${firstCount}`,
+        );
+      }
+
+      await importNquads(sdk, replaceCase.second, "replace");
+      const afterSecond = await exportQuads(sdk);
+      if (afterSecond.length !== replaceCase.resultCount) {
+        failures.push(
+          `[${replaceCase.name}] ${label} after second replace: ` +
+            `${afterSecond.length} quads != expected ${replaceCase.resultCount}`,
+        );
+      }
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    failures.push(`threw: ${message}`);
+  }
+  return { name: replaceCase.name, ok: failures.length === 0, failures };
+}
+
+async function checkQuadCounts(
+  fixtureName: string,
+  ref: SdkInterface,
+  cand: SdkInterface,
+  expected: number,
+  failures: string[],
+): Promise<void> {
+  for (
+    const [label, sdk] of [
+      ["reference", ref],
+      ["candidate", cand],
+    ] as const
+  ) {
+    const quads = await exportQuads(sdk);
+    if (quads.length !== expected) {
+      failures.push(
+        `[${fixtureName}] ${label} quad count ${quads.length} != expected ${expected}`,
+      );
+    }
+  }
+}
+
+async function checkGraphSizes(
+  fixtureName: string,
+  sdk: SdkInterface,
+  expected: Record<string, number> | undefined,
+  failures: string[],
+): Promise<void> {
+  if (!expected) return;
+  const quads = await exportQuads(sdk);
+  const sizes = new Map<string, number>();
+  for (const quad of quads) {
+    const graph = quad.graph.value;
+    sizes.set(graph, (sizes.get(graph) ?? 0) + 1);
+  }
+  for (const [graph, count] of Object.entries(expected)) {
+    if ((sizes.get(graph) ?? 0) !== count) {
+      failures.push(
+        `[${fixtureName}] candidate graph ${JSON.stringify(graph)} ` +
+          `has ${sizes.get(graph) ?? 0} quads != expected ${count}`,
+      );
+    }
+  }
+}
+
+/**
+ * checkRoundTrip verifies that exporting a world and re-importing the
+ * exported serialization yields byte-identical serializations (idempotent
+ * round-trip) on the candidate's own engine.
+ */
+async function checkRoundTrip(
+  fixtureName: string,
+  candidateFactory: SdkFactory,
+  nquads: string,
+  failures: string[],
+): Promise<void> {
+  const sdk1 = await candidateFactory();
+  await importNquads(sdk1, nquads);
+  const out1 = await exportSerialized(sdk1);
+
+  const sdk2 = await candidateFactory();
+  await importNquads(sdk2, out1.data);
+  const out2 = await exportSerialized(sdk2);
+
+  if (out1.data !== out2.data) {
+    failures.push(
+      `[${fixtureName}] candidate serialized export is not round-trip idempotent`,
+    );
+  }
+}
+
+async function checkSearchCase(
+  fixtureName: string,
+  options: ParitySuiteOptions,
+  nquads: string,
+  searchCase: ParitySearchCase,
+  strictOrder: boolean,
+  failures: string[],
+): Promise<void> {
+  const ref = await options.reference();
+  const cand = await options.candidate();
+  await importNquads(ref, nquads);
+  await importNquads(cand, nquads);
+
+  const refResults = (await ref.search(searchCase.request)).results ?? [];
+  const candResults = (await cand.search(searchCase.request)).results ?? [];
+
+  const refKeys = refResults.map(searchResultKey);
+  const candKeys = candResults.map(searchResultKey);
+
+  const equal = strictOrder
+    ? sequenceEqual(refKeys, candKeys)
+    : multisetEqual(refKeys, candKeys);
+
+  if (!equal) {
+    failures.push(
+      `[${fixtureName}] search case "${searchCase.name}": ` +
+        `candidate results differ from reference (query=${
+          JSON.stringify(searchCase.request.query)
+        })`,
+    );
+  }
+}
+
+async function checkSparqlCase(
+  fixtureName: string,
+  options: ParitySuiteOptions,
+  nquads: string,
+  sparqlCase: ParitySparqlCase,
+  failures: string[],
+): Promise<void> {
+  const ref = await options.reference();
+  const cand = await options.candidate();
+  await importNquads(ref, nquads);
+  await importNquads(cand, nquads);
+
+  const refResponse = await ref.sparql({ query: sparqlCase.query });
+  const candResponse = await cand.sparql({ query: sparqlCase.query });
+
+  checkSparqlAgainstExpectation(
+    fixtureName,
+    sparqlCase.name,
+    "reference",
+    refResponse,
+    sparqlCase.expected,
+    failures,
+  );
+  checkSparqlAgainstExpectation(
+    fixtureName,
+    sparqlCase.name,
+    "candidate",
+    candResponse,
+    sparqlCase.expected,
+    failures,
+  );
+  checkSparqlEquivalence(
+    fixtureName,
+    sparqlCase.name,
+    refResponse,
+    candResponse,
+    failures,
+  );
+}
+
+function checkSparqlAgainstExpectation(
+  fixtureName: string,
+  caseName: string,
+  label: "reference" | "candidate",
+  response: SparqlResponse,
+  expected: ParitySparqlCase["expected"],
+  failures: string[],
+): void {
+  if (expected.kind === "ask") {
+    if (response.kind !== "ask") {
+      failures.push(
+        `[${fixtureName}] SPARQL "${caseName}" (${label}): expected ask, got ${response.kind}`,
+      );
+      return;
+    }
+    if (response.data.boolean !== expected.boolean) {
+      failures.push(
+        `[${fixtureName}] SPARQL "${caseName}" (${label}): ` +
+          `ask ${response.data.boolean} != expected ${expected.boolean}`,
+      );
+    }
+    return;
+  }
+
+  if (expected.kind === "select") {
+    if (response.kind !== "select") {
+      failures.push(
+        `[${fixtureName}] SPARQL "${caseName}" (${label}): expected select, got ${response.kind}`,
+      );
+      return;
+    }
+    const got = response.data.results.bindings.map(bindingKey).sort();
+    const want = expected.bindings.map(bindingKey).sort();
+    if (!sequenceEqual(got, want)) {
+      failures.push(
+        `[${fixtureName}] SPARQL "${caseName}" (${label}): ` +
+          `bindings differ from expected (query=${JSON.stringify(caseName)})`,
+      );
+    }
+  }
+}
+
+function checkSparqlEquivalence(
+  fixtureName: string,
+  caseName: string,
+  refResponse: SparqlResponse,
+  candResponse: SparqlResponse,
+  failures: string[],
+): void {
+  if (refResponse.kind !== candResponse.kind) {
+    failures.push(
+      `[${fixtureName}] SPARQL "${caseName}": response kinds differ ` +
+        `(${refResponse.kind} vs ${candResponse.kind})`,
+    );
+    return;
+  }
+  if (refResponse.kind === "ask" && candResponse.kind === "ask") {
+    if (refResponse.data.boolean !== candResponse.data.boolean) {
+      failures.push(
+        `[${fixtureName}] SPARQL "${caseName}": ask results differ between reference and candidate`,
+      );
+    }
+    return;
+  }
+
+  if (refResponse.kind === "select" && candResponse.kind === "select") {
+    const refBindings = refResponse.data.results.bindings.map(bindingKey)
+      .sort();
+    const candBindings = candResponse.data.results.bindings.map(bindingKey)
+      .sort();
+    if (!sequenceEqual(refBindings, candBindings)) {
+      failures.push(
+        `[${fixtureName}] SPARQL "${caseName}": bindings differ between reference and candidate`,
+      );
+    }
+  }
+}
+
+async function exportQuads(sdk: SdkInterface): Promise<rdfjs.Quad[]> {
+  const response = await sdk.export({ format: { kind: "quads" } });
+  if (response.kind !== "quads") {
+    throw new Error("export did not return quads");
+  }
+  return response.quads;
+}
+
+async function exportSerialized(
+  sdk: SdkInterface,
+): Promise<{ data: string; contentType: string }> {
+  const response = await sdk.export({
+    format: { kind: "serialized", contentType: NQUADS },
+  });
+  if (response.kind !== "serialized") {
+    throw new Error("export did not return serialized data");
+  }
+  return { data: response.data, contentType: response.contentType };
+}
+
+async function importNquads(
+  sdk: SdkInterface,
+  nquads: string,
+  mode: ImportRequest["mode"] = "merge",
+): Promise<void> {
+  await sdk.import({
+    mode,
+    source: { kind: "serialized", data: nquads, contentType: NQUADS },
+  });
+}
+
+async function countNquads(nquads: string): Promise<number> {
+  const quads = await materializeImportQuads({
+    kind: "serialized",
+    data: nquads,
+    contentType: NQUADS,
+  });
+  return quads.length;
+}
+
+function searchResultKey(result: SearchResult): string {
+  return JSON.stringify({
+    id: result.id,
+    subject: result.subject,
+    predicate: result.predicate,
+    graph: result.graph,
+    text: result.text,
+  });
+}
+
+/** bindingKey canonicalizes a SPARQL binding (order-insensitive key comparison). */
+function bindingKey(binding: SparqlBinding): string {
+  const entries = Object.keys(binding).sort().map((variable) => {
+    return `${variable}=${valueKey(binding[variable])}`;
+  });
+  return `{${entries.join(", ")}}`;
+}
+
+function valueKey(value: SparqlValue): string {
+  switch (value.type) {
+    case "uri":
+    case "bnode":
+      return `${value.type}:${value.value}`;
+    case "literal": {
+      let key = `literal:${value.value}`;
+      if (value["xml:lang"]) key += `@${value["xml:lang"]}`;
+      if (value.datatype && value.datatype !== XSD_STRING) {
+        key += `^^${value.datatype}`;
+      }
+      if (value["its:dir"]) key += `[${value["its:dir"]}]`;
+      return key;
+    }
+    case "triple":
+      return `triple(${valueKey(value.value.subject)}, ` +
+        `${valueKey(value.value.predicate)}, ${valueKey(value.value.object)})`;
+  }
+}
+
+function sequenceEqual(a: string[], b: string[]): boolean {
+  return a.length === b.length && a.every((value, index) => value === b[index]);
+}
+
+function multisetEqual(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  const counts = new Map<string, number>();
+  for (const value of a) counts.set(value, (counts.get(value) ?? 0) + 1);
+  for (const value of b) {
+    const remaining = (counts.get(value) ?? 0) - 1;
+    if (remaining < 0) return false;
+    counts.set(value, remaining);
+  }
+  return true;
+}


### PR DESCRIPTION
## What

Scaffolds the shared parity/benchmark suite per the map decision [wazootech/workspace#72](https://github.com/wazootech/workspace/issues/72) — as a **test-only `./testing` subpath** of `@worlds/sdk` (no new package, no new interfaces), plus the **`./memory` subpath** exporting `createMemorySdk`, the portable in-memory parity reference decided in [wazootech/workspace#74](https://github.com/wazootech/workspace/issues/74).

### `@worlds/sdk/testing`
- `runParitySuite({ reference, candidate, fixtures?, replaceCases?, strictSearchOrder? })` — a thin driver over the existing `SdkInterface` seam. Per fixture it imports the world into fresh Sdks and checks: exact quad counts, per-graph sizes (the one-world-many-graphs guarantee, #71), serialized export round-trip idempotency, SPARQL against hand-authored expectations (verified on both Sdks + ref↔candidate equivalence), and search results compared candidate-vs-reference (order-sensitive top-K by default).
- `parity-fixtures.ts` — first corpus, all plain N-Quads data: `multiGraphWorld`, `typedLiteralsWorld` (incl. RTL Arabic), `rdfStarWorld` (declared gate — RDF-star storage is ahead of the durable reference), `chunkBoundaryWorld` (1,400-char literal past the 1000-char chunk default), `emptyWorld`, plus a `replaceModeCase`.
- Self-tests prove the harness both passes on the in-memory reference **and fails** on deliberately broken candidates (reordered search, wrong counts, declared-gate notes without failing).

### `@worlds/sdk/memory`
- `createMemorySdk(): Sdk` — the engine's `MemoryStore` wired into the standard facade (`RdfjsQuadStore` + `RdfjsSearchIndex` + `WazooSparqlEngine` over one shared store), independent fresh topology per call.

### Proving ground
- Harness self-test rewired onto `createMemorySdk` (was a private `n3.Store` double); n3 topology kept as a **cross-store differential test**.
- **`run-parity-suite.sqlite.test.ts`** — the zero-dependency proof: full corpus, reference = `createMemorySdk`, candidate = the real `@worlds/sqlite` `SqliteStore`, **no libsql anywhere in the run**. This is the exact shape worlds-sqlite's phase-4 parity suite (workspace#64) will take once `@worlds/sdk/testing` + `@worlds/sdk/memory` publish.

## Verification
- `deno task ci` green — fmt, lint, check, **72 tests passed / 0 failed**.
- `deno publish --dry-run` — **Success**, slow-types clean; `./testing` + `./memory` registered.
- Version bumped `0.3.0` → `0.4.0` so the publish-on-merge workflow ships the new subpaths.
