### PR TITLE
feat: add optional SearchResult.scoreType field (worlds-cloudflare#30 prerequisite)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.8.1
+
+### Added
+
+- Optional `SearchResult.scoreType` field
+  ([worlds-cloudflare#30](https://github.com/wazootech/worlds-cloudflare/issues/30)):
+  `SearchResult` now carries an optional `scoreType: SearchScoreType`
+  (`"rrf" | "cosine" | "unranked"`) so conforming backends can label which
+  scoring family `score` expresses, per the hosted search contract D7
+  (worlds-api#30). Optional for backward compatibility — backends that have not
+  yet conformed simply omit it.
+
 ## 0.8.0
 
 ### Added

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@worlds/sdk",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "nodeModulesDir": "auto",
   "exports": {
     ".": "./src/mod.ts",

--- a/src/client/search-index/search-index-interface.ts
+++ b/src/client/search-index/search-index-interface.ts
@@ -1,4 +1,5 @@
 import type { QuadFilter } from "@/client/quad-store/mod.ts";
+import type { SearchScoreType } from "@/client/search-index/rrf-score.ts";
 
 /**
  * SearchRequest defines the parameters for executing a keyword search, extending central QuadFilter rules.
@@ -73,10 +74,20 @@ export interface SearchResult {
    *   should be treated as null-equivalent by consumers.
    *
    * The `SearchScoreType` union (`"rrf" | "cosine" | "unranked"`) in
-   * `rrf-score.ts` enumerates these families; backends opt in to emitting it
-   * as part of the hosted search contract rollout (worlds-cloudflare#30).
+   * `rrf-score.ts` enumerates these families; backends opt in to emitting
+   * `scoreType` as part of the hosted search contract rollout
+   * (worlds-cloudflare#30).
    */
   score: number;
+
+  /**
+   * scoreType identifies which scoring family score expresses. `rrf` results
+   * are normalized with 1.0 = best; `cosine` results are similarly bounded;
+   * `unranked` results carry no ordering meaning (e.g. fallback search) and
+   * should be treated as null-equivalent by consumers. Optional for backward
+   * compatibility — backends that have not yet conformed omit it.
+   */
+  scoreType?: SearchScoreType;
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds an optional `scoreType: SearchScoreType` field to `SearchResult` so conforming backends (starting with worlds-cloudflare#30) can label which scoring family `score` expresses — `"rrf" | "cosine" | "unranked"` per hosted search contract D7 (worlds-api#30).

This is the missing SDK surface for backend conformance: worlds-sdk-ts#206 shipped `normalizeRrfScore` + `SearchScoreType` + score docs, but deliberately deferred the field on `SearchResult`. It's **optional** so non-conforming backends (sqlite, indexeddb, rdfjs) continue to compile unchanged.

## Changes

| File | What |
|---|---|
| `src/client/search-index/search-index-interface.ts` | Optional `scoreType?: SearchScoreType` on `SearchResult`, with docs |
| `CHANGELOG.md`, `deno.json` | 0.8.1 entry + version bump (0.8.0 already published) |

## Verification

`deno task ci` green: fmt ✅, lint ✅, check ✅, 110 tests pass.