### PR TITLE
feat(wazoo): add createWazooSdk factory for remote Worlds API access

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -205,7 +205,8 @@ recorded in
 
 ## Non-goals
 
-- `@worlds/sdk` does not include a hosted Wazoo API client.
+- The hosted Worlds API client (`@worlds/sdk/wazoo`) is available via
+  `createWazooSdk`, backed by `@worlds/client` (peer dependency).
 - Durable/immediate persistent backends (LibSQL) are not implemented inside this
   package. They ship in separate JSR packages with different lifecycle and
   dependency profiles.

--- a/deno.json
+++ b/deno.json
@@ -56,6 +56,7 @@
         "check",
         "test"
       ]
-    }
+    },
+    "example:wazoo-hello-world": "deno -A --env ./examples/wazoo-hello-world/main.ts"
   }
 }

--- a/deno.json
+++ b/deno.json
@@ -13,7 +13,8 @@
     "./memory": "./src/memory/mod.ts",
     "./ai-sdk": "./src/ai-sdk/mod.ts",
     "./tfjs-use": "./src/tfjs-use/mod.ts",
-    "./testing": "./src/testing/mod.ts"
+    "./testing": "./src/testing/mod.ts",
+    "./wazoo": "./src/wazoo/mod.ts"
   },
   "imports": {
     "@/": "./src/",
@@ -32,7 +33,8 @@
     "n3": "npm:n3@^2.0.3",
     "@langchain/core": "npm:@langchain/core@^1.1.48",
     "@langchain/textsplitters": "npm:@langchain/textsplitters@^1.0.1",
-    "zod": "npm:zod@^4.4.3"
+    "zod": "npm:zod@^4.4.3",
+    "@worlds/client": "jsr:@worlds/client@^0.1.0"
   },
   "tasks": {
     "download:tfjs-use": "deno -A ./scripts/download-tfjs-use.ts",

--- a/deno.lock
+++ b/deno.lock
@@ -11,6 +11,7 @@
     "jsr:@std/path@^1.1.5": "1.1.5",
     "jsr:@wazoo/sparql-engine@*": "0.4.1",
     "jsr:@wazoo/sparql-engine@~0.4.1": "0.4.1",
+    "jsr:@worlds/client@0.1": "0.1.0",
     "npm:@ai-sdk/google@^3.0.80": "3.0.80_zod@4.4.3",
     "npm:@langchain/core@^1.1.48": "1.1.48",
     "npm:@langchain/textsplitters@^1.0.1": "1.0.1_@langchain+core@1.1.48",
@@ -65,6 +66,9 @@
       "dependencies": [
         "npm:@rdfjs/types"
       ]
+    },
+    "@worlds/client@0.1.0": {
+      "integrity": "0f55a9cdeb6316417233129e9fa000c92d79739b7317a8e1a33704cf2bb2b458"
     }
   },
   "npm": {
@@ -623,6 +627,7 @@
       "jsr:@std/fs@^1.0.24",
       "jsr:@std/path@^1.1.5",
       "jsr:@wazoo/sparql-engine@~0.4.1",
+      "jsr:@worlds/client@0.1",
       "npm:@ai-sdk/google@^3.0.80",
       "npm:@langchain/core@^1.1.48",
       "npm:@langchain/textsplitters@^1.0.1",

--- a/examples/wazoo-hello-world/main.ts
+++ b/examples/wazoo-hello-world/main.ts
@@ -1,0 +1,56 @@
+import { createWazooSdk } from "@worlds/sdk/wazoo";
+
+/**
+ * Wazoo Hello World — connects to a hosted Worlds API via createWazooSdk.
+ *
+ * Environment variables:
+ *   WORLDS_BASE_URL  — Worlds data-plane API root (default: https://worlds-api.wazoo.dev)
+ *   WORLDS_TOKEN     — Bearer token for authentication (required)
+ *   WORLDS_WORLD_ID  — Canonical world identifier, e.g. w_<uuid> (required)
+ *
+ * Usage:
+ *   WORLDS_TOKEN=xxx WORLDS_WORLD_ID=w_xxx deno task example:wazoo-hello-world
+ */
+if (import.meta.main) {
+  const baseUrl = Deno.env.get("WORLDS_BASE_URL") ??
+    "https://worlds-api.wazoo.dev";
+  const token = Deno.env.get("WORLDS_TOKEN");
+  const worldId = Deno.env.get("WORLDS_WORLD_ID");
+
+  if (!token || !worldId) {
+    console.error(
+      "Missing required env vars: WORLDS_TOKEN and WORLDS_WORLD_ID",
+    );
+    console.error(
+      "Usage: WORLDS_TOKEN=xxx WORLDS_WORLD_ID=w_xxx deno task example:wazoo-hello-world",
+    );
+    Deno.exit(1);
+  }
+
+  // Create a remote WorldsSdk — same interface as every other backend
+  const sdk = createWazooSdk({ baseUrl, token, worldId });
+
+  // Import a triple
+  console.log("Importing triple...");
+  await sdk.import({
+    source: {
+      kind: "serialized",
+      data:
+        `<http://example.com/subject> <http://example.com/predicate> "Hello, Wazoo!" .`,
+      contentType: "text/turtle",
+    },
+  });
+  console.log("Import complete.");
+
+  // Search for it
+  console.log("\nSearching for 'Hello'...");
+  const searchResponse = await sdk.search({ query: "Hello" });
+  console.log(JSON.stringify(searchResponse, null, 2));
+
+  // SPARQL query
+  console.log("\nRunning SPARQL query...");
+  const sparqlResponse = await sdk.sparql({
+    query: "SELECT ?s ?p ?o WHERE { ?s ?p ?o } LIMIT 10",
+  });
+  console.log(JSON.stringify(sparqlResponse, null, 2));
+}

--- a/src/wazoo/create-wazoo-sdk.test.ts
+++ b/src/wazoo/create-wazoo-sdk.test.ts
@@ -1,0 +1,413 @@
+import { assertEquals, assertRejects } from "@std/assert";
+import type * as rdfjs from "@rdfjs/types";
+import { DataFactory } from "n3";
+import { createWazooSdk } from "./create-wazoo-sdk.ts";
+import { RemoteQuadStore } from "./remote-quad-store.ts";
+import { RemoteSearchIndex } from "./remote-search-index.ts";
+import { RemoteSparqlEngine } from "./remote-sparql-engine.ts";
+
+const { namedNode, literal, quad } = DataFactory;
+
+// --- Mock client factory ---
+
+interface MockCall {
+  url: string;
+  method: string;
+  body?: unknown;
+  query?: unknown;
+}
+
+function createMockClient(
+  responses: Record<string, unknown>,
+): { client: unknown; calls: MockCall[] } {
+  const calls: MockCall[] = [];
+
+  const handler = {
+    get(
+      _target: unknown,
+      prop: string,
+    ): unknown {
+      if (
+        prop === "get" || prop === "post" || prop === "delete" ||
+        prop === "patch"
+      ) {
+        return (config: Record<string, unknown>) => {
+          calls.push({
+            url: config.url as string,
+            method: prop.toUpperCase(),
+            body: config.body,
+            query: config.query,
+          });
+
+          const url = config.url as string;
+          const responseData = responses[url];
+
+          if (responseData === undefined) {
+            return Promise.resolve({
+              data: null,
+              error: { error: { code: "NOT_FOUND", message: "Not found" } },
+            });
+          }
+
+          return Promise.resolve({ data: responseData, error: null });
+        };
+      }
+      return undefined;
+    },
+  };
+
+  return { client: new Proxy({}, handler), calls };
+}
+
+// --- RemoteQuadStore tests ---
+
+Deno.test("RemoteQuadStore.import serializes quads and calls importWorld", async () => {
+  const { client, calls } = createMockClient({
+    "/worlds/{id}/import": { imported: { quads: 2, chunks: 1 } },
+  });
+
+  const store = new RemoteQuadStore(
+    client as import("@worlds/client").Client,
+    "w_test",
+  );
+
+  const quads: rdfjs.Quad[] = [
+    quad(
+      namedNode("http://example.com/s1"),
+      namedNode("http://example.com/p1"),
+      literal("hello"),
+    ),
+    quad(
+      namedNode("http://example.com/s2"),
+      namedNode("http://example.com/p2"),
+      literal("world"),
+    ),
+  ];
+
+  await store.import({
+    mode: "merge",
+    source: { kind: "quads", quads },
+  });
+
+  assertEquals(calls.length, 1);
+  assertEquals(calls[0].url, "/worlds/{id}/import");
+  assertEquals(calls[0].method, "POST");
+  const body = calls[0].body as { data: string; contentType: string };
+  assertEquals(body.contentType, "application/n-quads");
+  assertEquals(body.data.includes("http://example.com/s1"), true);
+  assertEquals(body.data.includes("hello"), true);
+});
+
+Deno.test("RemoteQuadStore.import passes serialized source directly", async () => {
+  const { client, calls } = createMockClient({
+    "/worlds/{id}/import": { imported: { quads: 1, chunks: 1 } },
+  });
+
+  const store = new RemoteQuadStore(
+    client as import("@worlds/client").Client,
+    "w_test",
+  );
+
+  const nquads = `<http://example.com/s> <http://example.com/p> "test" .`;
+
+  await store.import({
+    mode: "merge",
+    source: { kind: "serialized", data: nquads, contentType: "text/turtle" },
+  });
+
+  assertEquals(calls.length, 1);
+  const body = calls[0].body as { data: string; contentType: string };
+  assertEquals(body.data, nquads);
+  assertEquals(body.contentType, "text/turtle");
+});
+
+Deno.test("RemoteQuadStore.export returns quads from API", async () => {
+  const { client, calls } = createMockClient({
+    "/worlds/{id}/export": {
+      quads: [
+        {
+          subject: "http://example.com/s",
+          predicate: "http://example.com/p",
+          object: '"hello"',
+        },
+      ],
+    },
+  });
+
+  const store = new RemoteQuadStore(
+    client as import("@worlds/client").Client,
+    "w_test",
+  );
+
+  const result = await store.export({ format: { kind: "quads" } });
+
+  assertEquals(calls.length, 1);
+  assertEquals(calls[0].url, "/worlds/{id}/export");
+  assertEquals(result.kind, "quads");
+  if (result.kind === "quads") {
+    assertEquals(result.quads.length, 1);
+    assertEquals(result.quads[0].subject.value, "http://example.com/s");
+    assertEquals(result.quads[0].predicate.value, "http://example.com/p");
+    assertEquals(result.quads[0].object.value, "hello");
+  }
+});
+
+Deno.test("RemoteQuadStore.export serialized format returns string", async () => {
+  const { client, calls } = createMockClient({
+    "/worlds/{id}/export": {
+      quads: [
+        {
+          subject: "http://example.com/s",
+          predicate: "http://example.com/p",
+          object: '"hello"',
+        },
+      ],
+    },
+  });
+
+  const store = new RemoteQuadStore(
+    client as import("@worlds/client").Client,
+    "w_test",
+  );
+
+  const result = await store.export({
+    format: { kind: "serialized", contentType: "application/n-quads" },
+  });
+
+  assertEquals(calls.length, 1);
+  assertEquals(result.kind, "serialized");
+  if (result.kind === "serialized") {
+    assertEquals(typeof result.data, "string");
+    assertEquals(result.contentType, "application/n-quads");
+  }
+});
+
+Deno.test("RemoteQuadStore.import throws on API error", async () => {
+  const { client } = createMockClient({
+    "/worlds/{id}/import": undefined,
+  });
+
+  const store = new RemoteQuadStore(
+    client as import("@worlds/client").Client,
+    "w_test",
+  );
+
+  await assertRejects(
+    () =>
+      store.import({
+        mode: "merge",
+        source: {
+          kind: "serialized",
+          data: "bad data",
+          contentType: "text/turtle",
+        },
+      }),
+    Error,
+    "Import failed",
+  );
+});
+
+// --- RemoteSearchIndex tests ---
+
+Deno.test("RemoteSearchIndex.search delegates to searchWorld", async () => {
+  const { client, calls } = createMockClient({
+    "/worlds/{id}/search": {
+      results: [
+        {
+          subject: "http://example.com/s",
+          predicate: "http://example.com/p",
+          graph: "http://example.com/g",
+          content: "hello world",
+          score: 0.95,
+        },
+      ],
+    },
+  });
+
+  const searchIndex = new RemoteSearchIndex(
+    client as import("@worlds/client").Client,
+    "w_test",
+  );
+
+  const result = await searchIndex.search({
+    query: "hello",
+    topK: 5,
+    minScore: 0.5,
+    include: {},
+    exclude: {},
+  });
+
+  assertEquals(calls.length, 1);
+  assertEquals(calls[0].url, "/worlds/{id}/search");
+  assertEquals(result.results?.length, 1);
+  assertEquals(result.results?.[0].subject, "http://example.com/s");
+  assertEquals(result.results?.[0].text, "hello world");
+  assertEquals(result.results?.[0].score, 0.95);
+  assertEquals(result.results?.[0].graph, "http://example.com/g");
+});
+
+Deno.test("RemoteSearchIndex.reindex delegates to reindexWorld", async () => {
+  const { client, calls } = createMockClient({
+    "/worlds/{id}/reindex": { ok: true, status: "completed" },
+  });
+
+  const searchIndex = new RemoteSearchIndex(
+    client as import("@worlds/client").Client,
+    "w_test",
+  );
+
+  const result = await searchIndex.reindex();
+
+  assertEquals(calls.length, 1);
+  assertEquals(calls[0].url, "/worlds/{id}/reindex");
+  assertEquals(result.processedQuadCount, 0);
+  assertEquals(result.chunkRowCount, 0);
+});
+
+Deno.test("RemoteSearchIndex.search throws on API error", async () => {
+  const { client } = createMockClient({
+    "/worlds/{id}/search": undefined,
+  });
+
+  const searchIndex = new RemoteSearchIndex(
+    client as import("@worlds/client").Client,
+    "w_test",
+  );
+
+  await assertRejects(
+    () =>
+      searchIndex.search({
+        query: "test",
+        include: {},
+        exclude: {},
+      }),
+    Error,
+    "Search failed",
+  );
+});
+
+// --- RemoteSparqlEngine tests ---
+
+Deno.test("RemoteSparqlEngine.execute delegates to sparqlWorld", async () => {
+  const { client, calls } = createMockClient({
+    "/worlds/{id}/sparql": {
+      head: { vars: ["p", "o"] },
+      results: {
+        bindings: [
+          {
+            p: { type: "uri", value: "http://example.com/p" },
+            o: { type: "literal", value: "hello" },
+          },
+        ],
+      },
+    },
+  });
+
+  const engine = new RemoteSparqlEngine(
+    client as import("@worlds/client").Client,
+    "w_test",
+  );
+
+  const result = await engine.execute({
+    query: "SELECT ?p ?o WHERE { <http://example.com/s> ?p ?o }",
+  });
+
+  assertEquals(calls.length, 1);
+  assertEquals(calls[0].url, "/worlds/{id}/sparql");
+  assertEquals(result.kind, "select");
+  if (result.kind === "select") {
+    assertEquals(result.data.head.vars, ["p", "o"]);
+    assertEquals(result.data.results.bindings.length, 1);
+    assertEquals(result.data.results.bindings[0].p.type, "uri");
+    assertEquals(
+      (result.data.results.bindings[0].p as { value: string }).value,
+      "http://example.com/p",
+    );
+  }
+});
+
+Deno.test("RemoteSparqlEngine.execute handles ASK responses", async () => {
+  const { client } = createMockClient({
+    "/worlds/{id}/sparql": {
+      head: {},
+      boolean: true,
+    },
+  });
+
+  const engine = new RemoteSparqlEngine(
+    client as import("@worlds/client").Client,
+    "w_test",
+  );
+
+  const result = await engine.execute({
+    query: "ASK WHERE { ?s ?p ?o }",
+  });
+
+  assertEquals(result.kind, "ask");
+  if (result.kind === "ask") {
+    assertEquals(result.data.boolean, true);
+  }
+});
+
+Deno.test("RemoteSparqlEngine.execute handles CONSTRUCT responses", async () => {
+  const { client } = createMockClient({
+    "/worlds/{id}/sparql": {
+      head: {},
+      quads: [
+        {
+          subject: "http://example.com/s",
+          predicate: "http://example.com/p",
+          object: '"hello"',
+        },
+      ],
+    },
+  });
+
+  const engine = new RemoteSparqlEngine(
+    client as import("@worlds/client").Client,
+    "w_test",
+  );
+
+  const result = await engine.execute({
+    query: "CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }",
+  });
+
+  assertEquals(result.kind, "construct");
+  if (result.kind === "construct") {
+    assertEquals(result.data.quads.length, 1);
+    assertEquals(result.data.quads[0].subject.value, "http://example.com/s");
+  }
+});
+
+Deno.test("RemoteSparqlEngine.execute throws on API error", async () => {
+  const { client } = createMockClient({
+    "/worlds/{id}/sparql": undefined,
+  });
+
+  const engine = new RemoteSparqlEngine(
+    client as import("@worlds/client").Client,
+    "w_test",
+  );
+
+  await assertRejects(
+    () => engine.execute({ query: "SELECT ?s WHERE { ?s ?p ?o }" }),
+    Error,
+    "SPARQL failed",
+  );
+});
+
+// --- createWazooSdk factory test ---
+
+Deno.test("createWazooSdk returns a WorldsSdkInterface", () => {
+  const sdk = createWazooSdk({
+    baseUrl: "https://worlds-api.wazoo.dev",
+    token: "test-token",
+    worldId: "w_test",
+  });
+
+  assertEquals(typeof sdk.import, "function");
+  assertEquals(typeof sdk.export, "function");
+  assertEquals(typeof sdk.search, "function");
+  assertEquals(typeof sdk.sparql, "function");
+  assertEquals(typeof sdk.reindex, "function");
+});

--- a/src/wazoo/create-wazoo-sdk.test.ts
+++ b/src/wazoo/create-wazoo-sdk.test.ts
@@ -379,6 +379,79 @@ Deno.test("RemoteSparqlEngine.execute handles CONSTRUCT responses", async () => 
   }
 });
 
+Deno.test("RemoteSparqlEngine.execute parses literal terms in CONSTRUCT", async () => {
+  const { client } = createMockClient({
+    "/worlds/{id}/sparql": {
+      head: {},
+      quads: [
+        {
+          subject: "http://example.com/s",
+          predicate: "http://example.com/p",
+          object: '"hello"^^<http://www.w3.org/2001/XMLSchema#string>',
+        },
+        {
+          subject: "http://example.com/s",
+          predicate: "http://example.com/lang",
+          object: '"bonjour"@fr',
+        },
+        {
+          subject: "http://example.com/s",
+          predicate: "http://example.com/node",
+          object: "_:b0",
+        },
+        {
+          subject: "http://example.com/s",
+          predicate: "http://example.com/iri",
+          object: "http://example.com/target",
+        },
+      ],
+    },
+  });
+
+  const engine = new RemoteSparqlEngine(
+    client as import("@worlds/client").Client,
+    "w_test",
+  );
+
+  const result = await engine.execute({
+    query: "CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }",
+  });
+
+  assertEquals(result.kind, "construct");
+  if (result.kind === "construct") {
+    assertEquals(result.data.quads.length, 4);
+
+    // Typed literal
+    const typed = result.data.quads[0].object;
+    assertEquals(typed.termType, "Literal");
+    assertEquals(typed.value, "hello");
+    if (typed.termType === "Literal") {
+      assertEquals(
+        typed.datatype.value,
+        "http://www.w3.org/2001/XMLSchema#string",
+      );
+    }
+
+    // Language-tagged literal
+    const lang = result.data.quads[1].object;
+    assertEquals(lang.termType, "Literal");
+    if (lang.termType === "Literal") {
+      assertEquals(lang.value, "bonjour");
+      assertEquals(lang.language, "fr");
+    }
+
+    // Blank node
+    const bnode = result.data.quads[2].object;
+    assertEquals(bnode.termType, "BlankNode");
+    assertEquals(bnode.value, "b0");
+
+    // Named node
+    const named = result.data.quads[3].object;
+    assertEquals(named.termType, "NamedNode");
+    assertEquals(named.value, "http://example.com/target");
+  }
+});
+
 Deno.test("RemoteSparqlEngine.execute throws on API error", async () => {
   const { client } = createMockClient({
     "/worlds/{id}/sparql": undefined,

--- a/src/wazoo/create-wazoo-sdk.ts
+++ b/src/wazoo/create-wazoo-sdk.ts
@@ -1,0 +1,57 @@
+import { type Client, createClient } from "@worlds/client";
+import { WorldsSdk } from "@/client/client.ts";
+import type { WorldsSdkInterface } from "@/client/client.ts";
+import { RemoteQuadStore } from "./remote-quad-store.ts";
+import { RemoteSearchIndex } from "./remote-search-index.ts";
+import { RemoteSparqlEngine } from "./remote-sparql-engine.ts";
+
+/**
+ * CreateWazooSdkOptions configures the remote Worlds SDK client.
+ */
+export interface CreateWazooSdkOptions {
+  /** baseUrl is the root URL of the Worlds data-plane API. */
+  baseUrl: string;
+
+  /** token is the Bearer token used to authenticate requests. */
+  token: string;
+
+  /** worldId is the canonical world identifier (e.g. w_<uuid>). */
+  worldId: string;
+}
+
+/**
+ * createWazooSdk assembles a WorldsSdk backed by the remote Worlds API.
+ *
+ * It wires RemoteQuadStore, RemoteSearchIndex, and RemoteSparqlEngine adapters
+ * behind the standard SdkInterface, giving consumers a one-call remote
+ * connection to any hosted Worlds API instance.
+ *
+ * @example
+ * ```ts
+ * import { createWazooSdk } from "@worlds/sdk/wazoo";
+ *
+ * const sdk = createWazooSdk({
+ *   baseUrl: "https://worlds-api.wazoo.dev",
+ *   token: process.env.WORLDS_TOKEN!,
+ *   worldId: "w_my-world",
+ * });
+ *
+ * const results = await sdk.search({ query: "explores" });
+ * ```
+ */
+export function createWazooSdk(
+  options: CreateWazooSdkOptions,
+): WorldsSdkInterface {
+  const client: Client = createClient({
+    baseUrl: options.baseUrl,
+    headers: {
+      Authorization: `Bearer ${options.token}`,
+    },
+  });
+
+  const quadStore = new RemoteQuadStore(client, options.worldId);
+  const searchIndex = new RemoteSearchIndex(client, options.worldId);
+  const sparqlEngine = new RemoteSparqlEngine(client, options.worldId);
+
+  return new WorldsSdk({ quadStore, searchIndex, sparqlEngine });
+}

--- a/src/wazoo/mod.ts
+++ b/src/wazoo/mod.ts
@@ -1,0 +1,7 @@
+export {
+  createWazooSdk,
+  type CreateWazooSdkOptions,
+} from "./create-wazoo-sdk.ts";
+export { RemoteQuadStore } from "./remote-quad-store.ts";
+export { RemoteSearchIndex } from "./remote-search-index.ts";
+export { RemoteSparqlEngine } from "./remote-sparql-engine.ts";

--- a/src/wazoo/remote-quad-store.ts
+++ b/src/wazoo/remote-quad-store.ts
@@ -8,6 +8,7 @@ import type {
   ImportRequest,
   QuadStoreInterface,
 } from "@/client/quad-store/mod.ts";
+import { parseNQuadsTerm } from "./term-parser.ts";
 
 /**
  * RemoteQuadStore implements QuadStoreInterface by delegating to the Worlds
@@ -89,11 +90,11 @@ function apiQuadToRdfjs(
   return {
     termType: "Quad" as const,
     value: "",
-    subject: termFromApi(q.subject) as rdfjs.Quad_Subject,
-    predicate: termFromApi(q.predicate) as rdfjs.Quad_Predicate,
-    object: termFromApi(q.object) as rdfjs.Quad_Object,
+    subject: parseNQuadsTerm(q.subject) as rdfjs.Quad_Subject,
+    predicate: parseNQuadsTerm(q.predicate) as rdfjs.Quad_Predicate,
+    object: parseNQuadsTerm(q.object) as rdfjs.Quad_Object,
     graph: q.graph
-      ? termFromApi(q.graph) as rdfjs.Quad_Graph
+      ? parseNQuadsTerm(q.graph) as rdfjs.Quad_Graph
       : { termType: "DefaultGraph" as const, value: "" } as rdfjs.DefaultGraph,
     equals(other: rdfjs.Term): boolean {
       if (other.termType !== "Quad") return false;
@@ -102,57 +103,4 @@ function apiQuadToRdfjs(
         this.object.equals(other.object);
     },
   };
-}
-
-/**
- * termFromApi converts a string IRI/bnode/literal from the Worlds API
- * into an RDF/JS term.
- */
-function termFromApi(value: string): rdfjs.Term {
-  if (value.startsWith("_:")) {
-    return { termType: "BlankNode", value: value.slice(2) } as rdfjs.Term;
-  }
-
-  if (value.startsWith('"')) {
-    // Simple literal: "value" or "value"^^<datatype> or "value"@lang
-    const match = value.match(
-      /^"(.*)"(?:\^\^(<.*>))?(@.*)?$/,
-    );
-    if (match) {
-      const [, lexical, datatype, lang] = match;
-      if (lang) {
-        return {
-          termType: "Literal",
-          value: lexical,
-          language: lang.slice(1),
-          datatype: {
-            termType: "NamedNode",
-            value: "http://www.w3.org/2001/XMLSchema#string",
-          },
-        } as rdfjs.Term;
-      }
-      if (datatype) {
-        return {
-          termType: "Literal",
-          value: lexical,
-          language: "",
-          datatype: {
-            termType: "NamedNode",
-            value: datatype,
-          },
-        } as rdfjs.Term;
-      }
-      return {
-        termType: "Literal",
-        value: lexical,
-        language: "",
-        datatype: {
-          termType: "NamedNode",
-          value: "http://www.w3.org/2001/XMLSchema#string",
-        },
-      } as rdfjs.Term;
-    }
-  }
-
-  return { termType: "NamedNode", value } as rdfjs.Term;
 }

--- a/src/wazoo/remote-quad-store.ts
+++ b/src/wazoo/remote-quad-store.ts
@@ -1,0 +1,152 @@
+import type * as rdfjs from "@rdfjs/types";
+import { type Client, exportWorld, importWorld } from "@worlds/client";
+import { serializeTurtle } from "@wazoo/sparql-engine";
+import { materializeImportQuads } from "@/client/quad-store/rdf-formats.ts";
+import type {
+  ExportRequest,
+  ExportResponse,
+  ImportRequest,
+  QuadStoreInterface,
+} from "@/client/quad-store/mod.ts";
+
+/**
+ * RemoteQuadStore implements QuadStoreInterface by delegating to the Worlds
+ * data-plane API via @worlds/client.
+ */
+export class RemoteQuadStore implements QuadStoreInterface {
+  constructor(
+    private readonly client: Client,
+    private readonly worldId: string,
+  ) {}
+
+  async import(request: ImportRequest): Promise<void> {
+    let data: string;
+    let contentType: string;
+
+    if (request.source.kind === "serialized") {
+      data = request.source.data;
+      contentType = request.source.contentType ?? "application/n-quads";
+    } else {
+      const quads = await materializeImportQuads(request.source);
+      data = serializeTurtle(quads, { format: "n-quads" });
+      contentType = "application/n-quads";
+    }
+
+    const result = await importWorld({
+      client: this.client,
+      path: { id: this.worldId },
+      body: { data, contentType },
+    });
+
+    if (result.error) {
+      throw new Error(
+        `Import failed: ${result.error.error.code} — ${result.error.error.message}`,
+      );
+    }
+  }
+
+  async export(request: ExportRequest): Promise<ExportResponse> {
+    const format = request.format.kind === "serialized"
+      ? (request.format.contentType ?? "application/n-quads")
+      : undefined;
+
+    const result = await exportWorld({
+      client: this.client,
+      path: { id: this.worldId },
+      query: format ? { format } : undefined,
+    });
+
+    if (result.error) {
+      throw new Error(
+        `Export failed: ${result.error.error.code} — ${result.error.error.message}`,
+      );
+    }
+
+    const data = result.data;
+    const quads: rdfjs.Quad[] = data.quads.map((q) => apiQuadToRdfjs(q));
+
+    if (request.format.kind === "quads") {
+      return { kind: "quads", quads };
+    }
+
+    const contentType = request.format.contentType ?? "application/n-quads";
+    const serialized = serializeTurtle(quads, { format: "n-quads" });
+    return { kind: "serialized", data: serialized, contentType };
+  }
+}
+
+/**
+ * apiQuadToRdfjs converts a Worlds API quad object into an RDF/JS Quad.
+ */
+function apiQuadToRdfjs(
+  q: { subject: string; predicate: string; object: string; graph?: string },
+): rdfjs.Quad {
+  return {
+    termType: "Quad" as const,
+    value: "",
+    subject: termFromApi(q.subject) as rdfjs.Quad_Subject,
+    predicate: termFromApi(q.predicate) as rdfjs.Quad_Predicate,
+    object: termFromApi(q.object) as rdfjs.Quad_Object,
+    graph: q.graph
+      ? termFromApi(q.graph) as rdfjs.Quad_Graph
+      : { termType: "DefaultGraph" as const, value: "" } as rdfjs.DefaultGraph,
+    equals(other: rdfjs.Term): boolean {
+      return this.subject.equals(other) &&
+        this.predicate.equals(other) &&
+        this.object.equals(other);
+    },
+  };
+}
+
+/**
+ * termFromApi converts a string IRI/bnode/literal from the Worlds API
+ * into an RDF/JS term.
+ */
+function termFromApi(value: string): rdfjs.Term {
+  if (value.startsWith("_:")) {
+    return { termType: "BlankNode", value: value.slice(2) } as rdfjs.Term;
+  }
+
+  if (value.startsWith('"')) {
+    // Simple literal: "value" or "value"^^<datatype> or "value"@lang
+    const match = value.match(
+      /^"(.*)"(?:\^\^(<.*>))?(@.*)?$/,
+    );
+    if (match) {
+      const [, lexical, datatype, lang] = match;
+      if (lang) {
+        return {
+          termType: "Literal",
+          value: lexical,
+          language: lang.slice(1),
+          datatype: {
+            termType: "NamedNode",
+            value: "http://www.w3.org/2001/XMLSchema#string",
+          },
+        } as rdfjs.Term;
+      }
+      if (datatype) {
+        return {
+          termType: "Literal",
+          value: lexical,
+          language: "",
+          datatype: {
+            termType: "NamedNode",
+            value: datatype,
+          },
+        } as rdfjs.Term;
+      }
+      return {
+        termType: "Literal",
+        value: lexical,
+        language: "",
+        datatype: {
+          termType: "NamedNode",
+          value: "http://www.w3.org/2001/XMLSchema#string",
+        },
+      } as rdfjs.Term;
+    }
+  }
+
+  return { termType: "NamedNode", value } as rdfjs.Term;
+}

--- a/src/wazoo/remote-quad-store.ts
+++ b/src/wazoo/remote-quad-store.ts
@@ -12,6 +12,11 @@ import type {
 /**
  * RemoteQuadStore implements QuadStoreInterface by delegating to the Worlds
  * data-plane API via @worlds/client.
+ *
+ * Limitations vs local backends:
+ * - `import.mode` is ignored (the API always merges). Replace semantics are
+ *   not supported by the data-plane API.
+ * - `export` does not support QuadFilter (include/exclude) scoping.
  */
 export class RemoteQuadStore implements QuadStoreInterface {
   constructor(
@@ -91,9 +96,10 @@ function apiQuadToRdfjs(
       ? termFromApi(q.graph) as rdfjs.Quad_Graph
       : { termType: "DefaultGraph" as const, value: "" } as rdfjs.DefaultGraph,
     equals(other: rdfjs.Term): boolean {
-      return this.subject.equals(other) &&
-        this.predicate.equals(other) &&
-        this.object.equals(other);
+      if (other.termType !== "Quad") return false;
+      return this.subject.equals(other.subject) &&
+        this.predicate.equals(other.predicate) &&
+        this.object.equals(other.object);
     },
   };
 }

--- a/src/wazoo/remote-search-index.ts
+++ b/src/wazoo/remote-search-index.ts
@@ -10,6 +10,13 @@ import type {
 /**
  * RemoteSearchIndex implements SearchIndexInterface by delegating to the Worlds
  * data-plane API via @worlds/client.
+ *
+ * Limitations vs local backends:
+ * - `search` QuadFilter (include/exclude) is ignored. The API does not support
+ *   graph-scoped search filtering.
+ * - `reindex` QuadFilter and readPageSize are ignored. The server-side reindex
+ *   is opaque; the response always reports 0 for processedQuadCount and
+ *   chunkRowCount.
  */
 export class RemoteSearchIndex implements SearchIndexInterface {
   constructor(

--- a/src/wazoo/remote-search-index.ts
+++ b/src/wazoo/remote-search-index.ts
@@ -1,0 +1,70 @@
+import { type Client, reindexWorld, searchWorld } from "@worlds/client";
+import type {
+  ReindexRequest,
+  ReindexResponse,
+  SearchIndexInterface,
+  SearchRequest,
+  SearchResponse,
+} from "@/client/search-index/mod.ts";
+
+/**
+ * RemoteSearchIndex implements SearchIndexInterface by delegating to the Worlds
+ * data-plane API via @worlds/client.
+ */
+export class RemoteSearchIndex implements SearchIndexInterface {
+  constructor(
+    private readonly client: Client,
+    private readonly worldId: string,
+  ) {}
+
+  async search(request: SearchRequest): Promise<SearchResponse> {
+    const result = await searchWorld({
+      client: this.client,
+      path: { id: this.worldId },
+      body: {
+        query: request.query,
+        topK: request.topK,
+        minScore: request.minScore,
+      },
+    });
+
+    if (result.error) {
+      throw new Error(
+        `Search failed: ${result.error.error.code} — ${result.error.error.message}`,
+      );
+    }
+
+    return {
+      results: result.data.results.map((r) => ({
+        id: `${r.subject}#${r.predicate}`,
+        subject: r.subject,
+        predicate: r.predicate,
+        graph: r.graph ?? "",
+        text: r.content ?? "",
+        score: r.score ?? 0,
+      })),
+    };
+  }
+
+  async reindex(_request?: ReindexRequest): Promise<ReindexResponse> {
+    const result = await reindexWorld({
+      client: this.client,
+      path: { id: this.worldId },
+    });
+
+    if (result.error) {
+      throw new Error(
+        `Reindex failed: ${result.error.error.code} — ${result.error.error.message}`,
+      );
+    }
+
+    // The API returns { ok, status } but the SDK interface expects
+    // { processedQuadCount, chunkRowCount }. The server-side reindex is
+    // opaque, so we return 0 for both counts — the caller only cares
+    // that it succeeded.
+    return {
+      processedQuadCount: 0,
+      chunkRowCount: 0,
+    };
+  }
+}

--- a/src/wazoo/remote-sparql-engine.ts
+++ b/src/wazoo/remote-sparql-engine.ts
@@ -1,0 +1,173 @@
+import type * as rdfjs from "@rdfjs/types";
+import { type Client, sparqlWorld } from "@worlds/client";
+import type {
+  SparqlEngineInterface,
+  SparqlRequest,
+  SparqlResponse,
+} from "@/client/sparql-engine/mod.ts";
+
+/**
+ * RemoteSparqlEngine implements SparqlEngineInterface by delegating to the
+ * Worlds data-plane API via @worlds/client.
+ */
+export class RemoteSparqlEngine implements SparqlEngineInterface {
+  constructor(
+    private readonly client: Client,
+    private readonly worldId: string,
+  ) {}
+
+  async execute(request: SparqlRequest): Promise<SparqlResponse> {
+    const result = await sparqlWorld({
+      client: this.client,
+      path: { id: this.worldId },
+      body: { query: request.query },
+    });
+
+    if (result.error) {
+      throw new Error(
+        `SPARQL failed: ${result.error.error.code} — ${result.error.error.message}`,
+      );
+    }
+
+    return parseSparqlResponse(result.data);
+  }
+}
+
+/**
+ * parseSparqlResponse interprets the raw JSON response from the Worlds API
+ * and returns a typed SparqlResponse.
+ */
+function parseSparqlResponse(data: unknown): SparqlResponse {
+  if (!data || typeof data !== "object") {
+    return { kind: "void" };
+  }
+
+  const obj = data as Record<string, unknown>;
+
+  // SELECT results: { head: { vars }, results: { bindings } }
+  if (
+    obj.head && typeof obj.head === "object" &&
+    "vars" in obj.head &&
+    obj.results && typeof obj.results === "object" &&
+    "bindings" in obj.results
+  ) {
+    const head = obj.head as { vars: string[]; link?: string[] };
+    const results = obj.results as {
+      bindings: Array<Record<string, unknown>>;
+    };
+
+    return {
+      kind: "select",
+      data: {
+        head: { vars: head.vars, link: head.link },
+        results: {
+          bindings: results.bindings.map((b) =>
+            parseBindings(b) as Record<
+              string,
+              import("@wazoo/sparql-engine").SparqlValue
+            >
+          ),
+        },
+      },
+    };
+  }
+
+  // ASK results: { head: {}, boolean: true/false }
+  if ("boolean" in obj && typeof obj.boolean === "boolean") {
+    return {
+      kind: "ask",
+      data: {
+        head: { link: undefined },
+        boolean: obj.boolean,
+      },
+    };
+  }
+
+  // CONSTRUCT results: { head: {}, quads: [...] }
+  if ("quads" in obj && Array.isArray(obj.quads)) {
+    return {
+      kind: "construct",
+      data: {
+        quads: obj.quads.map((q: Record<string, unknown>) => quadFromApi(q)),
+      },
+    };
+  }
+
+  return { kind: "void" };
+}
+
+function parseBindings(
+  raw: Record<string, unknown>,
+): Record<string, import("@wazoo/sparql-engine").SparqlValue> {
+  const result: Record<string, import("@wazoo/sparql-engine").SparqlValue> = {};
+  for (const [key, val] of Object.entries(raw)) {
+    result[key] = sparqlValueFromApi(val as Record<string, unknown>);
+  }
+  return result;
+}
+
+function sparqlValueFromApi(
+  val: Record<string, unknown>,
+): import("@wazoo/sparql-engine").SparqlValue {
+  const type = val.type as string;
+  const value = val.value as string;
+
+  if (type === "uri") {
+    return { type: "uri", value };
+  }
+  if (type === "bnode") {
+    return { type: "bnode", value };
+  }
+  if (type === "literal") {
+    return {
+      type: "literal",
+      value,
+      "xml:lang": (val["xml:lang"] as string) || undefined,
+      datatype: (val.datatype as string) || undefined,
+    };
+  }
+  if (type === "triple") {
+    const tripleVal = val.value as Record<string, unknown>;
+    return {
+      type: "triple",
+      value: {
+        subject: sparqlValueFromApi(
+          tripleVal.subject as Record<string, unknown>,
+        ),
+        predicate: sparqlValueFromApi(
+          tripleVal.predicate as Record<string, unknown>,
+        ),
+        object: sparqlValueFromApi(
+          tripleVal.object as Record<string, unknown>,
+        ),
+      },
+    };
+  }
+
+  return { type: "uri", value: String(value) };
+}
+
+function quadFromApi(q: Record<string, unknown>): rdfjs.Quad {
+  return {
+    termType: "Quad",
+    value: "",
+    subject: rdfTermFromApi(q.subject as string),
+    predicate: rdfTermFromApi(q.predicate as string),
+    object: rdfTermFromApi(q.object as string),
+    graph: q.graph
+      ? rdfTermFromApi(q.graph as string)
+      : { termType: "DefaultGraph", value: "" },
+    equals(other: rdfjs.Term): boolean {
+      return this.subject.equals(other) &&
+        this.predicate.equals(other) &&
+        this.object.equals(other);
+    },
+  } as rdfjs.Quad;
+}
+
+function rdfTermFromApi(value: string): rdfjs.Term {
+  if (value.startsWith("_:")) {
+    return { termType: "BlankNode", value: value.slice(2) } as rdfjs.Term;
+  }
+  return { termType: "NamedNode", value } as rdfjs.Term;
+}

--- a/src/wazoo/remote-sparql-engine.ts
+++ b/src/wazoo/remote-sparql-engine.ts
@@ -9,6 +9,10 @@ import type {
 /**
  * RemoteSparqlEngine implements SparqlEngineInterface by delegating to the
  * Worlds data-plane API via @worlds/client.
+ *
+ * Limitations vs local engines:
+ * - `baseIri`, `timeoutMs`, and `signal` are ignored. The API determines
+ *   timeout and does not support abort signals.
  */
 export class RemoteSparqlEngine implements SparqlEngineInterface {
   constructor(
@@ -158,9 +162,10 @@ function quadFromApi(q: Record<string, unknown>): rdfjs.Quad {
       ? rdfTermFromApi(q.graph as string)
       : { termType: "DefaultGraph", value: "" },
     equals(other: rdfjs.Term): boolean {
-      return this.subject.equals(other) &&
-        this.predicate.equals(other) &&
-        this.object.equals(other);
+      if (other.termType !== "Quad") return false;
+      return this.subject.equals(other.subject) &&
+        this.predicate.equals(other.predicate) &&
+        this.object.equals(other.object);
     },
   } as rdfjs.Quad;
 }

--- a/src/wazoo/remote-sparql-engine.ts
+++ b/src/wazoo/remote-sparql-engine.ts
@@ -5,6 +5,7 @@ import type {
   SparqlRequest,
   SparqlResponse,
 } from "@/client/sparql-engine/mod.ts";
+import { parseNQuadsTerm } from "./term-parser.ts";
 
 /**
  * RemoteSparqlEngine implements SparqlEngineInterface by delegating to the
@@ -155,11 +156,11 @@ function quadFromApi(q: Record<string, unknown>): rdfjs.Quad {
   return {
     termType: "Quad",
     value: "",
-    subject: rdfTermFromApi(q.subject as string),
-    predicate: rdfTermFromApi(q.predicate as string),
-    object: rdfTermFromApi(q.object as string),
+    subject: parseNQuadsTerm(q.subject as string),
+    predicate: parseNQuadsTerm(q.predicate as string),
+    object: parseNQuadsTerm(q.object as string),
     graph: q.graph
-      ? rdfTermFromApi(q.graph as string)
+      ? parseNQuadsTerm(q.graph as string)
       : { termType: "DefaultGraph", value: "" },
     equals(other: rdfjs.Term): boolean {
       if (other.termType !== "Quad") return false;
@@ -168,11 +169,4 @@ function quadFromApi(q: Record<string, unknown>): rdfjs.Quad {
         this.object.equals(other.object);
     },
   } as rdfjs.Quad;
-}
-
-function rdfTermFromApi(value: string): rdfjs.Term {
-  if (value.startsWith("_:")) {
-    return { termType: "BlankNode", value: value.slice(2) } as rdfjs.Term;
-  }
-  return { termType: "NamedNode", value } as rdfjs.Term;
 }

--- a/src/wazoo/term-parser.ts
+++ b/src/wazoo/term-parser.ts
@@ -1,0 +1,47 @@
+import type * as rdfjs from "@rdfjs/types";
+
+const XSD_STRING = "http://www.w3.org/2001/XMLSchema#string";
+
+const LITERAL_RE = /^"(.*)"(?:\^\^(<.*>))?(@.*)?$/;
+
+/**
+ * parseNQuadsTerm converts an N-Quads-serialized string (IRI, blank node,
+ * or literal) into an RDF/JS term. Used by both the remote quad store and
+ * the remote SPARQL engine when the API returns N-Quads string values.
+ */
+export function parseNQuadsTerm(value: string): rdfjs.Term {
+  if (value.startsWith("_:")) {
+    return { termType: "BlankNode", value: value.slice(2) } as rdfjs.Term;
+  }
+
+  if (value.startsWith('"')) {
+    const match = value.match(LITERAL_RE);
+    if (match) {
+      const [, lexical, datatype, lang] = match;
+      if (lang) {
+        return {
+          termType: "Literal",
+          value: lexical,
+          language: lang.slice(1),
+          datatype: { termType: "NamedNode", value: XSD_STRING },
+        } as rdfjs.Term;
+      }
+      if (datatype) {
+        return {
+          termType: "Literal",
+          value: lexical,
+          language: "",
+          datatype: { termType: "NamedNode", value: datatype.slice(1, -1) },
+        } as rdfjs.Term;
+      }
+      return {
+        termType: "Literal",
+        value: lexical,
+        language: "",
+        datatype: { termType: "NamedNode", value: XSD_STRING },
+      } as rdfjs.Term;
+    }
+  }
+
+  return { termType: "NamedNode", value } as rdfjs.Term;
+}


### PR DESCRIPTION
## Summary

Add `@worlds/sdk/wazoo` subpath export with `createWazooSdk(options)` factory that wires `@worlds/client` behind the existing `WorldsSdkInterface`.

## What's included

- **`RemoteQuadStore`** — delegates `import`/`export` to `importWorld`/`exportWorld` from `@worlds/client`
- **`RemoteSearchIndex`** — delegates `search`/`reindex` to `searchWorld`/`reindexWorld`
- **`RemoteSparqlEngine`** — delegates `execute` to `sparqlWorld`, parses SELECT/ASK/CONSTRUCT responses
- **`createWazooSdk(options)`** — one-call factory assembling all three adapters behind `WorldsSdk`
- **13 unit tests** with mocked `@worlds/client`, all passing

## Usage

```ts
import { createWazooSdk } from "@worlds/sdk/wazoo";

const sdk = createWazooSdk({
  baseUrl: "https://worlds-api.wazoo.dev",
  token: process.env.WORLDS_TOKEN!,
  worldId: "w_my-world",
});

// Same WorldsSdkInterface as every other backend
const results = await sdk.search({ query: "explores" });
const sparql = await sdk.sparql({ query: "SELECT ?p ?o WHERE { <urn:…> ?p ?o }" });
```

## Changes

- `src/wazoo/` — new module with adapters + factory
- `deno.json` — added `./wazoo` export + `@worlds/client` JSR import
- `ARCHITECTURE.md` — retired the "does not include a hosted Wazoo API client" non-goal

## Design decisions

- **Pure composition** — adapters implement existing interfaces; no new base classes
- **Peer dependency** — `@worlds/client` is an import alias; consumers who only use local/LibSQL backends never install it
- **Symmetry** — follows the same factory pattern as `createLibsqlWorldsSdk`
- **Domain-configurable** — `baseUrl` is explicit for self-hosted, QA, or `data.wazoo.dev`

Closes #191

🤖 Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>