### PR TITLE
fix:

### DIFF
--- a/examples/wazoo-hello-world/main.ts
+++ b/examples/wazoo-hello-world/main.ts
@@ -4,7 +4,7 @@ import { createWazooSdk } from "@worlds/sdk/wazoo";
  * Wazoo Hello World — connects to a hosted Worlds API via createWazooSdk.
  *
  * Environment variables:
- *   WORLDS_BASE_URL  — Worlds data-plane API root (default: https://worlds-api.wazoo.dev)
+ *   WORLDS_BASE_URL  — Worlds data-plane API root (default: https://data.wazoo.dev)
  *   WORLDS_TOKEN     — Bearer token for authentication (required)
  *   WORLDS_WORLD_ID  — Canonical world identifier, e.g. w_<uuid> (required)
  *
@@ -13,7 +13,7 @@ import { createWazooSdk } from "@worlds/sdk/wazoo";
  */
 if (import.meta.main) {
   const baseUrl = Deno.env.get("WORLDS_BASE_URL") ??
-    "https://worlds-api.wazoo.dev";
+    "https://data.wazoo.dev";
   const token = Deno.env.get("WORLDS_TOKEN");
   const worldId = Deno.env.get("WORLDS_WORLD_ID");
 

--- a/src/wazoo/create-wazoo-sdk.test.ts
+++ b/src/wazoo/create-wazoo-sdk.test.ts
@@ -473,7 +473,7 @@ Deno.test("RemoteSparqlEngine.execute throws on API error", async () => {
 
 Deno.test("createWazooSdk returns a WorldsSdkInterface", () => {
   const sdk = createWazooSdk({
-    baseUrl: "https://worlds-api.wazoo.dev",
+    baseUrl: "https://data.wazoo.dev",
     token: "test-token",
     worldId: "w_test",
   });

--- a/src/wazoo/create-wazoo-sdk.ts
+++ b/src/wazoo/create-wazoo-sdk.ts
@@ -31,7 +31,7 @@ export interface CreateWazooSdkOptions {
  * import { createWazooSdk } from "@worlds/sdk/wazoo";
  *
  * const sdk = createWazooSdk({
- *   baseUrl: "https://worlds-api.wazoo.dev",
+ *   baseUrl: "https://data.wazoo.dev",
  *   token: process.env.WORLDS_TOKEN!,
  *   worldId: "w_my-world",
  * });


### PR DESCRIPTION
The data plane moved from worlds-api(.qa).wazoo.dev to data(.qa).wazoo.dev as part of the Turso->D1 platform refactor. Update the remaining references to the current deployed hostnames.