### PR TITLE
chore: release 0.6.0

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@worlds/sdk",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "nodeModulesDir": "auto",
   "exports": {
     ".": "./src/mod.ts",


### PR DESCRIPTION
The WorldsSdk rename (#192) added a 0.6.0 CHANGELOG section with migration guide but never bumped \deno.json\ — main stayed at 0.5.0, which was already on JSR since 04:44Z, so the rename is unpublished and every \@worlds/sdk@^0.4.0\ consumer type-checks against pre-rename exports. This releases 0.6.0 so the rename ships.