### PR TITLE
docs: standardize Install section (package managers + CDN)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,44 @@
 
 ## Install
 
-```bash
+### Package managers
+
+```sh
+# Deno (first-class JSR support)
 deno add jsr:@worlds/sdk
+
+# Bun / npm / pnpm / Yarn (via JSR npm compatibility layer)
+npx jsr add @worlds/sdk
+```
+
+### CDN (browser / no build step)
+
+[esm.sh](https://esm.sh) serves JSR packages as ES modules — no install, no
+bundler needed.
+
+```js
+import { Sdk } from "https://esm.sh/jsr/@worlds/sdk@0.5.0";
+```
+
+With an import map:
+
+```html
+<script type="importmap">
+{
+  "imports": {
+    "@worlds/sdk": "https://esm.sh/jsr/@worlds/sdk@0.5.0"
+  }
+}
+</script>
+<script type="module">
+import { Sdk } from "@worlds/sdk";
+</script>
+```
+
+Pin to an exact build for deterministic caching:
+
+```js
+import { Sdk } from "https://esm.sh/jsr/@worlds/sdk@0.5.0?pin=v1724100000";
 ```
 
 ## Quickstart


### PR DESCRIPTION
Two-tier Install pattern from wazootech/workspace#77: full package-manager matrix (Deno + JSR npm-compat) and an esm.sh CDN subsection with pinned \@0.5.0\ URLs, import-map, and pin examples. Usage/Development sections untouched. Closes #183.