### PR TITLE
chore: release 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 0.5.0
+
+### Breaking
+
+- Quad IDs changed to `q2.` + base64url(sha256(canonical N-Quads)) — a sync
+  canonical N-Quads serializer (`src/client/quad-store/canonical-nquads.ts`)
+  replaces the async `rdf-canonize` dependency
+  ([worlds-sdk-ts#187](https://github.com/wazootech/worlds-sdk-ts/issues/187)).
+  Existing persisted stores are incompatible and must be recreated or reindexed;
+  no migration path is provided.
+- Removed the `@worlds/sdk/tfjs-universal-sentence-encoder` export. The
+  Universal Sentence Encoder embedding service is example code now — copy it
+  from
+  [`examples/tfjs-universal-sentence-encoder/`](examples/tfjs-universal-sentence-encoder/)
+  into your project if you want local, key-free embeddings.
+
+### Changed
+
+- `hashQuads` is synchronous again (no pending-cleanup commit step); callers
+  that awaited the old promise shape can drop the `await`.
+
 ## 0.3.0
 
 ### Breaking

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@worlds/sdk",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "nodeModulesDir": "auto",
   "exports": {
     ".": "./src/mod.ts",


### PR DESCRIPTION
Version bump + CHANGELOG for the breaking changes already on \main\ (implemented via #184/#187):

### Breaking
- Quad IDs are now \q2.\ + base64url(sha256(canonical N-Quads)) — sync canonical N-Quads serializer replaces \df-canonize\ (#187). **Existing persisted stores are incompatible; recreate or reindex — no migration path** (per maintainer decision: pre-\q2.\ databases are disposable).
- Removed \@worlds/sdk/tfjs-universal-sentence-encoder\ export — USE embedding service is example code at \examples/tfjs-universal-sentence-encoder/\.

### Changed
- \hashQuad\/\hashQuads\ are synchronous again (0.4.0 shipped async RDFC-1.0).

Gates: \deno task ci\ green locally (79/79) and \deno task publish:dry\ success. Merging publishes 0.5.0 to JSR via the main-push workflow.