### PR TITLE
refactor: rename Sdk → WorldsSdk across public API (breaking)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,7 +168,8 @@ Never use parent-relative `../` to reach another domain. Never import
   `import type { SparqlEngineInterface } from "@/client/sparql-engine/mod.ts"`
 - ✅ `@/client/quad-store/mod.ts`, `@/client/sparql-engine/mod.ts`,
   `@/client/search-index/mod.ts`
-- ✅ `import { WorldsSdk } from "@/client/client.ts"` (avoids root barrel cycles)
+- ✅ `import { WorldsSdk } from "@/client/client.ts"` (avoids root barrel
+  cycles)
 - ✅ `./string-to-chars.ts` (from `tokenizer/tokenizer.ts`)
 - ✅ `./client.ts`, `../rdfjs/mod.ts` (from `src/client/client.test.ts`)
 - ❌ `@worlds/sdk/sparql-engine` inside `src/`
@@ -324,7 +325,8 @@ Public graph persistence facades must use explicit suffixes:
 
 LibSQL: `client.import` → `LibsqlQuadStore` → `LibsqlRdfjsStore.commit()`.
 Advanced assembly uses explicit
-`new WorldsSdk({ quadStore, searchIndex, sparqlEngine? })` with the suffixed stores.
+`new WorldsSdk({ quadStore, searchIndex, sparqlEngine? })` with the suffixed
+stores.
 
 > These conventions apply to the durable adapter repo
 > ([`@worlds/libsql`](https://github.com/wazootech/worlds-libsql)). This package
@@ -338,8 +340,8 @@ query pattern, and non-goals), see [ARCHITECTURE.md](ARCHITECTURE.md).
 ## Agent prompt contract
 
 This section defines the canonical interaction pattern for AI agents consuming
-the `WorldsSdk` API via tools. Agents use **hybrid search** to discover subject IRIs,
-then **SPARQL** to traverse and reason over the graph.
+the `WorldsSdk` API via tools. Agents use **hybrid search** to discover subject
+IRIs, then **SPARQL** to traverse and reason over the graph.
 
 ### Hybrid search retrieval modes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,7 +168,7 @@ Never use parent-relative `../` to reach another domain. Never import
   `import type { SparqlEngineInterface } from "@/client/sparql-engine/mod.ts"`
 - ✅ `@/client/quad-store/mod.ts`, `@/client/sparql-engine/mod.ts`,
   `@/client/search-index/mod.ts`
-- ✅ `import { Sdk } from "@/client/client.ts"` (avoids root barrel cycles)
+- ✅ `import { WorldsSdk } from "@/client/client.ts"` (avoids root barrel cycles)
 - ✅ `./string-to-chars.ts` (from `tokenizer/tokenizer.ts`)
 - ✅ `./client.ts`, `../rdfjs/mod.ts` (from `src/client/client.test.ts`)
 - ❌ `@worlds/sdk/sparql-engine` inside `src/`
@@ -324,7 +324,7 @@ Public graph persistence facades must use explicit suffixes:
 
 LibSQL: `client.import` → `LibsqlQuadStore` → `LibsqlRdfjsStore.commit()`.
 Advanced assembly uses explicit
-`new Sdk({ quadStore, searchIndex, sparqlEngine? })` with the suffixed stores.
+`new WorldsSdk({ quadStore, searchIndex, sparqlEngine? })` with the suffixed stores.
 
 > These conventions apply to the durable adapter repo
 > ([`@worlds/libsql`](https://github.com/wazootech/worlds-libsql)). This package
@@ -338,7 +338,7 @@ query pattern, and non-goals), see [ARCHITECTURE.md](ARCHITECTURE.md).
 ## Agent prompt contract
 
 This section defines the canonical interaction pattern for AI agents consuming
-the `Sdk` API via tools. Agents use **hybrid search** to discover subject IRIs,
+the `WorldsSdk` API via tools. Agents use **hybrid search** to discover subject IRIs,
 then **SPARQL** to traverse and reason over the graph.
 
 ### Hybrid search retrieval modes
@@ -417,7 +417,7 @@ await refreshSearchChunksForSubjects(["http://example.org/Aurelia"], {
 ```
 
 Advanced: `rebuildLibsqlSearchIndexFromQuads` in `@worlds/libsql` remains
-available without a `Sdk` instance.
+available without a `WorldsSdk` instance.
 
 ### Alignment with eval harness
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -10,23 +10,23 @@ backend. Durable backends are published as separate packages.
 
 ### In this package
 
-| Export                      | Role                                                                              |
-| --------------------------- | --------------------------------------------------------------------------------- |
+| Export                      | Role                                                                               |
+| --------------------------- | ---------------------------------------------------------------------------------- |
 | `@worlds/sdk`               | Root barrel: `WorldsSdk`, interfaces, patch types, embedding-service, quad-chunker |
-| `@worlds/sdk/quad-store`    | Quad import/export API, RDF formats, patch transactions                           |
-| `@worlds/sdk/search-index`  | Search index interface and types                                                  |
-| `@worlds/sdk/sparql-engine` | SPARQL engine interface                                                           |
-| `@worlds/sdk/rdfjs`         | In-memory `RdfjsQuadStore` and `RdfjsSearchIndex` over the engine's `MemoryStore` |
-| `@worlds/sdk/ai-sdk`        | Vercel AI SDK embedding service                                                   |
+| `@worlds/sdk/quad-store`    | Quad import/export API, RDF formats, patch transactions                            |
+| `@worlds/sdk/search-index`  | Search index interface and types                                                   |
+| `@worlds/sdk/sparql-engine` | SPARQL engine interface                                                            |
+| `@worlds/sdk/rdfjs`         | In-memory `RdfjsQuadStore` and `RdfjsSearchIndex` over the engine's `MemoryStore`  |
+| `@worlds/sdk/ai-sdk`        | Vercel AI SDK embedding service                                                    |
 
 ### External durable backends
 
-| Package                                                                                                      | Persistence                | Search                       | Status                                            |
-| ------------------------------------------------------------------------------------------------------------ | -------------------------- | ---------------------------- | ------------------------------------------------- |
+| Package                                                                                                      | Persistence                | Search                       | Status                                                |
+| ------------------------------------------------------------------------------------------------------------ | -------------------------- | ---------------------------- | ----------------------------------------------------- |
 | [`@worlds/libsql`](https://jsr.io/@worlds/libsql) ([repo](https://github.com/wazootech/worlds-libsql))       | SQLite / Turso Cloud       | Hybrid FTS5 + vector         | **Beta — full SDK factory** (`createLibsqlWorldsSdk`) |
-| [`@worlds/sqlite`](https://jsr.io/@worlds/sqlite) ([repo](https://github.com/wazootech/worlds-sqlite))       | Local file (`node:sqlite`) | — (Layer 2 parked)           | Parked post-beta — `SqliteStore` only, no factory |
-| [`@worlds/postgres`](https://jsr.io/@worlds/postgres) ([repo](https://github.com/wazootech/worlds-postgres)) | PostgreSQL + pgvector      | Hybrid FTS5 + vector (store) | Parked post-beta — raw stores only, no factory    |
-| [`worlds-cloudflare`](https://github.com/wazootech/worlds-cloudflare) (no package yet)                       | — (D1 planned)             | — (Vectorize planned)        | Scaffold only — nothing shipped                   |
+| [`@worlds/sqlite`](https://jsr.io/@worlds/sqlite) ([repo](https://github.com/wazootech/worlds-sqlite))       | Local file (`node:sqlite`) | — (Layer 2 parked)           | Parked post-beta — `SqliteStore` only, no factory     |
+| [`@worlds/postgres`](https://jsr.io/@worlds/postgres) ([repo](https://github.com/wazootech/worlds-postgres)) | PostgreSQL + pgvector      | Hybrid FTS5 + vector (store) | Parked post-beta — raw stores only, no factory        |
+| [`worlds-cloudflare`](https://github.com/wazootech/worlds-cloudflare) (no package yet)                       | — (D1 planned)             | — (Vectorize planned)        | Scaffold only — nothing shipped                       |
 
 The Deno KV backend (`@worlds/denokv`) is
 [archived](https://github.com/wazootech/worlds-denokv); `@worlds/libsql` is the
@@ -37,15 +37,15 @@ only `@worlds/libsql` ships a full SDK factory today; `@worlds/sqlite`,
 below).
 
 Durable backends implement the same quad store, search index, and SPARQL
-interfaces. The LibSQL backend ships its own factory (`createLibsqlWorldsSdk`) that
-assembles a `WorldsSdk` internally.
+interfaces. The LibSQL backend ships its own factory (`createLibsqlWorldsSdk`)
+that assembles a `WorldsSdk` internally.
 
 ## Runtime model
 
 ### Dependency injection
 
-`WorldsSdk` (in `src/client/client.ts`) is a portable facade. All storage and query
-behavior is provided through injected dependencies:
+`WorldsSdk` (in `src/client/client.ts`) is a portable facade. All storage and
+query behavior is provided through injected dependencies:
 
 ```typescript
 interface WorldsSdkOptions {
@@ -57,13 +57,13 @@ interface WorldsSdkOptions {
 
 `WorldsSdk` delegates each operation to the injected layer:
 
-| WorldsSdk method | Delegates to         |
-| ---------- | ------------------------ |
-| `import`   | `quadStore.import()`     |
-| `export`   | `quadStore.export()`     |
-| `sparql`   | `sparqlEngine.execute()` |
-| `search`   | `searchIndex.search()`   |
-| `reindex`  | `searchIndex.reindex()`  |
+| WorldsSdk method | Delegates to             |
+| ---------------- | ------------------------ |
+| `import`         | `quadStore.import()`     |
+| `export`         | `quadStore.export()`     |
+| `sparql`         | `sparqlEngine.execute()` |
+| `search`         | `searchIndex.search()`   |
+| `reindex`        | `searchIndex.reindex()`  |
 
 ### In-memory topology (dev, tests, demos)
 
@@ -89,9 +89,9 @@ implementations inside the factory:
 import { createLibsqlWorldsSdk } from "@worlds/libsql";
 ```
 
-The factory returns the same `WorldsSdkInterface` contract. Application code never
-needs to import the concrete store implementations directly unless doing custom
-assembly.
+The factory returns the same `WorldsSdkInterface` contract. Application code
+never needs to import the concrete store implementations directly unless doing
+custom assembly.
 
 ## Query and retrieval model
 
@@ -181,9 +181,10 @@ is premature public abstraction (YAGNI):
 The three concrete strategy classes live on as **private worlds-libsql
 vocabulary** (`LibsqlConnectionDriver`, `LibsqlSchemaBuilder`,
 `LibsqlSearchQueryBuilder`) — backend-internal, not a published sdk contract.
-Cross-backend composition remains at the `WorldsSdk` seam (`QuadStoreInterface` /
-`SearchIndexInterface` / `SparqlEngineInterface`). Do not re-add a provider-seam
-subpath to `@worlds/sdk` in review. Supersedes the seam decisions recorded in
+Cross-backend composition remains at the `WorldsSdk` seam (`QuadStoreInterface`
+/ `SearchIndexInterface` / `SparqlEngineInterface`). Do not re-add a
+provider-seam subpath to `@worlds/sdk` in review. Supersedes the seam decisions
+recorded in
 [worlds-sdk-ts#168](https://github.com/wazootech/worlds-sdk-ts/issues/168) and
 [worlds-sdk-ts#170](https://github.com/wazootech/worlds-sdk-ts/issues/170).
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -12,7 +12,7 @@ backend. Durable backends are published as separate packages.
 
 | Export                      | Role                                                                              |
 | --------------------------- | --------------------------------------------------------------------------------- |
-| `@worlds/sdk`               | Root barrel: `Sdk`, interfaces, patch types, embedding-service, quad-chunker      |
+| `@worlds/sdk`               | Root barrel: `WorldsSdk`, interfaces, patch types, embedding-service, quad-chunker |
 | `@worlds/sdk/quad-store`    | Quad import/export API, RDF formats, patch transactions                           |
 | `@worlds/sdk/search-index`  | Search index interface and types                                                  |
 | `@worlds/sdk/sparql-engine` | SPARQL engine interface                                                           |
@@ -23,7 +23,7 @@ backend. Durable backends are published as separate packages.
 
 | Package                                                                                                      | Persistence                | Search                       | Status                                            |
 | ------------------------------------------------------------------------------------------------------------ | -------------------------- | ---------------------------- | ------------------------------------------------- |
-| [`@worlds/libsql`](https://jsr.io/@worlds/libsql) ([repo](https://github.com/wazootech/worlds-libsql))       | SQLite / Turso Cloud       | Hybrid FTS5 + vector         | **Beta — full SDK factory** (`createLibsqlSdk`)   |
+| [`@worlds/libsql`](https://jsr.io/@worlds/libsql) ([repo](https://github.com/wazootech/worlds-libsql))       | SQLite / Turso Cloud       | Hybrid FTS5 + vector         | **Beta — full SDK factory** (`createLibsqlWorldsSdk`) |
 | [`@worlds/sqlite`](https://jsr.io/@worlds/sqlite) ([repo](https://github.com/wazootech/worlds-sqlite))       | Local file (`node:sqlite`) | — (Layer 2 parked)           | Parked post-beta — `SqliteStore` only, no factory |
 | [`@worlds/postgres`](https://jsr.io/@worlds/postgres) ([repo](https://github.com/wazootech/worlds-postgres)) | PostgreSQL + pgvector      | Hybrid FTS5 + vector (store) | Parked post-beta — raw stores only, no factory    |
 | [`worlds-cloudflare`](https://github.com/wazootech/worlds-cloudflare) (no package yet)                       | — (D1 planned)             | — (Vectorize planned)        | Scaffold only — nothing shipped                   |
@@ -37,27 +37,27 @@ only `@worlds/libsql` ships a full SDK factory today; `@worlds/sqlite`,
 below).
 
 Durable backends implement the same quad store, search index, and SPARQL
-interfaces. The LibSQL backend ships its own factory (`createLibsqlSdk`) that
-assembles a `Sdk` internally.
+interfaces. The LibSQL backend ships its own factory (`createLibsqlWorldsSdk`) that
+assembles a `WorldsSdk` internally.
 
 ## Runtime model
 
 ### Dependency injection
 
-`Sdk` (in `src/client/client.ts`) is a portable facade. All storage and query
+`WorldsSdk` (in `src/client/client.ts`) is a portable facade. All storage and query
 behavior is provided through injected dependencies:
 
 ```typescript
-interface SdkOptions {
+interface WorldsSdkOptions {
   quadStore?: QuadStoreInterface;
   sparqlEngine?: SparqlEngineInterface;
   searchIndex?: SearchIndexInterface;
 }
 ```
 
-`Sdk` delegates each operation to the injected layer:
+`WorldsSdk` delegates each operation to the injected layer:
 
-| Sdk method | Delegates to             |
+| WorldsSdk method | Delegates to         |
 | ---------- | ------------------------ |
 | `import`   | `quadStore.import()`     |
 | `export`   | `quadStore.export()`     |
@@ -68,12 +68,12 @@ interface SdkOptions {
 ### In-memory topology (dev, tests, demos)
 
 ```typescript
-import { Sdk } from "@worlds/sdk";
+import { WorldsSdk } from "@worlds/sdk";
 import { MemoryStore, WazooSparqlEngine } from "@wazoo/sparql-engine";
 import { RdfjsQuadStore, RdfjsSearchIndex } from "@worlds/sdk/rdfjs";
 
 const store = new MemoryStore();
-const client = new Sdk({
+const client = new WorldsSdk({
   quadStore: new RdfjsQuadStore({ store }),
   searchIndex: new RdfjsSearchIndex(store),
   sparqlEngine: new WazooSparqlEngine({ store }),
@@ -86,10 +86,10 @@ Durable backends wrap their own `*QuadStore`, `*SearchIndex`, and `*RdfjsStore`
 implementations inside the factory:
 
 ```typescript
-import { createLibsqlSdk } from "@worlds/libsql";
+import { createLibsqlWorldsSdk } from "@worlds/libsql";
 ```
 
-The factory returns the same `SdkInterface` contract. Application code never
+The factory returns the same `WorldsSdkInterface` contract. Application code never
 needs to import the concrete store implementations directly unless doing custom
 assembly.
 
@@ -137,7 +137,7 @@ The single engine shipped today is:
 
 - **Wazoo** — [`@wazoo/sparql-engine`](https://jsr.io/@wazoo/sparql-engine) is
   the opinionated minimal default. It is a zero-runtime-dependency SPARQL 1.1 &
-  1.2 engine that implements `SparqlEngineInterface`, drops into a `Sdk`
+  1.2 engine that implements `SparqlEngineInterface`, drops into a `WorldsSdk`
   unchanged, and runs over any `rdfjs.Store` (the engine's `MemoryStore` here;
   `LibsqlRdfjsStore` in the LibSQL backend). It covers SELECT / ASK / CONSTRUCT
   / DESCRIBE plus UPDATE, enforces `timeoutMs`, and accepts a request-level
@@ -181,7 +181,7 @@ is premature public abstraction (YAGNI):
 The three concrete strategy classes live on as **private worlds-libsql
 vocabulary** (`LibsqlConnectionDriver`, `LibsqlSchemaBuilder`,
 `LibsqlSearchQueryBuilder`) — backend-internal, not a published sdk contract.
-Cross-backend composition remains at the `Sdk` seam (`QuadStoreInterface` /
+Cross-backend composition remains at the `WorldsSdk` seam (`QuadStoreInterface` /
 `SearchIndexInterface` / `SparqlEngineInterface`). Do not re-add a provider-seam
 subpath to `@worlds/sdk` in review. Supersedes the seam decisions recorded in
 [worlds-sdk-ts#168](https://github.com/wazootech/worlds-sdk-ts/issues/168) and
@@ -201,7 +201,7 @@ subpath to `@worlds/sdk` in review. Supersedes the seam decisions recorded in
 
 ## Agent integration
 
-For AI agents consuming the `Sdk` API via tools:
+For AI agents consuming the `WorldsSdk` API via tools:
 
 1. Call `client.search()` with a keyword. Use the returned `subject` IRI (not
    `text` alone) as the binding for SPARQL.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@
 ### Breaking
 
 - Renamed public SDK symbols to `Worlds*` prefix for consistency across the org
-  ([workspace#86](https://github.com/wazootech/workspace/issues/86)):
-  `Sdk` → `WorldsSdk`, `SdkInterface` → `WorldsSdkInterface`, `SdkOptions` →
+  ([workspace#86](https://github.com/wazootech/workspace/issues/86)): `Sdk` →
+  `WorldsSdk`, `SdkInterface` → `WorldsSdkInterface`, `SdkOptions` →
   `WorldsSdkOptions`, `SdkFactory` → `WorldsSdkFactory` (root barrel and
-  `@worlds/sdk/testing`). The in-memory factory is renamed
-  `createMemorySdk` → `createMemoryWorldsSdk` (`@worlds/sdk/memory`).
+  `@worlds/sdk/testing`). The in-memory factory is renamed `createMemorySdk` →
+  `createMemoryWorldsSdk` (`@worlds/sdk/memory`).
 
 ### Migration
 
@@ -21,14 +21,18 @@ import { type SdkFactory } from "@worlds/sdk/testing";
 const client = new Sdk({ quadStore, searchIndex, sparqlEngine });
 
 // After
-import { WorldsSdk, type WorldsSdkInterface, type WorldsSdkOptions } from "@worlds/sdk";
+import {
+  WorldsSdk,
+  type WorldsSdkInterface,
+  type WorldsSdkOptions,
+} from "@worlds/sdk";
 import { createMemoryWorldsSdk } from "@worlds/sdk/memory";
 import { type WorldsSdkFactory } from "@worlds/sdk/testing";
 const client = new WorldsSdk({ quadStore, searchIndex, sparqlEngine });
 ```
 
-Backend factory renames are published simultaneously in their respective packages
-(see workspace#86 for the full mapping).
+Backend factory renames are published simultaneously in their respective
+packages (see workspace#86 for the full mapping).
 
 ## 0.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## 0.6.0
+
+### Breaking
+
+- Renamed public SDK symbols to `Worlds*` prefix for consistency across the org
+  ([workspace#86](https://github.com/wazootech/workspace/issues/86)):
+  `Sdk` → `WorldsSdk`, `SdkInterface` → `WorldsSdkInterface`, `SdkOptions` →
+  `WorldsSdkOptions`, `SdkFactory` → `WorldsSdkFactory` (root barrel and
+  `@worlds/sdk/testing`). The in-memory factory is renamed
+  `createMemorySdk` → `createMemoryWorldsSdk` (`@worlds/sdk/memory`).
+
+### Migration
+
+```typescript
+// Before
+import { Sdk, type SdkInterface, type SdkOptions } from "@worlds/sdk";
+import { createMemorySdk } from "@worlds/sdk/memory";
+import { type SdkFactory } from "@worlds/sdk/testing";
+const client = new Sdk({ quadStore, searchIndex, sparqlEngine });
+
+// After
+import { WorldsSdk, type WorldsSdkInterface, type WorldsSdkOptions } from "@worlds/sdk";
+import { createMemoryWorldsSdk } from "@worlds/sdk/memory";
+import { type WorldsSdkFactory } from "@worlds/sdk/testing";
+const client = new WorldsSdk({ quadStore, searchIndex, sparqlEngine });
+```
+
+Backend factory renames are published simultaneously in their respective packages
+(see workspace#86 for the full mapping).
+
 ## 0.5.0
 
 ### Breaking

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ for structured traversal and reasoning, powered by the zero-dependency
 
 | Export                      | Role                                                 |
 | --------------------------- | ---------------------------------------------------- |
-| `@worlds/sdk`               | Root barrel: `WorldsSdk`, interfaces, patch types   |
+| `@worlds/sdk`               | Root barrel: `WorldsSdk`, interfaces, patch types    |
 | `@worlds/sdk/quad-store`    | Quad import/export API, RDF formats, patch buffering |
 | `@worlds/sdk/search-index`  | Search index interface and types                     |
 | `@worlds/sdk/sparql-engine` | SPARQL engine interface                              |
@@ -139,9 +139,9 @@ conventions, see [AGENTS.md](AGENTS.md).
 This package provides the core in-memory RDF/JS backend. Durable backends live
 in separate packages:
 
-| Package                                                                                                            | Persistence                | Search                           | Status                                                   |
-| ------------------------------------------------------------------------------------------------------------------ | -------------------------- | -------------------------------- | -------------------------------------------------------- |
-| `@worlds/sdk` (this package)                                                                                       | In-memory (`MemoryStore`)  | RDF/JS keyword                   | Core client + in-memory backend                          |
+| Package                                                                                                            | Persistence                | Search                           | Status                                                         |
+| ------------------------------------------------------------------------------------------------------------------ | -------------------------- | -------------------------------- | -------------------------------------------------------------- |
+| `@worlds/sdk` (this package)                                                                                       | In-memory (`MemoryStore`)  | RDF/JS keyword                   | Core client + in-memory backend                                |
 | [`@worlds/libsql`](https://jsr.io/@worlds/libsql) ([repo](https://github.com/wazootech/worlds-libsql))             | SQLite / Turso Cloud       | Hybrid FTS5 + vector             | **Available** — full SDK factory (`createLibsqlWorldsSdk`)     |
 | [`@worlds/sqlite`](https://jsr.io/@worlds/sqlite) ([repo](https://github.com/wazootech/worlds-sqlite))             | Local file (`node:sqlite`) | Hybrid FTS5 + sqlite-vec         | **Available** — full SDK factory (`createSqliteWorldsSdk`)     |
 | [`@worlds/postgres`](https://jsr.io/@worlds/postgres) ([repo](https://github.com/wazootech/worlds-postgres))       | PostgreSQL + pgvector      | Hybrid tsvector + pgvector       | **Available** — full SDK factory (`createPostgresWorldsSdk`)   |
@@ -150,9 +150,9 @@ in separate packages:
 
 **Backend maturity:** All five durable backends now ship full SDK factories and
 parity-green CI suites. Each assembles a quad store, hybrid search index, and
-SPARQL engine through the standard `create*WorldsSdk` factory. The Deno KV backend
-(`@worlds/denokv`) is [archived](https://github.com/wazootech/worlds-denokv);
-use `@worlds/libsql`.
+SPARQL engine through the standard `create*WorldsSdk` factory. The Deno KV
+backend (`@worlds/denokv`) is
+[archived](https://github.com/wazootech/worlds-denokv); use `@worlds/libsql`.
 
 **Choosing persistence:** LibSQL is the default for hybrid FTS/vector search and
 faster cold quad index preload at scale. See

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <a href="https://deepwiki.com/wazootech/worlds-sdk-ts"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki" /></a>
 </p>
 
-- **Portable facade** — Unified `Sdk` API that works across in-memory and
+- **Portable facade** — Unified `WorldsSdk` API that works across in-memory and
   LibSQL/Turso backends.
 - **Search** — Hybrid retrieval combining keyword FTS5 and vector embeddings.
 - **Query** — The zero-dependency Wazoo SPARQL engine as the opinionated minimal
@@ -37,7 +37,7 @@ npx jsr add @worlds/sdk
 bundler needed.
 
 ```js
-import { Sdk } from "https://esm.sh/jsr/@worlds/sdk@0.5.0";
+import { WorldsSdk } from "https://esm.sh/jsr/@worlds/sdk@0.5.0";
 ```
 
 With an import map:
@@ -51,25 +51,25 @@ With an import map:
 }
 </script>
 <script type="module">
-import { Sdk } from "@worlds/sdk";
+import { WorldsSdk } from "@worlds/sdk";
 </script>
 ```
 
 Pin to an exact build for deterministic caching:
 
 ```js
-import { Sdk } from "https://esm.sh/jsr/@worlds/sdk@0.5.0?pin=v1724100000";
+import { WorldsSdk } from "https://esm.sh/jsr/@worlds/sdk@0.5.0?pin=v1724100000";
 ```
 
 ## Quickstart
 
 ```typescript
-import { Sdk } from "@worlds/sdk";
+import { WorldsSdk } from "@worlds/sdk";
 import { MemoryStore, WazooSparqlEngine } from "@wazoo/sparql-engine";
 import { RdfjsQuadStore, RdfjsSearchIndex } from "@worlds/sdk/rdfjs";
 
 const store = new MemoryStore();
-const client = new Sdk({
+const client = new WorldsSdk({
   quadStore: new RdfjsQuadStore({ store }),
   searchIndex: new RdfjsSearchIndex(store),
   sparqlEngine: new WazooSparqlEngine({ store }),
@@ -114,11 +114,11 @@ for structured traversal and reasoning, powered by the zero-dependency
 
 ## Module layout
 
-`Sdk` is the portable facade. Shared modules sit under `src/client/`:
+`WorldsSdk` is the portable facade. Shared modules sit under `src/client/`:
 
 | Export                      | Role                                                 |
 | --------------------------- | ---------------------------------------------------- |
-| `@worlds/sdk`               | Root barrel: `Sdk`, interfaces, patch types          |
+| `@worlds/sdk`               | Root barrel: `WorldsSdk`, interfaces, patch types   |
 | `@worlds/sdk/quad-store`    | Quad import/export API, RDF formats, patch buffering |
 | `@worlds/sdk/search-index`  | Search index interface and types                     |
 | `@worlds/sdk/sparql-engine` | SPARQL engine interface                              |
@@ -142,15 +142,15 @@ in separate packages:
 | Package                                                                                                            | Persistence                | Search                           | Status                                                   |
 | ------------------------------------------------------------------------------------------------------------------ | -------------------------- | -------------------------------- | -------------------------------------------------------- |
 | `@worlds/sdk` (this package)                                                                                       | In-memory (`MemoryStore`)  | RDF/JS keyword                   | Core client + in-memory backend                          |
-| [`@worlds/libsql`](https://jsr.io/@worlds/libsql) ([repo](https://github.com/wazootech/worlds-libsql))             | SQLite / Turso Cloud       | Hybrid FTS5 + vector             | **Available** — full SDK factory (`createLibsqlSdk`)     |
-| [`@worlds/sqlite`](https://jsr.io/@worlds/sqlite) ([repo](https://github.com/wazootech/worlds-sqlite))             | Local file (`node:sqlite`) | Hybrid FTS5 + sqlite-vec         | **Available** — full SDK factory (`createSqliteSdk`)     |
-| [`@worlds/postgres`](https://jsr.io/@worlds/postgres) ([repo](https://github.com/wazootech/worlds-postgres))       | PostgreSQL + pgvector      | Hybrid tsvector + pgvector       | **Available** — full SDK factory (`createPostgresSdk`)   |
-| [`@worlds/cloudflare`](https://jsr.io/@worlds/cloudflare) ([repo](https://github.com/wazootech/worlds-cloudflare)) | D1 (miniflare)             | FTS5 keyword (Vectorize planned) | **Available** — full SDK factory (`createCloudflareSdk`) |
-| [`@worlds/indexeddb`](https://jsr.io/@worlds/indexeddb) ([repo](https://github.com/wazootech/worlds-indexeddb))    | Browser IndexedDB          | JS hybrid TF-IDF + cosine        | **Available** — full SDK factory (`createIndexeddbSdk`)  |
+| [`@worlds/libsql`](https://jsr.io/@worlds/libsql) ([repo](https://github.com/wazootech/worlds-libsql))             | SQLite / Turso Cloud       | Hybrid FTS5 + vector             | **Available** — full SDK factory (`createLibsqlWorldsSdk`)     |
+| [`@worlds/sqlite`](https://jsr.io/@worlds/sqlite) ([repo](https://github.com/wazootech/worlds-sqlite))             | Local file (`node:sqlite`) | Hybrid FTS5 + sqlite-vec         | **Available** — full SDK factory (`createSqliteWorldsSdk`)     |
+| [`@worlds/postgres`](https://jsr.io/@worlds/postgres) ([repo](https://github.com/wazootech/worlds-postgres))       | PostgreSQL + pgvector      | Hybrid tsvector + pgvector       | **Available** — full SDK factory (`createPostgresWorldsSdk`)   |
+| [`@worlds/cloudflare`](https://jsr.io/@worlds/cloudflare) ([repo](https://github.com/wazootech/worlds-cloudflare)) | D1 (miniflare)             | FTS5 keyword (Vectorize planned) | **Available** — full SDK factory (`createCloudflareWorldsSdk`) |
+| [`@worlds/indexeddb`](https://jsr.io/@worlds/indexeddb) ([repo](https://github.com/wazootech/worlds-indexeddb))    | Browser IndexedDB          | JS hybrid TF-IDF + cosine        | **Available** — full SDK factory (`createIndexeddbWorldsSdk`)  |
 
 **Backend maturity:** All five durable backends now ship full SDK factories and
 parity-green CI suites. Each assembles a quad store, hybrid search index, and
-SPARQL engine through the standard `create*Sdk` factory. The Deno KV backend
+SPARQL engine through the standard `create*WorldsSdk` factory. The Deno KV backend
 (`@worlds/denokv`) is [archived](https://github.com/wazootech/worlds-denokv);
 use `@worlds/libsql`.
 
@@ -162,12 +162,12 @@ benchmark methodology.
 ### In-memory (dev, tests, demos)
 
 ```typescript
-import { Sdk } from "@worlds/sdk";
+import { WorldsSdk } from "@worlds/sdk";
 import { MemoryStore, WazooSparqlEngine } from "@wazoo/sparql-engine";
 import { RdfjsQuadStore, RdfjsSearchIndex } from "@worlds/sdk/rdfjs";
 
 const store = new MemoryStore();
-const client = new Sdk({
+const client = new WorldsSdk({
   quadStore: new RdfjsQuadStore({ store }),
   searchIndex: new RdfjsSearchIndex(store),
   sparqlEngine: new WazooSparqlEngine({ store }),

--- a/examples/ai-sdk-hello-world/main.ts
+++ b/examples/ai-sdk-hello-world/main.ts
@@ -1,4 +1,4 @@
-import { Sdk } from "@worlds/sdk";
+import { WorldsSdk } from "@worlds/sdk";
 import { RdfjsQuadStore, RdfjsSearchIndex } from "@worlds/sdk/rdfjs";
 import { WazooSparqlEngine } from "@wazoo/sparql-engine";
 import { MemoryStore } from "@wazoo/sparql-engine";
@@ -13,7 +13,7 @@ if (import.meta.main) {
   console.log("Initializing embedded in-memory knowledge base...");
   const store = new MemoryStore();
 
-  const client = new Sdk({
+  const client = new WorldsSdk({
     quadStore: new RdfjsQuadStore({ store }),
     searchIndex: new RdfjsSearchIndex(store),
     sparqlEngine: new WazooSparqlEngine({ store: store }),

--- a/examples/ai-sdk-hello-world/tools.ts
+++ b/examples/ai-sdk-hello-world/tools.ts
@@ -1,4 +1,4 @@
-import type { SdkInterface } from "@worlds/sdk";
+import type { WorldsSdkInterface } from "@worlds/sdk";
 import {
   createExecuteSparqlTool,
   createExportRdfTool,
@@ -29,7 +29,7 @@ export interface AiSdkToolsOptions {
  * @returns An object containing the AI SDK tools.
  */
 export function createTools(
-  client: SdkInterface,
+  client: WorldsSdkInterface,
   options?: AiSdkToolsOptions,
 ) {
   return {

--- a/examples/ai-sdk-hello-world/tools/export.ts
+++ b/examples/ai-sdk-hello-world/tools/export.ts
@@ -1,5 +1,5 @@
 import { tool } from "ai";
-import type { SdkInterface } from "@worlds/sdk";
+import type { WorldsSdkInterface } from "@worlds/sdk";
 import type { ExportRequest } from "@worlds/sdk/quad-store";
 import { z } from "zod";
 
@@ -16,7 +16,7 @@ export type SerializedExportRequest = Omit<ExportRequest, "format"> & {
  * @param client The Worlds Client instance.
  * @returns An AI SDK tool for exporting data from the knowledge base.
  */
-export function createExportRdfTool(client: SdkInterface) {
+export function createExportRdfTool(client: WorldsSdkInterface) {
   return tool({
     description:
       "Export the entire knowledge base graph as serialized RDF data (like Turtle or N-Triples). Use this as a safety hatch or when a full system dump is explicitly requested.",

--- a/examples/ai-sdk-hello-world/tools/import.ts
+++ b/examples/ai-sdk-hello-world/tools/import.ts
@@ -1,5 +1,5 @@
 import { tool } from "ai";
-import type { SdkInterface } from "@worlds/sdk";
+import type { WorldsSdkInterface } from "@worlds/sdk";
 import type { ImportRequest } from "@worlds/sdk/quad-store";
 import { z } from "zod";
 
@@ -16,7 +16,7 @@ export type SerializedImportRequest = Omit<ImportRequest, "source"> & {
  * @param client The Worlds SDK instance.
  * @returns An AI SDK tool for importing data into the knowledge base.
  */
-export function createImportRdfTool(client: SdkInterface) {
+export function createImportRdfTool(client: WorldsSdkInterface) {
   return tool({
     description:
       "Import serialized RDF data (like Turtle or N-Triples) into the knowledge base. Useful for storing new factual statements or relations.",

--- a/examples/ai-sdk-hello-world/tools/search.ts
+++ b/examples/ai-sdk-hello-world/tools/search.ts
@@ -1,5 +1,5 @@
 import { tool } from "ai";
-import type { SdkInterface } from "@worlds/sdk";
+import type { WorldsSdkInterface } from "@worlds/sdk";
 import type { SearchRequest, SearchResponse } from "@worlds/sdk/search-index";
 import { z } from "zod";
 import { SEARCH_WORLD_TOOL_DESCRIPTION } from "./agent-tool-descriptions.ts";
@@ -10,7 +10,7 @@ import { SEARCH_WORLD_TOOL_DESCRIPTION } from "./agent-tool-descriptions.ts";
  * @param client The Worlds Client instance.
  * @returns An AI SDK tool for searching the knowledge base.
  */
-export function createSearchWorldTool(client: SdkInterface) {
+export function createSearchWorldTool(client: WorldsSdkInterface) {
   return tool({
     description: SEARCH_WORLD_TOOL_DESCRIPTION,
     inputSchema: z.object({

--- a/examples/ai-sdk-hello-world/tools/sparql.ts
+++ b/examples/ai-sdk-hello-world/tools/sparql.ts
@@ -1,5 +1,5 @@
 import { tool } from "ai";
-import type { SdkInterface } from "@worlds/sdk";
+import type { WorldsSdkInterface } from "@worlds/sdk";
 import type { SparqlRequest } from "@worlds/sdk/sparql-engine";
 import { z } from "zod";
 import { EXECUTE_SPARQL_TOOL_DESCRIPTION } from "./agent-tool-descriptions.ts";
@@ -23,7 +23,7 @@ export interface ExecuteSparqlOptions {
  * @returns An AI SDK tool for executing SPARQL queries against the knowledge base.
  */
 export function createExecuteSparqlTool(
-  client: SdkInterface,
+  client: WorldsSdkInterface,
   options?: ExecuteSparqlOptions,
 ) {
   return tool({

--- a/examples/hello-world/main.ts
+++ b/examples/hello-world/main.ts
@@ -1,11 +1,11 @@
-import { Sdk } from "@worlds/sdk";
+import { WorldsSdk } from "@worlds/sdk";
 import { WazooSparqlEngine } from "@wazoo/sparql-engine";
 import { RdfjsQuadStore, RdfjsSearchIndex } from "@worlds/sdk/rdfjs";
 import { MemoryStore } from "@wazoo/sparql-engine";
 
 if (import.meta.main) {
   const store = new MemoryStore();
-  const client = new Sdk({
+  const client = new WorldsSdk({
     quadStore: new RdfjsQuadStore({ store }),
     searchIndex: new RdfjsSearchIndex(store),
     sparqlEngine: new WazooSparqlEngine({ store }),

--- a/src/client/client.test.ts
+++ b/src/client/client.test.ts
@@ -1,14 +1,14 @@
 import { assertEquals, assertRejects } from "@std/assert";
 import { DataFactory, Store } from "n3";
-import { Sdk } from "./client.ts";
+import { WorldsSdk } from "./client.ts";
 import { RdfjsQuadStore, RdfjsSearchIndex } from "../rdfjs/mod.ts";
 import { WazooSparqlEngine } from "@wazoo/sparql-engine";
 import { hashQuad, type Patch, Transaction } from "./quad-store/mod.ts";
 
 const { quad, namedNode, literal } = DataFactory;
 
-function createTestClient(store: Store): Sdk {
-  return new Sdk({
+function createTestClient(store: Store): WorldsSdk {
+  return new WorldsSdk({
     quadStore: new RdfjsQuadStore({ store }),
     sparqlEngine: new WazooSparqlEngine({
       store: store,
@@ -26,7 +26,7 @@ function createTestClient(store: Store): Sdk {
   });
 }
 
-Deno.test("Sdk.import delegates to quadStore.import", async () => {
+Deno.test("WorldsSdk.import delegates to quadStore.import", async () => {
   const store = new Store();
   const client = createTestClient(store);
 
@@ -43,11 +43,11 @@ Deno.test("Sdk.import delegates to quadStore.import", async () => {
   assertEquals(
     store.size,
     1,
-    "Sdk should have successfully invoked quadStore import",
+    "WorldsSdk should have successfully invoked quadStore import",
   );
 });
 
-Deno.test("Sdk.export delegates to quadStore.export", async () => {
+Deno.test("WorldsSdk.export delegates to quadStore.export", async () => {
   const store = new Store();
   const client = createTestClient(store);
 
@@ -57,7 +57,7 @@ Deno.test("Sdk.export delegates to quadStore.export", async () => {
   assertEquals(response.quads.length, 0);
 });
 
-Deno.test("Sdk.sparql delegates to sparqlEngine.execute", async () => {
+Deno.test("WorldsSdk.sparql delegates to sparqlEngine.execute", async () => {
   const store = new Store();
   const client = createTestClient(store);
 
@@ -69,9 +69,9 @@ Deno.test("Sdk.sparql delegates to sparqlEngine.execute", async () => {
   assertEquals(response.data.boolean, false);
 });
 
-Deno.test("Sdk.sparql rejects when sparqlEngine is not configured", async () => {
+Deno.test("WorldsSdk.sparql rejects when sparqlEngine is not configured", async () => {
   const store = new Store();
-  const client = new Sdk({
+  const client = new WorldsSdk({
     quadStore: new RdfjsQuadStore({ store }),
     searchIndex: new RdfjsSearchIndex(store),
   });
@@ -83,8 +83,8 @@ Deno.test("Sdk.sparql rejects when sparqlEngine is not configured", async () => 
   );
 });
 
-Deno.test("Sdk.import rejects when quadStore is not configured", async () => {
-  const client = new Sdk({
+Deno.test("WorldsSdk.import rejects when quadStore is not configured", async () => {
+  const client = new WorldsSdk({
     searchIndex: new RdfjsSearchIndex(new Store()),
   });
 
@@ -104,8 +104,8 @@ Deno.test("Sdk.import rejects when quadStore is not configured", async () => {
   );
 });
 
-Deno.test("Sdk.search rejects when searchIndex is not configured", async () => {
-  const client = new Sdk({
+Deno.test("WorldsSdk.search rejects when searchIndex is not configured", async () => {
+  const client = new WorldsSdk({
     quadStore: new RdfjsQuadStore({ store: new Store() }),
   });
 
@@ -118,7 +118,7 @@ Deno.test("Sdk.search rejects when searchIndex is not configured", async () => {
   );
 });
 
-Deno.test("Sdk.search delegates to searchIndex.search", async () => {
+Deno.test("WorldsSdk.search delegates to searchIndex.search", async () => {
   const store = new Store();
   store.addQuad(
     namedNode("http://example.com/sub"),
@@ -133,7 +133,7 @@ Deno.test("Sdk.search delegates to searchIndex.search", async () => {
   assertEquals(response.results?.[0].text, "Integrate all systems.");
 });
 
-Deno.test("Sdk.search returns stable hashQuad-based search result ids", async () => {
+Deno.test("WorldsSdk.search returns stable hashQuad-based search result ids", async () => {
   const store = new Store();
   const indexedQuad = quad(
     namedNode("http://example.com/sub"),
@@ -152,7 +152,7 @@ Deno.test("Sdk.search returns stable hashQuad-based search result ids", async ()
   assertEquals(secondResponse.results?.[0].id, expectedId);
 });
 
-Deno.test("Sdk.reindex delegates to searchIndex.reindex", async () => {
+Deno.test("WorldsSdk.reindex delegates to searchIndex.reindex", async () => {
   const store = new Store();
   store.addQuad(
     namedNode("http://example.com/sub"),
@@ -167,9 +167,9 @@ Deno.test("Sdk.reindex delegates to searchIndex.reindex", async () => {
   assertEquals(response.chunkRowCount, 0);
 });
 
-Deno.test("Sdk - import delivers immediate search hits", async () => {
+Deno.test("WorldsSdk - import delivers immediate search hits", async () => {
   const store = new Store();
-  const client = new Sdk({
+  const client = new WorldsSdk({
     quadStore: new RdfjsQuadStore({ store }),
     searchIndex: new RdfjsSearchIndex(store),
   });
@@ -189,7 +189,7 @@ Deno.test("Sdk - import delivers immediate search hits", async () => {
   assertEquals(response.results?.[0].text, "Factory wiring works.");
 });
 
-Deno.test("Sdk - preloaded store is shared with the client", async () => {
+Deno.test("WorldsSdk - preloaded store is shared with the client", async () => {
   const store = new Store();
   store.addQuad(
     namedNode("http://example.com/existing"),
@@ -197,7 +197,7 @@ Deno.test("Sdk - preloaded store is shared with the client", async () => {
     literal("Preloaded fact."),
   );
 
-  const client = new Sdk({
+  const client = new WorldsSdk({
     quadStore: new RdfjsQuadStore({ store }),
     searchIndex: new RdfjsSearchIndex(store),
   });
@@ -207,9 +207,9 @@ Deno.test("Sdk - preloaded store is shared with the client", async () => {
   assertEquals(store.size, 1);
 });
 
-Deno.test("Sdk - queryEngine enables SELECT queries", async () => {
+Deno.test("WorldsSdk - queryEngine enables SELECT queries", async () => {
   const store = new Store();
-  const client = new Sdk({
+  const client = new WorldsSdk({
     quadStore: new RdfjsQuadStore({ store }),
     searchIndex: new RdfjsSearchIndex(store),
     sparqlEngine: new WazooSparqlEngine({

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -18,9 +18,9 @@ import type {
 } from "./search-index/mod.ts";
 
 /**
- * SdkInterface is the public contract for the Worlds SDK.
+ * WorldsSdkInterface is the public contract for the Worlds SDK.
  */
-export interface SdkInterface {
+export interface WorldsSdkInterface {
   /**
    * import imports data into the Worlds API.
    * @param request The import request body.
@@ -59,9 +59,9 @@ export interface SdkInterface {
 }
 
 /**
- * SdkOptions wires quad, SPARQL, and search facades for custom assembly and tests.
+ * WorldsSdkOptions wires quad, SPARQL, and search facades for custom assembly and tests.
  */
-export interface SdkOptions {
+export interface WorldsSdkOptions {
   /** quadStore manages the ingestion and extraction of triple/quad data. */
   quadStore?: QuadStoreInterface;
 
@@ -73,11 +73,11 @@ export interface SdkOptions {
 }
 
 /**
- * Sdk synthesizes a Worlds SDK facade from wired quad, SPARQL, and search subsystems.
+ * WorldsSdk synthesizes a Worlds SDK facade from wired quad, SPARQL, and search subsystems.
  */
-export class Sdk implements SdkInterface {
+export class WorldsSdk implements WorldsSdkInterface {
   public constructor(
-    private readonly options: SdkOptions,
+    private readonly options: WorldsSdkOptions,
   ) {}
 
   public import(request: ImportRequest): Promise<void> {

--- a/src/client/memory-store-client.test.ts
+++ b/src/client/memory-store-client.test.ts
@@ -5,7 +5,7 @@
  * @worlds/sqlite's SqliteStore (the durable node:sqlite store, moved out of
  * @wazoo/sparql-engine/sqlite on 2026-08-17) — are truly interchangeable
  * with the client's own stores (MemoryStore, LibsqlStore) end to end: the same
- * Sdk facade, wired with RdfjsQuadStore + RdfjsSearchIndex + a sparql
+ * WorldsSdk facade, wired with RdfjsQuadStore + RdfjsSearchIndex + a sparql
  * engine over one shared RDF/JS store, works identically across engines and
  * stores.
  */
@@ -14,7 +14,7 @@ import { assertEquals } from "@std/assert";
 import { DataFactory } from "@wazoo/sparql-engine/data-model";
 import { MemoryStore, WazooSparqlEngine } from "@wazoo/sparql-engine";
 import { SqliteStore } from "@worlds/sqlite";
-import { Sdk } from "./client.ts";
+import { WorldsSdk } from "./client.ts";
 import type { SparqlBinding, SparqlResponse } from "./sparql-engine/mod.ts";
 import { RdfjsQuadStore, RdfjsSearchIndex } from "../rdfjs/mod.ts";
 
@@ -50,9 +50,9 @@ function normalizeBindings(bindings: SparqlBinding[]): unknown {
   );
 }
 
-/* * Wires the full Sdk facade over one shared RDF/JS store + WazooSparqlEngine. */
-function createWazooClient(store: rdfjs.Store & { size: number }): Sdk {
-  return new Sdk({
+/* * Wires the full WorldsSdk facade over one shared RDF/JS store + WazooSparqlEngine. */
+function createWazooClient(store: rdfjs.Store & { size: number }): WorldsSdk {
+  return new WorldsSdk({
     quadStore: new RdfjsQuadStore({ store }),
     sparqlEngine: new WazooSparqlEngine({ store }),
     searchIndex: new RdfjsSearchIndex(store),

--- a/src/memory/create-memory-sdk.test.ts
+++ b/src/memory/create-memory-sdk.test.ts
@@ -1,5 +1,5 @@
 import { assertEquals } from "@std/assert";
-import { createMemorySdk } from "./create-memory-sdk.ts";
+import { createMemoryWorldsSdk } from "./create-memory-sdk.ts";
 
 const SEED = [
   '<urn:alice> <urn:likes> "sailing"@en .',
@@ -7,8 +7,8 @@ const SEED = [
   '<urn:alice> <urn:posts> "a public note" <urn:graph:public> .',
 ].join("\n");
 
-Deno.test("createMemorySdk — import → search → SELECT → ASK → reindex end to end", async () => {
-  const sdk = createMemorySdk();
+Deno.test("createMemoryWorldsSdk — import → search → SELECT → ASK → reindex end to end", async () => {
+  const sdk = createMemoryWorldsSdk();
 
   await sdk.import({
     source: {
@@ -42,9 +42,9 @@ Deno.test("createMemorySdk — import → search → SELECT → ASK → reindex 
   assertEquals(reindex.processedQuadCount, 3);
 });
 
-Deno.test("createMemorySdk — each call returns an independent fresh topology", async () => {
-  const first = createMemorySdk();
-  const second = createMemorySdk();
+Deno.test("createMemoryWorldsSdk — each call returns an independent fresh topology", async () => {
+  const first = createMemoryWorldsSdk();
+  const second = createMemoryWorldsSdk();
 
   await first.import({
     source: {
@@ -56,5 +56,5 @@ Deno.test("createMemorySdk — each call returns an independent fresh topology",
 
   const secondExport = await second.export({ format: { kind: "quads" } });
   if (secondExport.kind !== "quads") throw new Error("Expected quads");
-  assertEquals(secondExport.quads.length, 0, "second Sdk must start empty");
+  assertEquals(secondExport.quads.length, 0, "second WorldsSdk must start empty");
 });

--- a/src/memory/create-memory-sdk.test.ts
+++ b/src/memory/create-memory-sdk.test.ts
@@ -56,5 +56,9 @@ Deno.test("createMemoryWorldsSdk — each call returns an independent fresh topo
 
   const secondExport = await second.export({ format: { kind: "quads" } });
   if (secondExport.kind !== "quads") throw new Error("Expected quads");
-  assertEquals(secondExport.quads.length, 0, "second WorldsSdk must start empty");
+  assertEquals(
+    secondExport.quads.length,
+    0,
+    "second WorldsSdk must start empty",
+  );
 });

--- a/src/memory/create-memory-sdk.ts
+++ b/src/memory/create-memory-sdk.ts
@@ -1,26 +1,26 @@
-import { Sdk } from "@/client/client.ts";
+import { WorldsSdk } from "@/client/client.ts";
 import { RdfjsQuadStore, RdfjsSearchIndex } from "@/rdfjs/mod.ts";
 import { MemoryStore, WazooSparqlEngine } from "@wazoo/sparql-engine";
 
 /**
- * createMemorySdk builds a portable in-memory Worlds Sdk backed by the Wazoo
+ * createMemoryWorldsSdk builds a portable in-memory WorldsSdk backed by the Wazoo
  * engine's MemoryStore (the in-memory baseline, per the durable-backend map's
  * consolidation decision, wazootech/workspace#74).
  *
  * It is the shared parity reference and proving ground for the family: the
  * @worlds/sdk/testing harness (runParitySuite) and every backend's phase-4
  * parity suite can use it as a zero-dependency, in-memory reference — no
- * libsql checkout or private test double required. It wires the same Sdk
+ * libsql checkout or private test double required. It wires the same WorldsSdk
  * facade the durable backends expose (quad store + SPARQL + search over one
  * shared RDF/JS store), so a backend that matches it matches the family.
  *
- * The store is owned by the Sdk: each call returns an independent, fresh
- * topology. Use a factory (`() => createMemorySdk()`) where each case needs
+ * The store is owned by the WorldsSdk: each call returns an independent, fresh
+ * topology. Use a factory (`() => createMemoryWorldsSdk()`) where each case needs
  * an isolated world.
  */
-export function createMemorySdk(): Sdk {
+export function createMemoryWorldsSdk(): WorldsSdk {
   const store = new MemoryStore();
-  return new Sdk({
+  return new WorldsSdk({
     quadStore: new RdfjsQuadStore({ store }),
     sparqlEngine: new WazooSparqlEngine({ store }),
     searchIndex: new RdfjsSearchIndex(store),

--- a/src/memory/mod.ts
+++ b/src/memory/mod.ts
@@ -1,7 +1,7 @@
 /**
- * The @worlds/sdk/memory subpath exports the portable in-memory Sdk — the
+ * The @worlds/sdk/memory subpath exports the portable in-memory WorldsSdk — the
  * durable-backend family's shared parity reference (wazootech/workspace#74).
- * createMemorySdk wires the engine's MemoryStore into the standard Sdk facade
+ * createMemoryWorldsSdk wires the engine's MemoryStore into the standard WorldsSdk facade
  * (RdfjsQuadStore + RdfjsSearchIndex + WazooSparqlEngine over one shared
  * store), so the @worlds/sdk/testing harness and every backend's phase-4
  * parity suite can run against a zero-dependency in-memory reference.

--- a/src/testing/mod.ts
+++ b/src/testing/mod.ts
@@ -1,7 +1,7 @@
 /**
  * The @worlds/sdk/testing subpath is the shared parity harness for the
  * durable-backend family (per the shared parity/benchmark suite definition,
- * wazootech/workspace#72). It is a thin driver over the existing Sdk seam —
+ * wazootech/workspace#72). It is a thin driver over the existing WorldsSdk seam —
  * no new interfaces, no new runtime surface — consumed by backend repos as a
  * devDependency in their phase-4 parity suites.
  *
@@ -9,7 +9,7 @@
  *   typed literals, RDF-star [declared], chunk-boundary texts, empty world,
  *   replace-mode) as plain N-Quads data.
  * - `run-parity-suite.ts` — `runParitySuite`, comparing a candidate backend
- *   against a reference Sdk (libsql) on the corpus.
+ *   against a reference WorldsSdk (libsql) on the corpus.
  */
 export * from "./parity-fixtures.ts";
 export * from "./run-parity-suite.ts";

--- a/src/testing/parity-fixtures.ts
+++ b/src/testing/parity-fixtures.ts
@@ -40,7 +40,7 @@ export interface ParitySparqlCase {
 
 /**
  * gate controls corpus strictness:
- * - "reference" (default): the case must pass on the reference Sdk (libsql)
+ * - "reference" (default): the case must pass on the reference WorldsSdk (libsql)
  *   and on the candidate. New fixtures default here.
  * - "declared": the corpus category is declared but the durable reference does
  *   not support it yet (e.g. RDF-star storage — the backend-neutral Term

--- a/src/testing/run-parity-suite.n3.test.ts
+++ b/src/testing/run-parity-suite.n3.test.ts
@@ -1,9 +1,9 @@
 import { assertEquals } from "@std/assert";
 import { Store } from "n3";
-import { Sdk } from "@/client/client.ts";
+import { WorldsSdk } from "@/client/client.ts";
 import { type Patch, Transaction } from "@/client/quad-store/mod.ts";
 import { RdfjsQuadStore, RdfjsSearchIndex } from "@/rdfjs/mod.ts";
-import { createMemorySdk } from "@/memory/mod.ts";
+import { createMemoryWorldsSdk } from "@/memory/mod.ts";
 import { WazooSparqlEngine } from "@wazoo/sparql-engine";
 import { parityCorpus } from "./parity-fixtures.ts";
 import { runParitySuite } from "./run-parity-suite.ts";
@@ -19,9 +19,9 @@ import { runParitySuite } from "./run-parity-suite.ts";
  * implementation detail — the parity contract that matters is that the same
  * worlds yield the same result sets on both stores.
  */
-function createN3Sdk(): Sdk {
+function createN3WorldsSdk(): WorldsSdk {
   const store = new Store();
-  return new Sdk({
+  return new WorldsSdk({
     quadStore: new RdfjsQuadStore({ store }),
     sparqlEngine: new WazooSparqlEngine({
       store,
@@ -43,8 +43,8 @@ Deno.test(
   "runParitySuite - engine MemoryStore and n3.Store agree on the full corpus",
   async () => {
     const report = await runParitySuite({
-      reference: () => createMemorySdk(),
-      candidate: () => createN3Sdk(),
+      reference: () => createMemoryWorldsSdk(),
+      candidate: () => createN3WorldsSdk(),
       strictSearchOrder: false,
     });
 

--- a/src/testing/run-parity-suite.sqlite.test.ts
+++ b/src/testing/run-parity-suite.sqlite.test.ts
@@ -1,7 +1,7 @@
 import { assertEquals } from "@std/assert";
-import { Sdk } from "@/client/client.ts";
+import { WorldsSdk } from "@/client/client.ts";
 import { RdfjsQuadStore, RdfjsSearchIndex } from "@/rdfjs/mod.ts";
-import { createMemorySdk } from "@/memory/mod.ts";
+import { createMemoryWorldsSdk } from "@/memory/mod.ts";
 import { SqliteStore } from "@worlds/sqlite";
 import { WazooSparqlEngine } from "@wazoo/sparql-engine";
 import { parityCorpus } from "./parity-fixtures.ts";
@@ -9,9 +9,9 @@ import { runParitySuite } from "./run-parity-suite.ts";
 
 /**
  * Zero-dependency parity proof (wazootech/workspace#74): the harness runs the
- * full corpus with the in-memory reference (createMemorySdk) against a real
+ * full corpus with the in-memory reference (createMemoryWorldsSdk) against a real
  * backend store — @worlds/sqlite's durable SqliteStore, the store the future
- * createSqliteSdk is built on — with no libsql anywhere in the run.
+ * createSqliteWorldsSdk is built on — with no libsql anywhere in the run.
  *
  * This is the pre-publish shape of worlds-sqlite's phase-4 parity suite
  * (workspace#64): once @worlds/sdk 0.4.0 with ./testing + ./memory publishes,
@@ -20,9 +20,9 @@ import { runParitySuite } from "./run-parity-suite.ts";
  * set-wise (strictSearchOrder: false): scan-based keyword search order is a
  * store implementation detail, not a parity contract.
  */
-function createSqliteSdk(): Sdk {
+function createSqliteWorldsSdk(): WorldsSdk {
   const store = new SqliteStore({ path: ":memory:" });
-  return new Sdk({
+  return new WorldsSdk({
     quadStore: new RdfjsQuadStore({ store }),
     sparqlEngine: new WazooSparqlEngine({ store }),
     searchIndex: new RdfjsSearchIndex(store),
@@ -33,8 +33,8 @@ Deno.test(
   "runParitySuite - SqliteStore agrees with the in-memory reference on the full corpus",
   async () => {
     const report = await runParitySuite({
-      reference: () => createMemorySdk(),
-      candidate: () => createSqliteSdk(),
+      reference: () => createMemoryWorldsSdk(),
+      candidate: () => createSqliteWorldsSdk(),
       strictSearchOrder: false,
     });
 

--- a/src/testing/run-parity-suite.test.ts
+++ b/src/testing/run-parity-suite.test.ts
@@ -1,19 +1,19 @@
 import { assertEquals, assertFalse } from "@std/assert";
 import { DataFactory } from "n3";
 import type * as rdfjs from "@rdfjs/types";
-import { createMemorySdk } from "@/memory/mod.ts";
+import { createMemoryWorldsSdk } from "@/memory/mod.ts";
 import { multiGraphWorld, parityCorpus } from "./parity-fixtures.ts";
-import { runParitySuite, type SdkFactory } from "./run-parity-suite.ts";
+import { runParitySuite, type WorldsSdkFactory } from "./run-parity-suite.ts";
 
 const { quad, namedNode, literal } = DataFactory;
 
 /**
  * The harness proves itself against the engine's MemoryStore via
- * createMemorySdk (@worlds/sdk/memory) — the family's portable in-memory
+ * createMemoryWorldsSdk (@worlds/sdk/memory) — the family's portable in-memory
  * reference (wazootech/workspace#74). The n3.Store topology lives in
  * run-parity-suite.n3.test.ts as a cross-store differential check.
  */
-const memoryFactory: SdkFactory = () => createMemorySdk();
+const memoryFactory: WorldsSdkFactory = () => createMemoryWorldsSdk();
 
 Deno.test("runParitySuite - passes the full corpus on identical in-memory Sdks", async () => {
   const report = await runParitySuite({
@@ -46,8 +46,8 @@ Deno.test("runParitySuite - passes the full corpus on identical in-memory Sdks",
 });
 
 Deno.test("runParitySuite - fails when the candidate reorders search results", async () => {
-  const brokenCandidate: SdkFactory = () => {
-    const sdk = createMemorySdk();
+  const brokenCandidate: WorldsSdkFactory = () => {
+    const sdk = createMemoryWorldsSdk();
     const originalSearch = sdk.search.bind(sdk);
     // Deliberately invert top-K ordering to violate the parity contract.
     sdk.search = async (request) => {
@@ -79,8 +79,8 @@ Deno.test("runParitySuite - fails when the candidate's quad counts differ", asyn
     namedNode("urn:p"),
     literal("stray"),
   );
-  const bloatedCandidate: SdkFactory = () => {
-    const sdk = createMemorySdk();
+  const bloatedCandidate: WorldsSdkFactory = () => {
+    const sdk = createMemoryWorldsSdk();
     const originalImport = sdk.import.bind(sdk);
     // Deliberately add a stray quad after every import to break the count contract.
     sdk.import = async (request) => {
@@ -110,8 +110,8 @@ Deno.test("runParitySuite - fails when the candidate's quad counts differ", asyn
 });
 
 Deno.test("runParitySuite - reports declared-gate notes without failing the suite", async () => {
-  const throwingReference: SdkFactory = () => {
-    const sdk = createMemorySdk();
+  const throwingReference: WorldsSdkFactory = () => {
+    const sdk = createMemoryWorldsSdk();
     const originalImport = sdk.import.bind(sdk);
     // Simulate a durable reference that cannot store RDF-star (throws on import).
     sdk.import = async (request) => {

--- a/src/testing/run-parity-suite.ts
+++ b/src/testing/run-parity-suite.ts
@@ -22,7 +22,9 @@ const NQUADS = "application/n-quads";
 const XSD_STRING = "http://www.w3.org/2001/XMLSchema#string";
 
 /** WorldsSdkFactory constructs a fresh WorldsSdk (quad store + search + SPARQL wired) for one case. */
-export type WorldsSdkFactory = () => Promise<WorldsSdkInterface> | WorldsSdkInterface;
+export type WorldsSdkFactory = () =>
+  | Promise<WorldsSdkInterface>
+  | WorldsSdkInterface;
 
 /** ParitySuiteOptions configures a parity run: the reference, the candidate, and the corpus. */
 export interface ParitySuiteOptions {

--- a/src/testing/run-parity-suite.ts
+++ b/src/testing/run-parity-suite.ts
@@ -1,5 +1,5 @@
 import type * as rdfjs from "@rdfjs/types";
-import type { SdkInterface } from "@/client/client.ts";
+import type { WorldsSdkInterface } from "@/client/client.ts";
 import {
   type ImportRequest,
   materializeImportQuads,
@@ -21,19 +21,19 @@ import {
 const NQUADS = "application/n-quads";
 const XSD_STRING = "http://www.w3.org/2001/XMLSchema#string";
 
-/** SdkFactory constructs a fresh Sdk (quad store + search + SPARQL wired) for one case. */
-export type SdkFactory = () => Promise<SdkInterface> | SdkInterface;
+/** WorldsSdkFactory constructs a fresh WorldsSdk (quad store + search + SPARQL wired) for one case. */
+export type WorldsSdkFactory = () => Promise<WorldsSdkInterface> | WorldsSdkInterface;
 
 /** ParitySuiteOptions configures a parity run: the reference, the candidate, and the corpus. */
 export interface ParitySuiteOptions {
   /**
-   * reference is the known-good Sdk (libsql-backed) that candidates must
+   * reference is the known-good WorldsSdk (libsql-backed) that candidates must
    * match — the "parity vs libsql" baseline per the shared suite definition.
    */
-  reference: SdkFactory;
+  reference: WorldsSdkFactory;
 
   /** candidate is the backend under test. */
-  candidate: SdkFactory;
+  candidate: WorldsSdkFactory;
 
   /** fixtures overrides the corpus fixtures (defaults to parityCorpus.fixtures). */
   fixtures?: ParityFixture[];
@@ -71,10 +71,10 @@ export interface ParityReport {
 
 /**
  * runParitySuite verifies a candidate durable backend against a reference
- * Sdk on the shared fixture corpus. Every fixture is imported into a fresh
- * pair of Sdks, then checked for: exact quad counts, per-graph counts,
+ * WorldsSdk on the shared fixture corpus. Every fixture is imported into a fresh
+ * pair of WorldsSdks, then checked for: exact quad counts, per-graph counts,
  * idempotent serialized export round-trips, SPARQL results against
- * hand-authored expectations (both Sdks), and search results compared to the
+ * hand-authored expectations (both WorldsSdks), and search results compared to the
  * reference (order-sensitive by default). See the shared parity/benchmark
  * suite definition (wazootech/workspace#72).
  */
@@ -206,8 +206,8 @@ async function runReplaceCase(
 
 async function checkQuadCounts(
   fixtureName: string,
-  ref: SdkInterface,
-  cand: SdkInterface,
+  ref: WorldsSdkInterface,
+  cand: WorldsSdkInterface,
   expected: number,
   failures: string[],
 ): Promise<void> {
@@ -228,7 +228,7 @@ async function checkQuadCounts(
 
 async function checkGraphSizes(
   fixtureName: string,
-  sdk: SdkInterface,
+  sdk: WorldsSdkInterface,
   expected: Record<string, number> | undefined,
   failures: string[],
 ): Promise<void> {
@@ -256,7 +256,7 @@ async function checkGraphSizes(
  */
 async function checkRoundTrip(
   fixtureName: string,
-  candidateFactory: SdkFactory,
+  candidateFactory: WorldsSdkFactory,
   nquads: string,
   failures: string[],
 ): Promise<void> {
@@ -426,7 +426,7 @@ function checkSparqlEquivalence(
   }
 }
 
-async function exportQuads(sdk: SdkInterface): Promise<rdfjs.Quad[]> {
+async function exportQuads(sdk: WorldsSdkInterface): Promise<rdfjs.Quad[]> {
   const response = await sdk.export({ format: { kind: "quads" } });
   if (response.kind !== "quads") {
     throw new Error("export did not return quads");
@@ -435,7 +435,7 @@ async function exportQuads(sdk: SdkInterface): Promise<rdfjs.Quad[]> {
 }
 
 async function exportSerialized(
-  sdk: SdkInterface,
+  sdk: WorldsSdkInterface,
 ): Promise<{ data: string; contentType: string }> {
   const response = await sdk.export({
     format: { kind: "serialized", contentType: NQUADS },
@@ -447,7 +447,7 @@ async function exportSerialized(
 }
 
 async function importNquads(
-  sdk: SdkInterface,
+  sdk: WorldsSdkInterface,
   nquads: string,
   mode: ImportRequest["mode"] = "merge",
 ): Promise<void> {


### PR DESCRIPTION
## Summary

Breaking public-API rename for org-wide consistency (tracked in wazootech/workspace#86):

- `Sdk` → `WorldsSdk`
- `SdkInterface` → `WorldsSdkInterface`
- `SdkOptions` → `WorldsSdkOptions`
- `SdkFactory` → `WorldsSdkFactory`
- `createMemorySdk` → `createMemoryWorldsSdk`

Updates source, tests, examples, README, ARCHITECTURE.md, AGENTS.md, and adds a **0.6.0 CHANGELOG entry with migration guide**. Branch is exactly 1 commit ahead of `main`, 0 behind.

## Migration

See the CHANGELOG 0.6.0 entry: replace `Sdk`-family imports/types with their `WorldsSdk` equivalents; no behavioral changes.

🤖 Generated with Codebuff · part of the workspace#86 rename sweep
