### PR TITLE
docs: flip maturity ladder to Available for all five durable backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,19 +103,20 @@ conventions, see [AGENTS.md](AGENTS.md).
 This package provides the core in-memory RDF/JS backend. Durable backends live
 in separate packages:
 
-| Package                                                                                                      | Persistence                | Search                       | Status                                            |
-| ------------------------------------------------------------------------------------------------------------ | -------------------------- | ---------------------------- | ------------------------------------------------- |
-| `@worlds/sdk` (this package)                                                                                 | In-memory (`MemoryStore`)  | RDF/JS keyword               | Core client + in-memory backend                   |
-| [`@worlds/libsql`](https://jsr.io/@worlds/libsql) ([repo](https://github.com/wazootech/worlds-libsql))       | SQLite / Turso Cloud       | Hybrid FTS5 + vector         | **Beta — full SDK factory** (`createLibsqlSdk`)   |
-| [`@worlds/sqlite`](https://jsr.io/@worlds/sqlite) ([repo](https://github.com/wazootech/worlds-sqlite))       | Local file (`node:sqlite`) | — (Layer 2 parked)           | Parked post-beta — `SqliteStore` only, no factory |
-| [`@worlds/postgres`](https://jsr.io/@worlds/postgres) ([repo](https://github.com/wazootech/worlds-postgres)) | PostgreSQL + pgvector      | Hybrid FTS5 + vector (store) | Parked post-beta — raw stores only, no factory    |
-| [`worlds-cloudflare`](https://github.com/wazootech/worlds-cloudflare) (no package yet)                       | — (D1 planned)             | — (Vectorize planned)        | Scaffold only — nothing shipped                   |
+| Package                                                                                                      | Persistence                | Search                            | Status                                                     |
+| ------------------------------------------------------------------------------------------------------------ | -------------------------- | --------------------------------- | ---------------------------------------------------------- |
+| `@worlds/sdk` (this package)                                                                                 | In-memory (`MemoryStore`)  | RDF/JS keyword                    | Core client + in-memory backend                            |
+| [`@worlds/libsql`](https://jsr.io/@worlds/libsql) ([repo](https://github.com/wazootech/worlds-libsql))       | SQLite / Turso Cloud       | Hybrid FTS5 + vector              | **Available** — full SDK factory (`createLibsqlSdk`)        |
+| [`@worlds/sqlite`](https://jsr.io/@worlds/sqlite) ([repo](https://github.com/wazootech/worlds-sqlite))       | Local file (`node:sqlite`) | Hybrid FTS5 + sqlite-vec          | **Available** — full SDK factory (`createSqliteSdk`)        |
+| [`@worlds/postgres`](https://jsr.io/@worlds/postgres) ([repo](https://github.com/wazootech/worlds-postgres)) | PostgreSQL + pgvector      | Hybrid tsvector + pgvector        | **Available** — full SDK factory (`createPostgresSdk`)      |
+| [`@worlds/cloudflare`](https://jsr.io/@worlds/cloudflare) ([repo](https://github.com/wazootech/worlds-cloudflare)) | D1 (miniflare)        | FTS5 keyword (Vectorize planned)  | **Available** — full SDK factory (`createCloudflareSdk`)    |
+| [`@worlds/indexeddb`](https://jsr.io/@worlds/indexeddb) ([repo](https://github.com/wazootech/worlds-indexeddb)) | Browser IndexedDB   | JS hybrid TF-IDF + cosine         | **Available** — full SDK factory (`createIndexeddbSdk`)     |
 
-**Backend maturity:** Of the durable backend packages, only `@worlds/libsql`
-ships a full SDK factory today; `@worlds/sqlite`, `@worlds/postgres`, and
-`@worlds/cloudflare` are parked post-beta. The Deno KV backend
-(`@worlds/denokv`) is [archived](https://github.com/wazootech/worlds-denokv);
-use `@worlds/libsql`.
+**Backend maturity:** All five durable backends now ship full SDK factories
+and parity-green CI suites. Each assembles a quad store, hybrid search
+index, and SPARQL engine through the standard `create*Sdk` factory. The Deno
+KV backend (`@worlds/denokv`) is
+[archived](https://github.com/wazootech/worlds-denokv); use `@worlds/libsql`.
 
 **Choosing persistence:** LibSQL is the default for hybrid FTS/vector search and
 faster cold quad index preload at scale. See

--- a/README.md
+++ b/README.md
@@ -103,20 +103,20 @@ conventions, see [AGENTS.md](AGENTS.md).
 This package provides the core in-memory RDF/JS backend. Durable backends live
 in separate packages:
 
-| Package                                                                                                      | Persistence                | Search                            | Status                                                     |
-| ------------------------------------------------------------------------------------------------------------ | -------------------------- | --------------------------------- | ---------------------------------------------------------- |
-| `@worlds/sdk` (this package)                                                                                 | In-memory (`MemoryStore`)  | RDF/JS keyword                    | Core client + in-memory backend                            |
-| [`@worlds/libsql`](https://jsr.io/@worlds/libsql) ([repo](https://github.com/wazootech/worlds-libsql))       | SQLite / Turso Cloud       | Hybrid FTS5 + vector              | **Available** — full SDK factory (`createLibsqlSdk`)        |
-| [`@worlds/sqlite`](https://jsr.io/@worlds/sqlite) ([repo](https://github.com/wazootech/worlds-sqlite))       | Local file (`node:sqlite`) | Hybrid FTS5 + sqlite-vec          | **Available** — full SDK factory (`createSqliteSdk`)        |
-| [`@worlds/postgres`](https://jsr.io/@worlds/postgres) ([repo](https://github.com/wazootech/worlds-postgres)) | PostgreSQL + pgvector      | Hybrid tsvector + pgvector        | **Available** — full SDK factory (`createPostgresSdk`)      |
-| [`@worlds/cloudflare`](https://jsr.io/@worlds/cloudflare) ([repo](https://github.com/wazootech/worlds-cloudflare)) | D1 (miniflare)        | FTS5 keyword (Vectorize planned)  | **Available** — full SDK factory (`createCloudflareSdk`)    |
-| [`@worlds/indexeddb`](https://jsr.io/@worlds/indexeddb) ([repo](https://github.com/wazootech/worlds-indexeddb)) | Browser IndexedDB   | JS hybrid TF-IDF + cosine         | **Available** — full SDK factory (`createIndexeddbSdk`)     |
+| Package                                                                                                            | Persistence                | Search                           | Status                                                   |
+| ------------------------------------------------------------------------------------------------------------------ | -------------------------- | -------------------------------- | -------------------------------------------------------- |
+| `@worlds/sdk` (this package)                                                                                       | In-memory (`MemoryStore`)  | RDF/JS keyword                   | Core client + in-memory backend                          |
+| [`@worlds/libsql`](https://jsr.io/@worlds/libsql) ([repo](https://github.com/wazootech/worlds-libsql))             | SQLite / Turso Cloud       | Hybrid FTS5 + vector             | **Available** — full SDK factory (`createLibsqlSdk`)     |
+| [`@worlds/sqlite`](https://jsr.io/@worlds/sqlite) ([repo](https://github.com/wazootech/worlds-sqlite))             | Local file (`node:sqlite`) | Hybrid FTS5 + sqlite-vec         | **Available** — full SDK factory (`createSqliteSdk`)     |
+| [`@worlds/postgres`](https://jsr.io/@worlds/postgres) ([repo](https://github.com/wazootech/worlds-postgres))       | PostgreSQL + pgvector      | Hybrid tsvector + pgvector       | **Available** — full SDK factory (`createPostgresSdk`)   |
+| [`@worlds/cloudflare`](https://jsr.io/@worlds/cloudflare) ([repo](https://github.com/wazootech/worlds-cloudflare)) | D1 (miniflare)             | FTS5 keyword (Vectorize planned) | **Available** — full SDK factory (`createCloudflareSdk`) |
+| [`@worlds/indexeddb`](https://jsr.io/@worlds/indexeddb) ([repo](https://github.com/wazootech/worlds-indexeddb))    | Browser IndexedDB          | JS hybrid TF-IDF + cosine        | **Available** — full SDK factory (`createIndexeddbSdk`)  |
 
-**Backend maturity:** All five durable backends now ship full SDK factories
-and parity-green CI suites. Each assembles a quad store, hybrid search
-index, and SPARQL engine through the standard `create*Sdk` factory. The Deno
-KV backend (`@worlds/denokv`) is
-[archived](https://github.com/wazootech/worlds-denokv); use `@worlds/libsql`.
+**Backend maturity:** All five durable backends now ship full SDK factories and
+parity-green CI suites. Each assembles a quad store, hybrid search index, and
+SPARQL engine through the standard `create*Sdk` factory. The Deno KV backend
+(`@worlds/denokv`) is [archived](https://github.com/wazootech/worlds-denokv);
+use `@worlds/libsql`.
 
 **Choosing persistence:** LibSQL is the default for hybrid FTS/vector search and
 faster cold quad index preload at scale. See


### PR DESCRIPTION
Updates the adapters table to reflect that all five durable backends now ship full SDK factories. Part of workspace#59.