### PR TITLE
feat: add shared rrf score normalization mapper (#206)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 0.8.0
+
+### Added
+
+- Shared rrf score normalization mapper
+  ([worlds-sdk-ts#206](https://github.com/wazootech/worlds-sdk-ts/issues/206)):
+  `normalizeRrfScore(rank, k = 60)` normalizes raw reciprocal rank fusion scores
+  to the
+  [hosted search contract](https://github.com/wazootech/worlds-api/issues/30) D7
+  scale — `score = k / (k + rank)`, rank 0 → 1.0, strictly decreasing, in (0, 1]
+  for all finite ranks — as the single normalization point for all backends
+  (sqlite, libsql, indexeddb, cloudflare). Exported from
+  `@worlds/sdk/search-index` (`src/client/search-index/rrf-score.ts`) along with
+  `SearchScoreType` (`"rrf" | "cosine" | "unranked"`) and `DEFAULT_RRF_K` (60).
+  `SearchResult.score` docs updated to the contract scale; the hybrid fused-list
+  factor is deferred to Phase C
+  ([worlds-cloudflare#30](https://github.com/wazootech/worlds-cloudflare/issues/30)).
+
+### Added (test)
+
+- `src/client/search-index/rrf-score.test.ts`: `normalizeRrfScore` coverage for
+  rank 0 → 1.0, strict monotone decrease across wide rank ranges, (0, 1] bounds,
+  k edge cases (default 60, k = 1, larger-k behavior), asymptotic near-zero at
+  far ranks, and RangeError rejection of invalid rank/k
+  ([worlds-sdk-ts#206](https://github.com/wazootech/worlds-sdk-ts/issues/206)).
+
 ## 0.7.0
 
 ### Added

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@worlds/sdk",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "nodeModulesDir": "auto",
   "exports": {
     ".": "./src/mod.ts",

--- a/src/client/search-index/mod.ts
+++ b/src/client/search-index/mod.ts
@@ -1,3 +1,4 @@
 export * from "./search-index-interface.ts";
 export * from "./build-search-result-id.ts";
 export * from "./search-chunk-fts.ts";
+export * from "./rrf-score.ts";

--- a/src/client/search-index/rrf-score.test.ts
+++ b/src/client/search-index/rrf-score.test.ts
@@ -1,0 +1,90 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import {
+  DEFAULT_RRF_K,
+  normalizeRrfScore,
+  type SearchScoreType,
+} from "./rrf-score.ts";
+
+Deno.test("RRF.normalizeRrfScore - rank 0 maps to exactly 1.0 (default k)", () => {
+  assertEquals(normalizeRrfScore(0), 1.0);
+});
+
+Deno.test("RRF.normalizeRrfScore - rank 0 maps to exactly 1.0 (custom k)", () => {
+  assertEquals(normalizeRrfScore(0, 1), 1.0);
+  assertEquals(normalizeRrfScore(0, 10_000), 1.0);
+});
+
+Deno.test("RRF.normalizeRrfScore - is strictly decreasing in rank", () => {
+  // Sample a wide range of ranks and assert each successive score is lower.
+  const ranks = [0, 1, 2, 5, 10, 25, 59, 60, 61, 100, 1_000, 10_000];
+  for (let i = 1; i < ranks.length; i++) {
+    const previous = normalizeRrfScore(ranks[i - 1]);
+    const current = normalizeRrfScore(ranks[i]);
+    assertEquals(
+      current < previous,
+      true,
+      `score at rank ${ranks[i]} (${current}) must be < score at rank ${
+        ranks[i - 1]
+      } (${previous})`,
+    );
+  }
+});
+
+Deno.test("RRF.normalizeRrfScore - stays in (0, 1] for all finite ranks", () => {
+  for (const rank of [0, 1, 60, 1_000, 1_000_000, Number.MAX_SAFE_INTEGER]) {
+    const score = normalizeRrfScore(rank);
+    assertEquals(
+      score > 0 && score <= 1,
+      true,
+      `score ${score} at rank ${rank}`,
+    );
+  }
+});
+
+Deno.test("RRF.normalizeRrfScore - k edge cases", () => {
+  // k = 1: rank 1 → 1 / (1 + 1) = 0.5
+  assertEquals(normalizeRrfScore(1, 1), 0.5);
+  // k = 60: rank 60 → 60 / (60 + 60) = 0.5
+  assertEquals(normalizeRrfScore(60), 0.5);
+  assertEquals(normalizeRrfScore(60, 60), 0.5);
+  // Larger k flattens the curve: same rank scores higher with larger k.
+  const rank = 60;
+  assertEquals(
+    normalizeRrfScore(rank, 120) > normalizeRrfScore(rank, 60),
+    true,
+    "larger k should yield a higher normalized score at the same rank",
+  );
+});
+
+Deno.test("RRF.normalizeRrfScore - asymptotic behavior approaches 0 but never reaches it", () => {
+  const score = normalizeRrfScore(Number.MAX_SAFE_INTEGER);
+  assertEquals(score > 0, true);
+  // 60 / (60 + 2^53) ≈ 6.7e-15 — assert it degrades orders of magnitude below
+  // the rank-1 score (60/61 ≈ 0.984) without ever reaching exactly 0.
+  assertEquals(score < 1e-12, true, "far ranks should be near-zero");
+  assertEquals(score === 0, false, "score must remain strictly positive");
+});
+
+Deno.test("RRF.normalizeRrfScore - rejects invalid ranks", () => {
+  assertThrows(() => normalizeRrfScore(-1), RangeError);
+  assertThrows(() => normalizeRrfScore(Number.NaN), RangeError);
+  assertThrows(() => normalizeRrfScore(Number.POSITIVE_INFINITY), RangeError);
+});
+
+Deno.test("RRF.normalizeRrfScore - rejects invalid k", () => {
+  assertThrows(() => normalizeRrfScore(0, 0), RangeError);
+  assertThrows(() => normalizeRrfScore(0, -60), RangeError);
+  assertThrows(() => normalizeRrfScore(0, Number.NaN), RangeError);
+});
+
+Deno.test("RRF.DEFAULT_RRF_K - is the documented k = 60 constant", () => {
+  assertEquals(DEFAULT_RRF_K, 60);
+});
+
+Deno.test("RRF.SearchScoreType - enumerates the contract score families", () => {
+  const scoreTypes: Array<SearchScoreType> = ["rrf", "cosine", "unranked"];
+  assertEquals(scoreTypes.length, 3);
+  assertEquals(scoreTypes.includes("rrf"), true);
+  assertEquals(scoreTypes.includes("cosine"), true);
+  assertEquals(scoreTypes.includes("unranked"), true);
+});

--- a/src/client/search-index/rrf-score.ts
+++ b/src/client/search-index/rrf-score.ts
@@ -1,0 +1,59 @@
+/**
+ * DEFAULT_RRF_K is the reciprocal rank fusion constant used by all search
+ * backends (RRF, $k = 60$). See the hosted search contract (worlds-api#30)
+ * decision D7 for the score-scale requirements this module implements.
+ */
+export const DEFAULT_RRF_K = 60;
+
+/**
+ * SearchScoreType enumerates the scoring family a SearchResult.score expresses.
+ *
+ * - `"rrf"`: reciprocal rank fusion, normalized to the contract [0, 1] scale
+ *   via {@link normalizeRrfScore} (rank 0 → 1.0).
+ * - `"cosine"`: vector cosine similarity, already in [0, 1].
+ * - `"unranked"`: no relevance ranking was produced (e.g. fallback search);
+ *   score carries no ordering meaning.
+ */
+export type SearchScoreType = "rrf" | "cosine" | "unranked";
+
+/**
+ * normalizeRrfScore normalizes a raw reciprocal rank to the hosted search
+ * contract scale (worlds-api#30 D7): `score = k / (k + rank)`.
+ *
+ * The raw RRF formula `1 / (k + rank)` tops out near 0.017 for realistic
+ * result pools (k = 60, rank 0), which makes any caller-side `minScore` floor
+ * meaningless. This mapper is the single normalization point for all backends
+ * (sqlite, libsql, indexeddb, cloudflare) so that:
+ *
+ * - rank 0 → 1.0 (best possible score)
+ * - scores are strictly decreasing in rank
+ * - scores are always > 0 for any finite rank, approaching 0 asymptotically
+ * - the transform is rank-monotone: result ordering is unchanged
+ *
+ * The hybrid fused-list factor for multi-list RRF is deliberately deferred
+ * (Phase C, worlds-cloudflare#30) — no hybrid backend exists on the hosted
+ * path yet, so single-list normalization is all the contract needs today.
+ *
+ * @param rank zero-based result rank (0 = best hit).
+ * @param k reciprocal rank fusion constant; must be a finite number > 0.
+ *   Defaults to {@link DEFAULT_RRF_K} (60).
+ * @returns the normalized score in (0, 1], with 1.0 at rank 0.
+ * @throws RangeError when rank is negative or non-finite, or k is not a
+ *   finite number > 0.
+ */
+export function normalizeRrfScore(
+  rank: number,
+  k: number = DEFAULT_RRF_K,
+): number {
+  if (!Number.isFinite(rank) || rank < 0) {
+    throw new RangeError(
+      `normalizeRrfScore: rank must be a finite number >= 0, got ${rank}`,
+    );
+  }
+  if (!Number.isFinite(k) || k <= 0) {
+    throw new RangeError(
+      `normalizeRrfScore: k must be a finite number > 0, got ${k}`,
+    );
+  }
+  return k / (k + rank);
+}

--- a/src/client/search-index/search-index-interface.ts
+++ b/src/client/search-index/search-index-interface.ts
@@ -60,7 +60,21 @@ export interface SearchResult {
   text: string;
 
   /**
-   * score is the combined rank of the hit (Reciprocal Rank Fusion).
+   * score is the relevance score of the hit on the hosted search contract
+   * scale (worlds-api#30 D7): a number in [0, 1] where 1.0 = best.
+   *
+   * - `rrf` scores are reciprocal rank fusion normalized via the
+   *   `normalizeRrfScore` mapper (score = `k / (k + rank)`, k = 60, exported
+   *   from this module's sibling `rrf-score.ts`), so rank 0 maps to exactly
+   *   1.0 — raw `1/(k+rank)` values are NOT the contract scale and must be
+   *   normalized before comparison against `minScore`.
+   * - `cosine` scores are vector cosine similarity, already in [0, 1].
+   * - `unranked` scores carry no ordering meaning (e.g. fallback search) and
+   *   should be treated as null-equivalent by consumers.
+   *
+   * The `SearchScoreType` union (`"rrf" | "cosine" | "unranked"`) in
+   * `rrf-score.ts` enumerates these families; backends opt in to emitting it
+   * as part of the hosted search contract rollout (worlds-cloudflare#30).
    */
   score: number;
 }


### PR DESCRIPTION
Closes #206.

## Summary

Adds `normalizeRrfScore(rank, k = 60)` as the **single normalization point** for the [hosted search contract](https://github.com/wazootech/worlds-api/issues/30) D7 score scale: `score = k / (k + rank)` with rank 0 → 1.0, strictly decreasing, in (0, 1] for all finite ranks.

Today every backend emits raw reciprocal-rank scores `1/(k+rank)` (k = 60), which top out near **0.017** — so the contract's "0–1, 1.0 = best" promise and any caller-side `minScore` floor are meaningless. The mapper fixes the scale once, is rank-monotone (ordering unchanged), and removes the need for per-backend SQL/JS re-derivation.

## Changes

| File | What |
|---|---|
| `src/client/search-index/rrf-score.ts` | **New**: `normalizeRrfScore`, `SearchScoreType` (`"rrf" \| "cosine" \| "unranked"`), `DEFAULT_RRF_K` (60) with contract-scope JSDoc |
| `src/client/search-index/rrf-score.test.ts` | **New**: 10 unit tests — rank 0 → 1.0, strict monotone decrease, (0, 1] bounds, k edge cases, asymptotic near-zero, RangeError on invalid rank/k |
| `src/client/search-index/mod.ts` | Export the new module |
| `src/client/search-index/search-index-interface.ts` | `SearchResult.score` documented on the contract scale + scoreType families |
| `CHANGELOG.md`, `deno.json` | 0.8.0 entry + version bump (0.7.0 is already published; publish guard would fail otherwise) |

## Scope notes

- **Deferred (Phase C):** the fused-list factor for hybrid mode — no hybrid backend exists on the hosted path yet; defined when one ships (worlds-cloudflare#30).
- **Not included:** emitting `scoreType` on results — that's worlds-cloudflare#30's conformance work, and adding the field here would break every backend constructing `SearchResult`.

## Verification

- `deno task ci` green: fmt ✅, lint ✅, check ✅, 110 tests pass (10 new).