### PR TITLE
feat: add SearchMode and optional SearchResponse.mode (Phase C)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.9.0
+
+### Added
+
+- `SearchMode` type and optional `SearchResponse.mode` field (Phase C,
+  [worlds-cloudflare](https://github.com/wazootech/worlds-cloudflare)):
+  `SearchResponse` now carries an optional `mode: SearchMode`
+  (`"semantic" | "keyword" | "hybrid" | "fallback"`) mirroring the hosted search
+  contract D5 (worlds-api#30), so backends report which search mode actually ran
+  instead of leaving consumers to assume semantic. Optional for backward
+  compatibility — non-conforming backends omit it.
+
 ## 0.8.1
 
 ### Added
@@ -63,8 +75,6 @@
   round-trip, and materializeImportQuads from serialized TriG and dataset
   sources
   ([worlds-sdk-ts#167](https://github.com/wazootech/worlds-sdk-ts/issues/167)).
-
-# Changelog
 
 ## 0.6.0
 
@@ -211,8 +221,7 @@ packages (see workspace#86 for the full mapping).
 - Renamed `createLibsqlAdapter` → `createLibsqlClient` (and matching
   `LibsqlClientOptions`). Same pattern for RDF/JS and Deno KV.
 - Removed `createLibsqlClientFromStores`, `createLibsqlClientInfrastructure`,
-  `createLibsqlStores`, `createDenokvClientFromStores`, and
-  `createDenokvStores`. Custom assembly uses explicit
+  `createLibsqlStores`, `createDenokvStores`. Custom assembly uses explicit
   `new Client({ quadStore, searchIndex, sparqlEngine? })`.
 - Narrowed `@worlds/sdk/adapters/libsql` and `@worlds/sdk/adapters/denokv`
   exports to factory entry points, suffixed stores, and search helpers; SQL/KV

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@worlds/sdk",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "nodeModulesDir": "auto",
   "exports": {
     ".": "./src/mod.ts",

--- a/src/client/search-index/search-index-interface.ts
+++ b/src/client/search-index/search-index-interface.ts
@@ -16,11 +16,25 @@ export interface SearchRequest extends QuadFilter {
 }
 
 /**
+ * SearchMode is the set of search modes a backend can actually run, mirroring
+ * the hosted search contract (worlds-api#30 D5): `semantic` (vector only),
+ * `keyword` (full-text only), `hybrid` (both fused), or `fallback` (LIKE).
+ */
+export type SearchMode = "semantic" | "keyword" | "hybrid" | "fallback";
+
+/**
  * SearchResponse packages the set of discovered triple hits.
  */
 export interface SearchResponse {
   /** Total collected hits matching criteria. */
   results?: Array<SearchResult>;
+
+  /**
+   * mode reports which search mode actually ran (hosted search contract D5).
+   * Optional for backward compatibility — backends that have not yet conformed
+   * omit it and are treated as keyword-ranked by consumers.
+   */
+  mode?: SearchMode;
 }
 
 /**
@@ -95,10 +109,10 @@ export interface SearchResult {
  */
 export interface SearchIndexInterface {
   /**
-   * search executes a keyword query against the indexed graph data.
+   * search executes a keyword and/or vector query against the indexed graph data.
    *
    * @param request contains the raw query string and optional include/exclude boundary filters.
-   * @returns promise resolving to a set of relevancy-ranked triple matches.
+   * @returns promise resolving to a set of relevancy-ranked triple matches plus the mode that ran.
    */
   search(request: SearchRequest): Promise<SearchResponse>;
 


### PR DESCRIPTION
## Summary

Adds the Phase C SDK surface required by worlds-cloudflare hybrid search (worlds-cloudflare#30 follow-up):

- **`SearchMode`** type — `"semantic" | "keyword" | "hybrid" | "fallback"`, mirroring the hosted search contract D5 (worlds-api#30).
- **Optional `SearchResponse.mode`** — backends report which mode actually ran instead of consumers assuming semantic. Optional for backward compatibility; non-conforming backends omit it.
- Docs updated on `search()` and the new field.

Bumps `@worlds/sdk` to **0.9.0** (0.8.1 is latest on JSR) so worlds-cloudflare can pin the new surface for its hybrid engine work.

## Verification
- `deno task ci` green: fmt:check (102 files), lint (90), check, 110/110 tests.

Sequencing: worlds-cloudflare's hybrid engine (PR to follow) depends on this landing + publishing to JSR.